### PR TITLE
chore: Upgrade xap-db-load to 0.4

### DIFF
--- a/tutoraspects/templates/aspects/build/aspects/requirements.txt
+++ b/tutoraspects/templates/aspects/build/aspects/requirements.txt
@@ -4,4 +4,4 @@ clickhouse-sqlalchemy==0.1.9
 # dbt packages
 dbt-core==1.4.0
 dbt-clickhouse==1.4.1
-git+https://github.com/openedx/xapi-db-load@0.3#egg=xapi-db-load==0.3
+git+https://github.com/openedx/xapi-db-load@0.4#egg=xapi-db-load==0.4


### PR DESCRIPTION
This release removes some log spam and introduces the ability to populate the event sink tables for courses and xblocks, which should facilitate more realistic performance testing.