### PR TITLE
feat: add support for extra rlsf

### DIFF
--- a/tutoraspects/patches/superset-row-level-security
+++ b/tutoraspects/patches/superset-row-level-security
@@ -1,0 +1,8 @@
+{
+    "schema": "{{ASPECTS_XAPI_DATABASE}}",
+    "table_name": "{{ASPECTS_XAPI_TABLE}}",
+    "role_name": "{{SUPERSET_OPENEDX_ROLE_NAME}}",
+    "group_key": "{{SUPERSET_ROW_LEVEL_SECURITY_XAPI_GROUP_KEY}}",
+    "clause": {% raw %}'{{can_view_courses(current_username(), "splitByChar(\'/\', course_id)[-1]")}}',{% endraw %}
+    "filter_type": "Regular",
+},


### PR DESCRIPTION
## Description

This PR allows importing extra row-level security filters, which in combination with #123 will allow users to have granular control over what users can see.

## Use cases:

- Bootstrap a new dev environment with custom filters
- Call an external API, perform validations, and verify user permissions 
- Use data from some external DB to control which data a user has access to.
- Among others