### PR TITLE
feat: add video timeline chart (FC-0024)

### DIFF
--- a/tutoraspects/templates/aspects/apps/superset/pythonpath/assets.yaml
+++ b/tutoraspects/templates/aspects/apps/superset/pythonpath/assets.yaml
@@ -24,6 +24,9 @@
 {% include 'openedx-assets/fact_learner_problem_summary.yaml' %}
 {% include 'openedx-assets/fact_problem_responses.yaml' %}
 {% include 'openedx-assets/hints_per_success.yaml' %}
+{% include 'openedx-assets/dim_course_videos.yaml' %}
+{% include 'openedx-assets/fact_watched_video_segments.yaml' %}
+{% include 'openedx-assets/Watched_video_segments_51.yaml' %}
 
 
 {{ patch("superset-extra-assets") }}

--- a/tutoraspects/templates/openedx-assets/Instructor_dashboard_9.yaml
+++ b/tutoraspects/templates/openedx-assets/Instructor_dashboard_9.yaml
@@ -16,8 +16,11 @@
           - 32
           - 34
           - 37
-          - 38
-          - 39
+          - 45
+          - 46
+          - 47
+          - 48
+          - 52
         controlValues:
           enableEmptyFilter: false
         defaultDataMask:
@@ -33,7 +36,10 @@
           excluded: []
           rootPath:
             - ROOT_ID
-        tabsInScope: []
+        tabsInScope:
+          - TAB-8BxDuJd9Jb
+          - TAB-NR4UTAs9K
+          - TAB-7PGDduCA7
         targets:
           - {}
         type: NATIVE_FILTER
@@ -44,8 +50,11 @@
           - 32
           - 34
           - 37
-          - 38
-          - 39
+          - 45
+          - 46
+          - 47
+          - 48
+          - 52
         controlValues:
           defaultToFirstItem: true
           enableEmptyFilter: true
@@ -65,7 +74,10 @@
           excluded: []
           rootPath:
             - ROOT_ID
-        tabsInScope: []
+        tabsInScope:
+          - TAB-8BxDuJd9Jb
+          - TAB-NR4UTAs9K
+          - TAB-7PGDduCA7
         targets:
           - column:
               name: org
@@ -79,8 +91,11 @@
           - 32
           - 34
           - 37
-          - 38
-          - 39
+          - 45
+          - 46
+          - 47
+          - 48
+          - 52
         controlValues:
           defaultToFirstItem: false
           enableEmptyFilter: false
@@ -99,7 +114,10 @@
           excluded: []
           rootPath:
             - ROOT_ID
-        tabsInScope: []
+        tabsInScope:
+          - TAB-8BxDuJd9Jb
+          - TAB-NR4UTAs9K
+          - TAB-7PGDduCA7
         targets:
           - column:
               name: course_name
@@ -114,8 +132,11 @@
           - 32
           - 34
           - 37
-          - 38
-          - 39
+          - 45
+          - 46
+          - 47
+          - 48
+          - 52
         controlValues:
           defaultToFirstItem: false
           enableEmptyFilter: false
@@ -134,7 +155,10 @@
           excluded: []
           rootPath:
             - ROOT_ID
-        tabsInScope: []
+        tabsInScope:
+          - TAB-8BxDuJd9Jb
+          - TAB-NR4UTAs9K
+          - TAB-7PGDduCA7
         targets:
           - column:
               name: run_name
@@ -145,7 +169,10 @@
           - NATIVE_FILTER-XPuiTOej4
           - NATIVE_FILTER-E6-vOpjZv
         chartsInScope:
-          - 40
+          - 45
+          - 46
+          - 47
+          - 52
         controlValues:
           defaultToFirstItem: false
           enableEmptyFilter: false
@@ -162,30 +189,75 @@
         name: Problem name
         scope:
           excluded:
-            - 34
-            - 32
-            - 25
-            - 24
-            - 37
-            - 41
+            - 48
           rootPath:
-            - ROOT_ID
-        tabsInScope: []
+            - TAB-NR4UTAs9K
+        tabsInScope:
+          - TAB-NR4UTAs9K
+          - TAB-7PGDduCA7
         targets:
           - column:
               name: problem_name
             datasetUuid: 008e2907-fc6b-45ef-bf85-73a04c5791ff
+        type: NATIVE_FILTER
+      - cascadeParentIds:
+          - NATIVE_FILTER-Vx7HxG8_7
+          - NATIVE_FILTER-XPuiTOej4
+          - NATIVE_FILTER-E6-vOpjZv
+        chartsInScope:
+          - 52
+        controlValues:
+          defaultToFirstItem: false
+          enableEmptyFilter: false
+          inverseSelection: false
+          multiSelect: true
+          searchAllOptions: false
+        defaultDataMask:
+          extraFormData: {}
+          filterState: {}
+          ownState: {}
+        description: ""
+        filterType: filter_select
+        id: NATIVE_FILTER-V77Ybaw2w
+        name: Video name
+        scope:
+          excluded:
+            - 25
+            - 24
+          rootPath:
+            - TAB-7PGDduCA7
+        tabsInScope:
+          - TAB-7PGDduCA7
+        targets:
+          - column:
+              name: video_name
+            datasetUuid: 417b2035-8fa1-4c60-a405-4b1947c3c966
         type: NATIVE_FILTER
     refresh_frequency: 0
     shared_label_colors: {}
     show_native_filters: true
     timed_refresh_immune_slices: []
   position:
+    CHART-1nuLZrBxuC:
+      children: []
+      id: CHART-1nuLZrBxuC
+      meta:
+        chartId: 52
+        height: 50
+        sliceName: Watched video segments
+        uuid: 2985a9db-c338-4008-af52-2930b81ee2e5
+        width: 12
+      parents:
+        - ROOT_ID
+        - TABS-SNeKAJcjhd
+        - TAB-7PGDduCA7
+        - ROW-zM_Vvq_Wo4
+      type: CHART
     CHART-6ShUwMXI4Q:
       children: []
       id: CHART-6ShUwMXI4Q
       meta:
-        chartId: 42
+        chartId: 47
         height: 50
         sliceName: Attempts to first success
         uuid: db90930f-f16e-4c32-8050-0e4abae28f4c
@@ -245,7 +317,7 @@
       children: []
       id: CHART-VBeaYzSdd6
       meta:
-        chartId: 43
+        chartId: 46
         height: 50
         sliceName: Hints and answers displayed per correct answer
         uuid: ee94be4c-6fdd-4295-b43c-40890d6c549d
@@ -275,7 +347,7 @@
       children: []
       id: CHART-hrPFXl_7_X
       meta:
-        chartId: 40
+        chartId: 45
         height: 50
         sliceName: Response distribution
         uuid: f1651c44-a8f4-4b44-ad49-962823009319
@@ -305,7 +377,7 @@
       children: []
       id: CHART-s8sC81tP9u
       meta:
-        chartId: 41
+        chartId: 48
         height: 48
         sliceName: Problem submission counts
         uuid: 3dc6a642-a71d-4c8c-ab98-14f54852b40f
@@ -435,9 +507,21 @@
         - TABS-SNeKAJcjhd
         - TAB-8BxDuJd9Jb
       type: ROW
+    ROW-zM_Vvq_Wo4:
+      children:
+        - CHART-1nuLZrBxuC
+      id: ROW-zM_Vvq_Wo4
+      meta:
+        background: BACKGROUND_TRANSPARENT
+      parents:
+        - ROOT_ID
+        - TABS-SNeKAJcjhd
+        - TAB-7PGDduCA7
+      type: ROW
     TAB-7PGDduCA7:
       children:
         - ROW-BO2IHCiYF8
+        - ROW-zM_Vvq_Wo4
       id: TAB-7PGDduCA7
       meta:
         defaultText: Tab title

--- a/tutoraspects/templates/openedx-assets/Watched_video_segments_51.yaml
+++ b/tutoraspects/templates/openedx-assets/Watched_video_segments_51.yaml
@@ -1,0 +1,33 @@
+- _file_name: Watched_video_segments_51.yaml
+  cache_timeout: null
+  dataset_uuid: c2c391b3-3403-4f05-bc0b-3de53bd366ec
+  params:
+    adhoc_filters: []
+    bar_stacked: true
+    bottom_margin: auto
+    color_scheme: supersetColors
+    columns: []
+    datasource: 49__table
+    extra_form_data: {}
+    granularity_sqla: started_at
+    groupby:
+      - segment_start
+    metrics:
+      - unique_viewers
+      - repeat_views
+    order_bars: true
+    order_desc: true
+    rich_tooltip: true
+    row_limit: 10000
+    show_legend: true
+    time_range: No filter
+    viz_type: dist_bar
+    x_ticks_layout: auto
+    y_axis_bounds:
+      - null
+      - null
+    y_axis_format: SMART_NUMBER
+  slice_name: Watched video segments
+  uuid: 2985a9db-c338-4008-af52-2930b81ee2e5
+  version: 1.0.0
+  viz_type: dist_bar

--- a/tutoraspects/templates/openedx-assets/dim_course_videos.yaml
+++ b/tutoraspects/templates/openedx-assets/dim_course_videos.yaml
@@ -1,0 +1,99 @@
+- _file_name: dim_course_videos.yaml
+  cache_timeout: null
+  columns:
+    - advanced_data_type: null
+      column_name: course_key
+      description: null
+      expression: null
+      extra: null
+      filterable: true
+      groupby: true
+      is_active: true
+      is_dttm: false
+      python_date_format: null
+      type: String
+      verbose_name: null
+    - advanced_data_type: null
+      column_name: org
+      description: null
+      expression: null
+      extra: null
+      filterable: true
+      groupby: true
+      is_active: true
+      is_dttm: false
+      python_date_format: null
+      type: String
+      verbose_name: null
+    - advanced_data_type: null
+      column_name: video_name
+      description: null
+      expression: null
+      extra: null
+      filterable: true
+      groupby: true
+      is_active: true
+      is_dttm: false
+      python_date_format: null
+      type: String
+      verbose_name: null
+    - advanced_data_type: null
+      column_name: course_name
+      description: null
+      expression: null
+      extra: null
+      filterable: true
+      groupby: true
+      is_active: true
+      is_dttm: false
+      python_date_format: null
+      type: String
+      verbose_name: null
+    - advanced_data_type: null
+      column_name: video_id
+      description: null
+      expression: null
+      extra: null
+      filterable: true
+      groupby: true
+      is_active: true
+      is_dttm: false
+      python_date_format: null
+      type: String
+      verbose_name: null
+    - advanced_data_type: null
+      column_name: run_name
+      description: null
+      expression: null
+      extra: null
+      filterable: true
+      groupby: true
+      is_active: true
+      is_dttm: false
+      python_date_format: null
+      type: String
+      verbose_name: null
+  database_uuid: 21174b6c-4d40-4958-8161-d6c3cf5e77b6
+  default_endpoint: null
+  description: null
+  extra: null
+  fetch_values_predicate: null
+  filter_select_enabled: false
+  main_dttm_col: null
+  metrics:
+    - d3format: null
+      description: null
+      expression: count(*)
+      extra: null
+      metric_name: count
+      metric_type: null
+      verbose_name: null
+      warning_text: null
+  offset: 0
+  params: null
+  schema: null
+  sql: "{% include 'openedx-assets/queries/dim_course_videos.sql' %}"
+  table_name: dim_course_videos
+  template_params: {}
+  uuid: 417b2035-8fa1-4c60-a405-4b1947c3c966
+  version: 1.0.0

--- a/tutoraspects/templates/openedx-assets/fact_watched_video_segments.yaml
+++ b/tutoraspects/templates/openedx-assets/fact_watched_video_segments.yaml
@@ -1,0 +1,128 @@
+- _file_name: fact_watched_video_segments.yaml
+  cache_timeout: null
+  columns:
+    - advanced_data_type: null
+      column_name: started_at
+      description: null
+      expression: null
+      extra: {}
+      filterable: true
+      groupby: true
+      is_active: true
+      is_dttm: true
+      python_date_format: null
+      type: DateTime64(6)
+      verbose_name: null
+    - advanced_data_type: null
+      column_name: segment_start
+      description: null
+      expression: null
+      extra: {}
+      filterable: true
+      groupby: true
+      is_active: true
+      is_dttm: false
+      python_date_format: null
+      type: Int32
+      verbose_name: null
+    - advanced_data_type: null
+      column_name: actor_id
+      description: null
+      expression: null
+      extra: {}
+      filterable: true
+      groupby: true
+      is_active: true
+      is_dttm: false
+      python_date_format: null
+      type: String
+      verbose_name: null
+    - advanced_data_type: null
+      column_name: course_name
+      description: null
+      expression: null
+      extra: {}
+      filterable: true
+      groupby: true
+      is_active: true
+      is_dttm: false
+      python_date_format: null
+      type: String
+      verbose_name: null
+    - advanced_data_type: null
+      column_name: video_name
+      description: null
+      expression: null
+      extra: {}
+      filterable: true
+      groupby: true
+      is_active: true
+      is_dttm: false
+      python_date_format: null
+      type: String
+      verbose_name: null
+    - advanced_data_type: null
+      column_name: run_name
+      description: null
+      expression: null
+      extra: {}
+      filterable: true
+      groupby: true
+      is_active: true
+      is_dttm: false
+      python_date_format: null
+      type: String
+      verbose_name: null
+    - advanced_data_type: null
+      column_name: org
+      description: null
+      expression: null
+      extra: {}
+      filterable: true
+      groupby: true
+      is_active: true
+      is_dttm: false
+      python_date_format: null
+      type: String
+      verbose_name: null
+  database_uuid: 21174b6c-4d40-4958-8161-d6c3cf5e77b6
+  default_endpoint: null
+  description: null
+  extra: null
+  fetch_values_predicate: null
+  filter_select_enabled: false
+  main_dttm_col: null
+  metrics:
+    - d3format: null
+      description: null
+      expression: count(*) - count(distinct actor_id)
+      extra: {}
+      metric_name: repeat_views
+      metric_type: null
+      verbose_name: Repeat views
+      warning_text: null
+    - d3format: null
+      description: null
+      expression: count(distinct actor_id)
+      extra: {}
+      metric_name: unique_viewers
+      metric_type: null
+      verbose_name: Unique viewers
+      warning_text: null
+    - d3format: null
+      description: null
+      expression: count(*)
+      extra:
+        warning_markdown: ""
+      metric_name: count
+      metric_type: null
+      verbose_name: Total views
+      warning_text: null
+  offset: 0
+  params: null
+  schema: null
+  sql: "{% include 'openedx-assets/queries/fact_watched_video_segments.sql' %}"
+  table_name: fact_watched_video_segments
+  template_params: null
+  uuid: c2c391b3-3403-4f05-bc0b-3de53bd366ec
+  version: 1.0.0

--- a/tutoraspects/templates/openedx-assets/queries/dim_course_videos.sql
+++ b/tutoraspects/templates/openedx-assets/queries/dim_course_videos.sql
@@ -14,6 +14,9 @@ with courses as (
         {% if filter_values('org') != [] %}
         and org in {{ filter_values('org') | where_in }}
         {% endif %}
+        {% if filter_values('video_name') != [] %}
+        and video_name in {{ filter_values('video_name') | where_in }}
+        {% endif %}
     {%- endraw %}
 )
 

--- a/tutoraspects/templates/openedx-assets/queries/fact_watched_video_segments.sql
+++ b/tutoraspects/templates/openedx-assets/queries/fact_watched_video_segments.sql
@@ -1,0 +1,85 @@
+with courses as (
+    {% include 'openedx-assets/queries/dim_course_videos.sql' %}
+), starts as (
+    select
+        emission_time,
+        org,
+        course_id,
+        splitByString('/xblock/', object_id)[-1] as video_id,
+        actor_id,
+        verb_id,
+        video_position
+    from xapi.video_playback_events
+    where
+        verb_id = 'https://w3id.org/xapi/video/verbs/played'
+        {% raw -%}
+        {% if filter_values('org') != [] %}
+        and org in {{ filter_values('org') | where_in }}
+        {% endif %}
+        {%- endraw %}
+), ends as (
+    select
+        emission_time,
+        org,
+        course_id,
+        splitByString('/xblock/', object_id)[-1] as video_id,
+        actor_id,
+        verb_id,
+        video_position
+    from xapi.video_playback_events
+    where
+        verb_id in (
+            'http://adlnet.gov/expapi/verbs/completed',
+            'https://w3id.org/xapi/video/verbs/seeked',
+            'https://w3id.org/xapi/video/verbs/paused',
+            'http://adlnet.gov/expapi/verbs/terminated'
+        )
+        {% raw -%}
+        {% if filter_values('org') != [] %}
+        and org in {{ filter_values('org') | where_in }}
+        {% endif %}
+        {%- endraw %}
+), segments as(
+    select
+        starts.org as org,
+        splitByString('/', starts.course_id)[-1] as course_key,
+        starts.video_id as video_id,
+        starts.actor_id,
+        cast(starts.video_position as Int32) as start_position,
+        cast(ends.video_position as Int32) as end_position,
+        starts.emission_time as started_at,
+        ends.emission_time as ended_at,
+        ends.verb_id as end_type
+    from
+        starts
+        left asof join ends
+            on (starts.org = ends.org
+                and starts.course_id = ends.course_id
+                and starts.video_id = ends.video_id
+                and starts.actor_id = ends.actor_id
+                and starts.emission_time < ends.emission_time)
+), enriched_segments as (
+    select
+        courses.org as org,
+        courses.course_name as course_name,
+        courses.run_name as run_name,
+        courses.video_name as video_name,
+        segments.actor_id as actor_id,
+        segments.started_at as started_at,
+        segments.start_position - (segments.start_position % 5) as start_position,
+        segments.end_position - (segments.end_position % 5) as end_position
+    from
+        segments
+        join courses
+            on (segments.org = courses.org and segments.course_key = courses.course_key)
+)
+
+select
+    org,
+    course_name,
+    run_name,
+    video_name,
+    actor_id,
+    started_at,
+    arrayJoin(range(start_position, end_position, 5)) as segment_start
+from enriched_segments

--- a/tutoraspects/templates/openedx-assets/queries/fact_watched_video_segments.sql
+++ b/tutoraspects/templates/openedx-assets/queries/fact_watched_video_segments.sql
@@ -9,7 +9,7 @@ with courses as (
         actor_id,
         verb_id,
         video_position
-    from xapi.video_playback_events
+    from {{ ASPECTS_XAPI_DATABASE }}.{{ ASPECTS_VIDEO_PLAYBACK_EVENTS_TABLE }}
     where
         verb_id = 'https://w3id.org/xapi/video/verbs/played'
         {% raw -%}
@@ -26,7 +26,7 @@ with courses as (
         actor_id,
         verb_id,
         video_position
-    from xapi.video_playback_events
+    from from {{ ASPECTS_XAPI_DATABASE }}.{{ ASPECTS_VIDEO_PLAYBACK_EVENTS_TABLE }}
     where
         verb_id in (
             'http://adlnet.gov/expapi/verbs/completed',


### PR DESCRIPTION
Here is a dataset and dashboard update to show a breakdown of which segments of videos were watched. There is an additional filter, scoped only to the video tab, to select a specific video. Here is a screenshot of the new chart:

![image](https://github.com/openedx/tutor-contrib-aspects/assets/2566242/5e42ec4c-77d4-4087-85d5-ebd6eacd5971)
