### PR TITLE
fix: smart parsing of starting_position (FC-0024)

### DIFF
--- a/tutoraspects/templates/aspects/jobs/init/clickhouse/aspects_init_schemas_tables_users.sh
+++ b/tutoraspects/templates/aspects/jobs/init/clickhouse/aspects_init_schemas_tables_users.sh
@@ -243,9 +243,17 @@ SELECT
     org,
     verb_id,
     JSON_VALUE(event_str, '$.object.definition.type') AS object_type,
-    JSON_VALUE(
-        event_str,
-        '$.context.extensions."http://id.tincanapi.com/extension/starting-position"'
+    -- clicking a link and selecting a module outline have no starting-position field
+    if (
+        object_type in (
+            'http://adlnet.gov/expapi/activities/link',
+            'http://adlnet.gov/expapi/activities/module'
+        ),
+        0,
+        cast(JSON_VALUE(
+            event_str,
+            '$.context.extensions."http://id.tincanapi.com/extension/starting-position"'
+        ) as Int16)
     ) AS starting_position,
     JSON_VALUE(
         event_str,


### PR DESCRIPTION
My apologies for the oversight, but somehow I didn't catch this through all the recent MV changes. I tested this in ClickHouse cloud on the 100M row dataset, as well as locally with data generated by my dev environment.

Fixes an issue with `navigation_events_mv` where the `starting_position` field was not being parsed appropriately. The MV query now:
- parses the field to an `Int16` data type
- defaults to 0 for cases where the field is not expected