### PR TITLE
feat: allow to install extra dbt packages

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -190,6 +190,22 @@ Available languages are stored in a mapping, and so best edited directly in Tuto
 
 Where the first key is the abbreviation of the language to use, "flag" is which flag icon is displayed in the user interface for choosing the language, and "name" is the displayed name for that language. The mapping above shows all of the current languages supported by Superset, but please note that different languages have different levels of completion and support at this time.
 
+
+Extending the DBT project
+^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+To extend the DBT project there are multiple options:
+
+    #. DBT_REPOSITORY: A git repository URL to the DBT project
+    #. DBT_BRANCH: A git branch to use for the DBT project
+    #. DBT_REPOSITORY_PATH: A path to the DBT project in the git repository
+    #. EXTRA_DBT_PACKAGES: A list of python packages necessary for the DBT project
+    #. DBT_ENABLE_OVERRIDE: A boolean to enable/disable the DBT project override, those overrides
+       allows you to extend the DBT project without having to fork it. For this to work you need
+       to create a patch with the name ``dbt-packages`` and ``dbt-project``. We recommend to copy
+       the default DBT files (``dbt_project.yml`` and ``packages.yml``) and add your changes from
+       there.
+
 License
 -------
 

--- a/tutoraspects/plugin.py
+++ b/tutoraspects/plugin.py
@@ -224,6 +224,7 @@ hooks.Filters.CONFIG_DEFAULTS.add_items(
         ("DBT_PROFILE_SYNC_REQUEST_TIMEOUT", "5"),
         # Compression block size if compression is enabled, this is the default value
         ("DBT_PROFILE_COMPRESS_BLOCK_SIZE", "1048576"),
+        ("DBT_ENABLE_OVERRIDE", False),
     ]
 )
 

--- a/tutoraspects/templates/aspects/apps/aspects/dbt/dbt_project.yml
+++ b/tutoraspects/templates/aspects/apps/aspects/dbt/dbt_project.yml
@@ -1,0 +1,1 @@
+{{ patch("dbt-project") }}

--- a/tutoraspects/templates/aspects/apps/aspects/dbt/packages.yml
+++ b/tutoraspects/templates/aspects/apps/aspects/dbt/packages.yml
@@ -1,0 +1,1 @@
+{{ patch("dbt-packages") }}

--- a/tutoraspects/templates/aspects/apps/aspects/scripts/dbt.sh
+++ b/tutoraspects/templates/aspects/apps/aspects/scripts/dbt.sh
@@ -12,6 +12,14 @@ git clone -b {{ DBT_BRANCH }} {{ DBT_REPOSITORY }}
 
 cd {{ DBT_REPOSITORY_PATH }} || exit
 
+{% if DBT_ENABLE_OVERRIDE %}
+echo /app/aspects/dbt/packages.yml > packages.yml
+echo /app/aspects/dbt/dbt_project.yml > dbt_project.yml
+
+cat {{ DBT_REPOSITORY_PATH }}/packages.yml
+cat {{ DBT_REPOSITORY_PATH }}/dbt_project.yml
+{% endif %}
+
 echo "Installing dbt dependencies"
 dbt deps --profiles-dir /app/aspects/dbt/
 


### PR DESCRIPTION
## Description

This PR allows installing custom DBT packages

Author concerns:
- Most DBT packages require configuration and changes in the project itself, do not see any reason to add this feature.
- If you want to add a package, fork the repo and modify the project as you need.
- This approach cannot override already existing packages in packages.yml
- Some DBT packages depend on already installed DBT packages, this creates a conflict
- It would be better to override completely the DBT packages file. Waiting for feedback