### PR TITLE
feat: add chart for active enrollments per day (FC-0024)

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -162,6 +162,25 @@ To contribute assets to Aspects:
    of what data question they answer.
 
 
+Virtual datasets in Superset
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Superset supports creating virtual datasets, which are datasets defined using a SQL query instead of mapping directly to an underlying database object. Aspects leverages virtual datasets, along with `SQL templating <https://superset.apache.org/docs/installation/sql-templating/>`_, to make better use of table indexes.
+
+To make it easier for developers to manage virtual datasets, there is an extra step that can be done on the output of ``tutor aspects serialize``. The ``sql`` section of the dataset yaml can be moved to its own file in the `queries`_ directory and included in the yaml like so:
+
+.. code-block:: yaml
+
+   sql: "{% include 'tutoraspects/templates/aspects/apps/superset/pythonpath/queries/query.sql' %}"
+
+
+However, please keep in mind that the assets declaration is itself a jinja template. That means that any jinja used in the dataset definition should be escaped. There are examples of how to handle this in the existing queries, such as `dim_courses.sql`_.
+
+.. _queries: tutoraspects/templates/aspects/apps/superset/pythonpath/queries
+
+.. _dim_courses.sql: tutoraspects/templates/aspects/apps/superset/pythonpath/queries/dim_courses.sql
+
+
 Changing Superset Language Settings
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 

--- a/README.rst
+++ b/README.rst
@@ -171,7 +171,7 @@ To make it easier for developers to manage virtual datasets, there is an extra s
 
 .. code-block:: yaml
 
-   sql: "{% include 'tutoraspects/templates/aspects/apps/superset/pythonpath/queries/query.sql' %}"
+   sql: "{% include 'aspects/apps/superset/pythonpath/queries/query.sql' %}"
 
 
 However, please keep in mind that the assets declaration is itself a jinja template. That means that any jinja used in the dataset definition should be escaped. There are examples of how to handle this in the existing queries, such as `dim_courses.sql`_.

--- a/tutoraspects/templates/aspects/apps/superset/pythonpath/assets.yaml
+++ b/tutoraspects/templates/aspects/apps/superset/pythonpath/assets.yaml
@@ -788,7 +788,7 @@
   uuid: 46183302-6fa6-41a3-b6a7-79ff6c1c8402
   version: 1.0.0
 
-- _file_name: Instructor_dashboard_8.yaml
+- _file_name: Instructor_dashboard_9.yaml
   css: ''
   dashboard_title: Instructor dashboard
   description: null
@@ -801,10 +801,11 @@
     native_filter_configuration:
     - cascadeParentIds: []
       chartsInScope:
-      - 12
-      - 13
-      - 17
-      - 18
+      - 24
+      - 25
+      - 32
+      - 33
+      - 34
       controlValues:
         defaultToFirstItem: true
         enableEmptyFilter: true
@@ -833,10 +834,11 @@
     - cascadeParentIds:
       - NATIVE_FILTER-Vx7HxG8_7
       chartsInScope:
-      - 12
-      - 13
-      - 17
-      - 18
+      - 24
+      - 25
+      - 32
+      - 33
+      - 34
       controlValues:
         defaultToFirstItem: false
         enableEmptyFilter: false
@@ -864,7 +866,12 @@
     - cascadeParentIds:
       - NATIVE_FILTER-Vx7HxG8_7
       - NATIVE_FILTER-XPuiTOej4
-      chartsInScope: []
+      chartsInScope:
+      - 24
+      - 25
+      - 32
+      - 33
+      - 34
       controlValues:
         defaultToFirstItem: false
         enableEmptyFilter: false
@@ -889,6 +896,29 @@
           name: run_name
         datasetUuid: 4b274428-d781-41be-b362-ed6917443678
       type: NATIVE_FILTER
+    - cascadeParentIds: []
+      chartsInScope:
+      - 32
+      - 34
+      controlValues:
+        enableEmptyFilter: false
+      defaultDataMask:
+        extraFormData:
+          time_range: Last month
+        filterState:
+          value: Last month
+      description: ''
+      filterType: filter_time
+      id: NATIVE_FILTER-zxfszG4xH
+      name: Time range
+      scope:
+        excluded: []
+        rootPath:
+        - ROOT_ID
+      tabsInScope: []
+      targets:
+      - {}
+      type: NATIVE_FILTER
     refresh_frequency: 0
     shared_label_colors: {}
     show_native_filters: true
@@ -898,7 +928,7 @@
       children: []
       id: CHART-Jr-gNVms2Q
       meta:
-        chartId: 27
+        chartId: 34
         height: 50
         sliceName: Enrollment events per day
         uuid: bb1147cc-b7bc-44b7-b06a-79b0db6626aa
@@ -912,7 +942,7 @@
       children: []
       id: CHART-evjVO-ZSSd
       meta:
-        chartId: 26
+        chartId: 32
         height: 50
         sliceName: Cumulative enrollments by mode
         uuid: 05ed7102-5464-4e2f-86ae-31700b787cc3
@@ -950,25 +980,25 @@
       - GRID_ID
       - ROW-7OLwuieb8j
       type: CHART
-    CHART-yqceXpI-fP:
+    CHART-rnb6PSwCOS:
       children: []
-      id: CHART-yqceXpI-fP
+      id: CHART-rnb6PSwCOS
       meta:
-        chartId: 28
+        chartId: 36
         height: 50
         sliceName: Enrolled learners per day
-        uuid: 1e936880-74b0-4084-8c73-e3d9685271ec
+        uuid: ed2fe731-6544-422f-bc55-42f399f48b2c
         width: 12
       parents:
       - ROOT_ID
       - GRID_ID
-      - ROW-8i6Wwe2MXi
+      - ROW-K8s_8uq9IP
       type: CHART
     DASHBOARD_VERSION_KEY: v2
     GRID_ID:
       children:
       - HEADER-9oReNB0nyf
-      - ROW-8i6Wwe2MXi
+      - ROW-K8s_8uq9IP
       - ROW-je_Wqya3Ga
       - HEADER-Jevm46xhwX
       - ROW-7OLwuieb8j
@@ -1019,10 +1049,10 @@
       - ROOT_ID
       - GRID_ID
       type: ROW
-    ROW-8i6Wwe2MXi:
+    ROW-K8s_8uq9IP:
       children:
-      - CHART-yqceXpI-fP
-      id: ROW-8i6Wwe2MXi
+      - CHART-rnb6PSwCOS
+      id: ROW-K8s_8uq9IP
       meta:
         background: BACKGROUND_TRANSPARENT
       parents:
@@ -1781,8 +1811,7 @@
   uuid: 4b274428-d781-41be-b362-ed6917443678
   version: 1.0.0
 
-
-- _file_name: Enrolled_learners_per_day_28.yaml
+- _file_name: Enrolled_learners_per_day_36.yaml
   cache_timeout: null
   dataset_uuid: 352311fe-12f0-470c-8b8c-d4f6a3936b3d
   params:
@@ -1797,45 +1826,30 @@
       operatorId: EQUALS
       sqlExpression: null
       subject: enrollment_status
-    annotation_layers: []
-    color_scheme: supersetColors
-    comparison_type: values
-    datasource: 37__table
+    color_picker:
+      a: 1
+      b: 135
+      g: 122
+      r: 0
+    datasource: 40__table
     extra_form_data: {}
-    forecastInterval: 0.8
-    forecastPeriods: 10
     granularity_sqla: enrollment_status_date
-    groupby:
-    - enrollment_mode
-    legendOrientation: top
-    legendType: scroll
-    metrics:
-    - count
-    only_total: true
-    order_desc: true
-    orientation: vertical
-    rich_tooltip: true
-    row_limit: 10000
-    show_legend: true
-    stack: true
+    header_font_size: 0.4
+    metric: count
+    rolling_type: None
+    show_trend_line: true
+    start_y_axis_at_zero: true
+    subheader_font_size: 0.15
+    time_format: smart_date
     time_grain_sqla: P1D
     time_range: No filter
-    tooltipTimeFormat: smart_date
-    truncate_metric: true
-    viz_type: echarts_timeseries_bar
-    xAxisLabelRotation: 45
-    x_axis_time_format: '%Y-%m-%d'
-    x_axis_title_margin: 15
-    y_axis_bounds:
-    - null
-    - null
+    viz_type: big_number
     y_axis_format: SMART_NUMBER
-    y_axis_title_margin: 15
-    y_axis_title_position: Left
   slice_name: Enrolled learners per day
-  uuid: 1e936880-74b0-4084-8c73-e3d9685271ec
+  uuid: ed2fe731-6544-422f-bc55-42f399f48b2c
   version: 1.0.0
-  viz_type: echarts_timeseries_bar
+  viz_type: big_number
+
 
 - _file_name: fact_enrollments_by_day.yaml
   cache_timeout: null

--- a/tutoraspects/templates/aspects/apps/superset/pythonpath/assets.yaml
+++ b/tutoraspects/templates/aspects/apps/superset/pythonpath/assets.yaml
@@ -788,7 +788,7 @@
   uuid: 46183302-6fa6-41a3-b6a7-79ff6c1c8402
   version: 1.0.0
 
-- _file_name: Instructor_dashboard_5.yaml
+- _file_name: Instructor_dashboard_8.yaml
   css: ''
   dashboard_title: Instructor dashboard
   description: null
@@ -898,7 +898,7 @@
       children: []
       id: CHART-Jr-gNVms2Q
       meta:
-        chartId: 18
+        chartId: 27
         height: 50
         sliceName: Enrollment events per day
         uuid: bb1147cc-b7bc-44b7-b06a-79b0db6626aa
@@ -912,7 +912,7 @@
       children: []
       id: CHART-evjVO-ZSSd
       meta:
-        chartId: 17
+        chartId: 26
         height: 50
         sliceName: Cumulative enrollments by mode
         uuid: 05ed7102-5464-4e2f-86ae-31700b787cc3
@@ -926,7 +926,7 @@
       children: []
       id: CHART-hCz27s2NEX
       meta:
-        chartId: 13
+        chartId: 25
         height: 50
         sliceName: Watches per video
         uuid: 829c1d5b-2844-4115-876a-34ad3b3cad64
@@ -940,7 +940,7 @@
       children: []
       id: CHART-p5SkjOwu0w
       meta:
-        chartId: 12
+        chartId: 24
         height: 50
         sliceName: Transcript/closed captioning usage per video
         uuid: 6b830def-f3ca-4b4c-9455-7a7b7354bce8
@@ -950,10 +950,25 @@
       - GRID_ID
       - ROW-7OLwuieb8j
       type: CHART
+    CHART-yqceXpI-fP:
+      children: []
+      id: CHART-yqceXpI-fP
+      meta:
+        chartId: 28
+        height: 50
+        sliceName: Enrolled learners per day
+        uuid: 1e936880-74b0-4084-8c73-e3d9685271ec
+        width: 12
+      parents:
+      - ROOT_ID
+      - GRID_ID
+      - ROW-8i6Wwe2MXi
+      type: CHART
     DASHBOARD_VERSION_KEY: v2
     GRID_ID:
       children:
       - HEADER-9oReNB0nyf
+      - ROW-8i6Wwe2MXi
       - ROW-je_Wqya3Ga
       - HEADER-Jevm46xhwX
       - ROW-7OLwuieb8j
@@ -998,6 +1013,16 @@
       - CHART-hCz27s2NEX
       - CHART-p5SkjOwu0w
       id: ROW-7OLwuieb8j
+      meta:
+        background: BACKGROUND_TRANSPARENT
+      parents:
+      - ROOT_ID
+      - GRID_ID
+      type: ROW
+    ROW-8i6Wwe2MXi:
+      children:
+      - CHART-yqceXpI-fP
+      id: ROW-8i6Wwe2MXi
       meta:
         background: BACKGROUND_TRANSPARENT
       parents:
@@ -1755,5 +1780,174 @@
   template_params: {}
   uuid: 4b274428-d781-41be-b362-ed6917443678
   version: 1.0.0
+
+
+- _file_name: Enrolled_learners_per_day_28.yaml
+  cache_timeout: null
+  dataset_uuid: 352311fe-12f0-470c-8b8c-d4f6a3936b3d
+  params:
+    adhoc_filters:
+    - clause: WHERE
+      comparator: registered
+      expressionType: SIMPLE
+      filterOptionName: filter_hcnm4t7piq6_hfbtt65nqqs
+      isExtra: false
+      isNew: false
+      operator: ==
+      operatorId: EQUALS
+      sqlExpression: null
+      subject: enrollment_status
+    annotation_layers: []
+    color_scheme: supersetColors
+    comparison_type: values
+    datasource: 37__table
+    extra_form_data: {}
+    forecastInterval: 0.8
+    forecastPeriods: 10
+    granularity_sqla: enrollment_status_date
+    groupby:
+    - enrollment_mode
+    legendOrientation: top
+    legendType: scroll
+    metrics:
+    - count
+    only_total: true
+    order_desc: true
+    orientation: vertical
+    rich_tooltip: true
+    row_limit: 10000
+    show_legend: true
+    stack: true
+    time_grain_sqla: P1D
+    time_range: No filter
+    tooltipTimeFormat: smart_date
+    truncate_metric: true
+    viz_type: echarts_timeseries_bar
+    xAxisLabelRotation: 45
+    x_axis_time_format: '%Y-%m-%d'
+    x_axis_title_margin: 15
+    y_axis_bounds:
+    - null
+    - null
+    y_axis_format: SMART_NUMBER
+    y_axis_title_margin: 15
+    y_axis_title_position: Left
+  slice_name: Enrolled learners per day
+  uuid: 1e936880-74b0-4084-8c73-e3d9685271ec
+  version: 1.0.0
+  viz_type: echarts_timeseries_bar
+
+- _file_name: fact_enrollments_by_day.yaml
+  cache_timeout: null
+  columns:
+  - advanced_data_type: null
+    column_name: enrollment_mode
+    description: null
+    expression: null
+    extra: null
+    filterable: true
+    groupby: true
+    is_active: true
+    is_dttm: false
+    python_date_format: null
+    type: LowCardinality(String)
+    verbose_name: null
+  - advanced_data_type: null
+    column_name: enrollment_status_date
+    description: null
+    expression: null
+    extra: null
+    filterable: true
+    groupby: true
+    is_active: true
+    is_dttm: true
+    python_date_format: null
+    type: Date
+    verbose_name: null
+  - advanced_data_type: null
+    column_name: actor_id
+    description: null
+    expression: null
+    extra: null
+    filterable: true
+    groupby: true
+    is_active: true
+    is_dttm: false
+    python_date_format: null
+    type: String
+    verbose_name: null
+  - advanced_data_type: null
+    column_name: course_name
+    description: null
+    expression: null
+    extra: null
+    filterable: true
+    groupby: true
+    is_active: true
+    is_dttm: false
+    python_date_format: null
+    type: String
+    verbose_name: null
+  - advanced_data_type: null
+    column_name: enrollment_status
+    description: null
+    expression: null
+    extra: null
+    filterable: true
+    groupby: true
+    is_active: true
+    is_dttm: false
+    python_date_format: null
+    type: String
+    verbose_name: null
+  - advanced_data_type: null
+    column_name: run_name
+    description: null
+    expression: null
+    extra: null
+    filterable: true
+    groupby: true
+    is_active: true
+    is_dttm: false
+    python_date_format: null
+    type: String
+    verbose_name: null
+  - advanced_data_type: null
+    column_name: org
+    description: null
+    expression: null
+    extra: null
+    filterable: true
+    groupby: true
+    is_active: true
+    is_dttm: false
+    python_date_format: null
+    type: String
+    verbose_name: null
+  database_uuid: 21174b6c-4d40-4958-8161-d6c3cf5e77b6
+  default_endpoint: null
+  description: null
+  extra: null
+  fetch_values_predicate: null
+  filter_select_enabled: false
+  main_dttm_col: null
+  metrics:
+  - d3format: null
+    description: null
+    expression: count(*)
+    extra: null
+    metric_name: count
+    metric_type: null
+    verbose_name: null
+    warning_text: null
+  offset: 0
+  params: null
+  schema: null
+  sql: "{% include 'aspects/apps/superset/pythonpath/queries/fact_enrollments_by_day.sql' %}"
+  table_name: fact_enrollments_by_day
+  template_params: {}
+  uuid: 352311fe-12f0-470c-8b8c-d4f6a3936b3d
+  version: 1.0.0
+
 
 {{ patch("superset-extra-assets") }}

--- a/tutoraspects/templates/aspects/apps/superset/pythonpath/queries/fact_enrollments.sql
+++ b/tutoraspects/templates/aspects/apps/superset/pythonpath/queries/fact_enrollments.sql
@@ -9,7 +9,13 @@ with courses as (
         enrollment_mode,
         splitByString('/', verb_id)[-1] as enrollment_status
     from
-        xapi.enrollment_events
+        {{ ASPECTS_XAPI_DATABASE }}.{{ ASPECTS_ENROLLMENT_EVENTS_TABLE }}
+    {% raw -%}
+    {% if filter_values('org') != [] %}
+    where
+        org in {{ filter_values('org') | where_in }}
+    {% endif %}
+    {%- endraw %}
 )
 
 select

--- a/tutoraspects/templates/aspects/apps/superset/pythonpath/queries/fact_enrollments_by_day.sql
+++ b/tutoraspects/templates/aspects/apps/superset/pythonpath/queries/fact_enrollments_by_day.sql
@@ -1,0 +1,57 @@
+with enrollments as (
+    {% include 'aspects/apps/superset/pythonpath/queries/fact_enrollments.sql' %}
+), enrollments_ranked as (
+  select
+    emission_time,
+    org,
+    course_name,
+    run_name,
+    actor_id,
+    enrollment_mode,
+    enrollment_status,
+    rank() over (partition by date(emission_time), org, course_name, run_name, actor_id order by emission_time desc) as event_rank
+  from
+    enrollments
+), enrollment_windows as (
+  select
+    org,
+    course_name,
+    run_name,
+    actor_id,
+    enrollment_status,
+    enrollment_mode,
+    emission_time as window_start_at,
+    lagInFrame(emission_time, 1, now64(6)) over (partition by org, course_name, run_name, actor_id order by emission_time desc) as window_end_at
+  from
+    enrollments_ranked
+  where
+    event_rank = 1
+), enrollment_window_dates as (
+    select
+        org,
+        course_name,
+        run_name,
+        actor_id,
+        enrollment_status,
+        enrollment_mode,
+        date_trunc('day', window_start_at) as window_start_date,
+        date_trunc('day', coalesce(window_end_at, now())) as window_end_date
+    from enrollment_windows
+)
+select
+    date(fromUnixTimestamp(
+        arrayJoin(
+            range(
+                toUnixTimestamp(window_start_date),
+                toUnixTimestamp(window_end_date),
+                86400
+            )
+        )
+    )) as enrollment_status_date,
+    org,
+    course_name,
+    run_name,
+    actor_id,
+    enrollment_status,
+    enrollment_mode
+from enrollment_window_dates


### PR DESCRIPTION
In addition to adding a chart that shows registered learners per day, there is also a time window that defaults to the last month. I based that filter on the [first screenshot in the Cairn repo](https://github.com/overhangio/tutor-cairn/blob/master/screenshots/courseoverview-01.png).

The time window applies to all charts in the dashboard, but we can restrict it to only certain charts if that's preferred.

![image](https://github.com/openedx/tutor-contrib-aspects/assets/2566242/50f6e29b-08b9-4152-ab91-8f377a090d39)

