### PR TITLE
build: push openedx-dev cache to registry

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -119,5 +119,5 @@ jobs:
         uses: docker/setup-buildx-action@v2
       - name: Build Open edX Docker Images
         run: |
-          tutor images build openedx --cache-to-registry
+          tutor images build openedx openedx-dev --cache-to-registry
           tutor images push openedx


### PR DESCRIPTION
## Description

This PR pushes the openedx-dev image cache to the registry, which is needed for the test workflow.