### PR TITLE
Make Vector bulk import more idempotent

### DIFF
--- a/tutoraspects/commands_v0.py
+++ b/tutoraspects/commands_v0.py
@@ -3,7 +3,7 @@ import click
 from tutor import config as tutor_config
 
 
-@click.command(help="Create an Open edX user and interactively set their password")
+@click.command(help="Run dbt with the provided command and options.")
 @click.option(
     "-c",
     "--command",
@@ -37,7 +37,7 @@ def dbt(context, command) -> None:
     runner.run_job("aspects", command)
 
 
-@click.command()
+@click.command(help="Load generated fake xAPI test data to ClickHouse.")
 @click.option("-n", "--num_batches", default=100)
 @click.option("-s", "--batch_size", default=100)
 @click.pass_obj
@@ -57,7 +57,10 @@ def load_xapi_test_data(context, num_batches, batch_size) -> None:
     runner.run_job("aspects", command)
 
 
-@click.command(context_settings={"ignore_unknown_options": True})
+@click.command(
+    help="Run Alembic migrations with the given options.",
+    context_settings={"ignore_unknown_options": True},
+)
 @click.option(
     "-c",
     "--command",
@@ -107,9 +110,28 @@ def dump_courses_to_clickhouse(context, options) -> None:
     runner.run_job("cms", command)
 
 
+# pylint: disable=line-too-long
+# Ex: tutor local do transform-tracking-logs --options "--source_provider MINIO --source_config '{\"key\": \"openedx\", \"secret\": \"h3SIhXAqDDxJAP6TcXklNxro\", \"container\": \"openedx\", \"prefix\": \"/tracking_logs\", \"host\": \"files.local.overhang.io\", \"secure\": false}' --destination_provider LRS --transformer_type xapi"
+@click.command(help="Uses event-routing-backends to replay tracking logs.")
+@click.option("--options", default="")
+@click.pass_obj
+def transform_tracking_logs(context, options) -> None:
+    """
+    Job that proxies the dump_courses_to_clickhouse commands.
+    """
+    config = tutor_config.load(context.root)
+    runner = context.job_runner(config)
+
+    command = f"""
+    ./manage.py lms transform_tracking_logs {options}
+    """
+    runner.run_job("lms", command)
+
+
 COMMANDS = (
     load_xapi_test_data,
     dbt,
     alembic,
     dump_courses_to_clickhouse,
+    transform_tracking_logs,
 )

--- a/tutoraspects/commands_v1.py
+++ b/tutoraspects/commands_v1.py
@@ -104,9 +104,22 @@ def dump_courses_to_clickhouse(options) -> list[tuple[str, str]]:
     return [("cms", f"./manage.py cms dump_courses_to_clickhouse {options}")]
 
 
+# pylint: disable=line-too-long
+# Ex: tutor local do transform-tracking-logs --options "--source_provider LOCAL --source_config '{\"key\": \"/openedx/data/\", \"prefix\": \"tracking.log\", \"container\": \"logs\"}' --destination_provider LRS --transformer_type xapi"
+# Ex: tutor local do transform-tracking-logs --options "--source_provider MINIO --source_config '{\"key\": \"openedx\", \"secret\": \"h3SIhXAqDDxJAP6TcXklNxro\", \"container\": \"openedx\", \"prefix\": \"/tracking_logs\", \"host\": \"files.local.overhang.io\", \"secure\": false}' --destination_provider LRS --transformer_type xapi"
+@click.command(context_settings={"ignore_unknown_options": True})
+@click.option("--options", default="", type=click.UNPROCESSED)
+def transform_tracking_logs(options) -> list[tuple[str, str]]:
+    """
+    Job that proxies the dump_courses_to_clickhouse commands.
+    """
+    return [("lms", f"./manage.py lms transform_tracking_logs {options}")]
+
+
 COMMANDS = (
     load_xapi_test_data,
     dbt,
     alembic,
     dump_courses_to_clickhouse,
+    transform_tracking_logs,
 )

--- a/tutoraspects/patches/local-docker-compose-jobs-services
+++ b/tutoraspects/patches/local-docker-compose-jobs-services
@@ -6,10 +6,11 @@ aspects-job:
     - ASPECTS_ENROLLMENT_EVENTS_TABLE={{ ASPECTS_ENROLLMENT_EVENTS_TABLE }}
   volumes:
     - ../../env/plugins/aspects/apps/aspects:/app/aspects
-  depends_on:
-    - superset {% if RUN_CLICKHOUSE%}
-    - clickhouse{% endif %}
-    - ralph
+  {% if RUN_SUPERSET or RUN_CLICKHOUSE or RUN_RALPH %}depends_on:{% if RUN_SUPERSET %}
+    - superset{% endif %}{% if RUN_CLICKHOUSE%}
+    - clickhouse{% endif %}{% if RUN_RALPH %}
+    - ralph{% endif %}
+  {% endif %}
 clickhouse-job:
     image: {{DOCKER_IMAGE_CLICKHOUSE}}
     {% if RUN_CLICKHOUSE%}depends_on:

--- a/tutoraspects/templates/aspects/apps/aspects/migrations/README.rst
+++ b/tutoraspects/templates/aspects/apps/aspects/migrations/README.rst
@@ -10,7 +10,7 @@ Aspects interface for Alembic
 -----------------------------
 
 The Aspects project provides a custom interface for Alembic. This interface is
-available in the command line with the subcommand ``tutor local|dev alembic do -c "custom command"``.
+available in the command line with the subcommand ``tutor local|dev do alembic -c "custom command"``.
 
 For example, to run the command ``alembic upgrade head`` in the dev environment, you would run::
 
@@ -26,9 +26,10 @@ Create a new migration::
     tutor dev do alembic -c "revision -m 'migration message'"
 
 Run migrations::
-    
+
     tutor dev do alembic -c "upgrade head"
 
 Rollback migrations::
 
     tutor dev do alembic -c "downgrade -1"
+

--- a/tutoraspects/templates/aspects/apps/aspects/migrations/alembic/versions/0009_vector_replacingmergetree_xapi_raw.py
+++ b/tutoraspects/templates/aspects/apps/aspects/migrations/alembic/versions/0009_vector_replacingmergetree_xapi_raw.py
@@ -1,0 +1,117 @@
+"""
+This migration handles the somewhat complicated action of changing the table engine
+for the Vector xAPI table from MergeTree to ReplacingMergeTree. It takes a few steps.
+"""
+from alembic import op
+import sqlalchemy as sa
+
+revision = "0009"
+down_revision = "0008"
+branch_labels = None
+depends_on = None
+
+DESTINATION_TABLE = "{{ ASPECTS_VECTOR_DATABASE }}.{{ ASPECTS_VECTOR_RAW_XAPI_TABLE }}"
+TMP_TABLE_NEW = DESTINATION_TABLE + "_tmp_0009"
+TMP_TABLE_ORIG = DESTINATION_TABLE + "_tmp_mergetree_0009"
+
+def upgrade():
+    # 1. Create our new table with the desired engine
+    op.execute(
+        f"""
+        CREATE OR REPLACE TABLE {TMP_TABLE_NEW}
+        (
+            event_id      UUID,
+            emission_time DateTime64(6),
+            event_str     String
+        )
+        engine = ReplacingMergeTree
+        PRIMARY KEY (emission_time)
+        ORDER BY (emission_time, event_id);
+        """
+    )
+    # 2. Attach our table to the existing partitions of the old MergeTree table.
+    #    This works because our "order by" is the same. It should be instant no matter
+    #    the size of the table since it's not copying anything.
+    op.execute(
+        f"""
+        ALTER TABLE {TMP_TABLE_NEW}
+        ATTACH PARTITION tuple() FROM 
+        {DESTINATION_TABLE};
+        """
+    )
+    # 3. Swap both tables in a single rename statement.
+    op.execute(
+        f"""
+        RENAME TABLE {DESTINATION_TABLE}
+         TO {TMP_TABLE_ORIG}, 
+         {TMP_TABLE_NEW}
+         TO {DESTINATION_TABLE};
+        """
+    )
+    # 4. Force deduplication of the existing data and may take a very long time
+    #    on a larger dataset, but since Aspects isn't in production anywhere yet this
+    #    seems like a reasonable thing to do. If you're looking at this as fodder for
+    #    a future migration, make sure to understand the potential issues here.
+    op.execute(
+        f"""
+        OPTIMIZE TABLE {DESTINATION_TABLE} FINAL;
+        """
+    )
+    # 5. Drop the renamed version of the original table.
+    op.execute(
+        f"""
+        DROP TABLE {TMP_TABLE_ORIG};
+        """
+    )
+
+
+def downgrade():
+    # 1. Create a new table with the old engine
+    op.execute(
+        f"""
+        CREATE TABLE IF NOT EXISTS {TMP_TABLE_ORIG}
+        (
+            event_id      UUID,
+            emission_time DateTime64(6),
+            event_str     String
+        )
+        engine = MergeTree
+        PRIMARY KEY (emission_time)
+        ORDER BY (emission_time, event_id);
+        """
+    )
+    # 2. Attach our table to the existing partitions of the ReplacingMergeTree table.
+    #    This works because our "order by" is the same. It should be instant no matter
+    #    the size of the table since it's not copying anything.
+    op.execute(
+        f"""
+        ALTER TABLE {TMP_TABLE_ORIG}
+        ATTACH PARTITION tuple() FROM 
+        {DESTINATION_TABLE};
+        """
+    )
+    # 3. Swap both tables in a single rename statement.
+    op.execute(
+        f"""
+        RENAME TABLE {DESTINATION_TABLE}
+         TO {TMP_TABLE_NEW}, 
+         {TMP_TABLE_ORIG}
+         TO {DESTINATION_TABLE};
+        """
+    )
+    # 4. Force deduplication of the existing data and may take a very long time
+    #    on a larger dataset, but since Aspects isn't in production anywhere yet this
+    #    seems like a reasonable thing to do. If you're looking at this as fodder for
+    #    a future migration, make sure to understand the potential issues here.
+    op.execute(
+        f"""
+        OPTIMIZE TABLE {DESTINATION_TABLE} 
+        FINAL DEDUPLICATE;
+        """
+    )
+    # 5. Drop the renamed version of the original table.
+    op.execute(
+        f"""
+        DROP TABLE {TMP_TABLE_NEW};
+        """
+    )

--- a/tutoraspects/templates/aspects/apps/aspects/migrations/alembic/versions/0010_vector_replacingmergetree_xapi_parsed.py
+++ b/tutoraspects/templates/aspects/apps/aspects/migrations/alembic/versions/0010_vector_replacingmergetree_xapi_parsed.py
@@ -1,0 +1,128 @@
+"""
+This migration handles the somewhat complicated action of changing the table engine
+for the Vector xAPI table from MergeTree to ReplacingMergeTree. It takes a few steps.
+"""
+from alembic import op
+import sqlalchemy as sa
+
+revision = "0010"
+down_revision = "0009"
+branch_labels = None
+depends_on = None
+
+DESTINATION_TABLE = "{{ ASPECTS_XAPI_DATABASE }}.{{ ASPECTS_XAPI_TABLE }}"
+TMP_TABLE_NEW = f"{DESTINATION_TABLE}_tmp_{revision}"
+TMP_TABLE_ORIG = f"{DESTINATION_TABLE}_tmp_mergetree_{revision}"
+
+
+def upgrade():
+    # 1. Create our new table with the desired engine
+    op.execute(
+        f"""
+        CREATE OR REPLACE TABLE {TMP_TABLE_NEW}
+        (
+            event_id      UUID,
+            verb_id       String,
+            actor_id      String,
+            object_id     String,
+            org           String,
+            course_id     String,
+            emission_time DateTime64(6),
+            event_str     String
+        )
+        ENGINE = ReplacingMergeTree 
+        PRIMARY KEY (org, course_id, verb_id, actor_id, emission_time, event_id)
+        ORDER BY (org, course_id, verb_id, actor_id, emission_time, event_id);
+        """
+    )
+    # 2. Attach our table to the existing partitions of the old MergeTree table.
+    #    This works because our "order by" is the same. It should be instant no matter
+    #    the size of the table since it's not copying anything.
+    op.execute(
+        f"""
+        ALTER TABLE {TMP_TABLE_NEW}
+        ATTACH PARTITION tuple() FROM 
+        {DESTINATION_TABLE}
+        """
+    )
+    # 3. Swap both tables in a single rename statement.
+    op.execute(
+        f"""
+        RENAME TABLE {DESTINATION_TABLE} 
+         TO {TMP_TABLE_ORIG}, 
+         {TMP_TABLE_NEW}
+         TO {DESTINATION_TABLE};
+        """
+    )
+    # 4. Force deduplication of the existing data and may take a very long time
+    #    on a larger dataset, but since Aspects isn't in production anywhere yet this
+    #    seems like a reasonable thing to do. If you're looking at this as fodder for
+    #    a future migration, make sure to understand the potential issues here.
+    op.execute(
+        f"""
+        OPTIMIZE TABLE {DESTINATION_TABLE} FINAL;
+        """
+    )
+    # 5. Drop the renamed version of the original table.
+    op.execute(
+        f"""
+        DROP TABLE {TMP_TABLE_ORIG};
+        """
+    )
+
+
+def downgrade():
+    # 1. Create a new table with the old engine
+    op.execute(
+        f"""
+        CREATE OR REPLACE TABLE {TMP_TABLE_ORIG}
+        (
+            event_id      UUID,
+            verb_id       String,
+            actor_id      String,
+            object_id     String,
+            org           String,
+            course_id     String,
+            emission_time DateTime64(6),
+            event_str     String
+        )
+        ENGINE = MergeTree 
+        PRIMARY KEY (org, course_id, verb_id, actor_id, emission_time, event_id)
+        ORDER BY (org, course_id, verb_id, actor_id, emission_time, event_id);
+        """
+    )
+    # 2. Attach our table to the existing partitions of the ReplacingMergeTree table.
+    #    This works because our "order by" is the same. It should be instant no matter
+    #    the size of the table since it's not copying anything.
+    op.execute(
+        f"""
+        ALTER TABLE {TMP_TABLE_ORIG}
+        ATTACH PARTITION tuple() FROM 
+        {DESTINATION_TABLE};
+        """
+    )
+    # 3. Swap both tables in a single rename statement.
+    op.execute(
+        f"""
+        RENAME TABLE {DESTINATION_TABLE}
+         TO {TMP_TABLE_NEW}, 
+         {TMP_TABLE_ORIG}
+         TO {DESTINATION_TABLE};
+        """
+    )
+    # 4. Force deduplication of the existing data and may take a very long time
+    #    on a larger dataset, but since Aspects isn't in production anywhere yet this
+    #    seems like a reasonable thing to do. If you're looking at this as fodder for
+    #    a future migration, make sure to understand the potential issues here.
+    op.execute(
+        f"""
+        OPTIMIZE TABLE {DESTINATION_TABLE} 
+        FINAL DEDUPLICATE;
+        """
+    )
+    # 5. Drop the renamed version of the original table.
+    op.execute(
+        f"""
+        DROP TABLE {TMP_TABLE_NEW};
+        """
+    )

--- a/tutoraspects/templates/aspects/apps/aspects/migrations/alembic/versions/0011_enrollment_replacingmergetree.py
+++ b/tutoraspects/templates/aspects/apps/aspects/migrations/alembic/versions/0011_enrollment_replacingmergetree.py
@@ -1,0 +1,120 @@
+from alembic import op
+import sqlalchemy as sa
+
+revision = "0011"
+down_revision = "0010"
+branch_labels = None
+depends_on = None
+
+DESTINATION_TABLE = "{{ ASPECTS_XAPI_DATABASE }}.{{ ASPECTS_ENROLLMENT_EVENTS_TABLE }}"
+TMP_TABLE_NEW = f"{DESTINATION_TABLE}_tmp_{revision}"
+TMP_TABLE_ORIG = f"{DESTINATION_TABLE}_tmp_mergetree_{revision}"
+
+
+def upgrade():
+    # 1. Create our new table with the desired engine
+    op.execute(
+        f"""
+        CREATE TABLE IF NOT EXISTS {TMP_TABLE_NEW} (
+            `event_id` UUID NOT NULL,
+            `emission_time` DateTime64(6) NOT NULL,
+            `actor_id` String NOT NULL,
+            `object_id` String NOT NULL,
+            `course_id` String NOT NULL,
+            `org` String NOT NULL,
+            `verb_id` LowCardinality(String) NOT NULL,
+            `enrollment_mode` LowCardinality(String)
+        ) ENGINE = ReplacingMergeTree
+        PRIMARY KEY (org, course_id)
+        ORDER BY (org, course_id, actor_id, enrollment_mode, emission_time);
+        """
+    )
+    # 2. Attach our table to the existing partitions of the old MergeTree table.
+    #    This works because our "order by" is the same. It should be instant no matter
+    #    the size of the table since it's not copying anything.
+    op.execute(
+        f"""
+        ALTER TABLE {TMP_TABLE_NEW}
+        ATTACH PARTITION tuple() FROM 
+        {DESTINATION_TABLE}
+        """
+    )
+    # 3. Swap both tables in a single rename statement.
+    op.execute(
+        f"""
+        RENAME TABLE {DESTINATION_TABLE} 
+         TO {TMP_TABLE_ORIG}, 
+         {TMP_TABLE_NEW}
+         TO {DESTINATION_TABLE};
+        """
+    )
+    # 4. Force deduplication of the existing data and may take a very long time
+    #    on a larger dataset, but since Aspects isn't in production anywhere yet this
+    #    seems like a reasonable thing to do. If you're looking at this as fodder for
+    #    a future migration, make sure to understand the potential issues here.
+    op.execute(
+        f"""
+        OPTIMIZE TABLE {DESTINATION_TABLE} FINAL;
+        """
+    )
+    # 5. Drop the renamed version of the original table.
+    op.execute(
+        f"""
+        DROP TABLE {TMP_TABLE_ORIG};
+        """
+    )
+
+
+def downgrade():
+    # 1. Create a new table with the old engine
+    op.execute(
+        f"""
+        CREATE TABLE IF NOT EXISTS {TMP_TABLE_ORIG} (
+            `event_id` UUID NOT NULL,
+            `emission_time` DateTime64(6) NOT NULL,
+            `actor_id` String NOT NULL,
+            `object_id` String NOT NULL,
+            `course_id` String NOT NULL,
+            `org` String NOT NULL,
+            `verb_id` LowCardinality(String) NOT NULL,
+            `enrollment_mode` LowCardinality(String)
+        ) ENGINE = MergeTree
+        PRIMARY KEY (org, course_id)
+        ORDER BY (org, course_id, actor_id, enrollment_mode, emission_time);
+        """
+    )
+    # 2. Attach our table to the existing partitions of the ReplacingMergeTree table.
+    #    This works because our "order by" is the same. It should be instant no matter
+    #    the size of the table since it's not copying anything.
+    op.execute(
+        f"""
+        ALTER TABLE {TMP_TABLE_ORIG}
+        ATTACH PARTITION tuple() FROM 
+        {DESTINATION_TABLE};
+        """
+    )
+    # 3. Swap both tables in a single rename statement.
+    op.execute(
+        f"""
+        RENAME TABLE {DESTINATION_TABLE}
+         TO {TMP_TABLE_NEW}, 
+         {TMP_TABLE_ORIG}
+         TO {DESTINATION_TABLE};
+        """
+    )
+    # 4. Force deduplication of the existing data and may take a very long time
+    #    on a larger dataset, but since Aspects isn't in production anywhere yet this
+    #    seems like a reasonable thing to do. If you're looking at this as fodder for
+    #    a future migration, make sure to understand the potential issues here.
+    op.execute(
+        f"""
+        OPTIMIZE TABLE {DESTINATION_TABLE} 
+        FINAL DEDUPLICATE;
+        """
+    )
+    # 5. Drop the renamed version of the original table.
+    op.execute(
+        f"""
+        DROP TABLE {TMP_TABLE_NEW};
+        """
+    )

--- a/tutoraspects/templates/aspects/apps/aspects/migrations/alembic/versions/0012_video_replacingmergetree.py
+++ b/tutoraspects/templates/aspects/apps/aspects/migrations/alembic/versions/0012_video_replacingmergetree.py
@@ -1,0 +1,113 @@
+from alembic import op
+import sqlalchemy as sa
+
+revision = "0012"
+down_revision = "0011"
+branch_labels = None
+depends_on = None
+
+DESTINATION_TABLE = "{{ ASPECTS_XAPI_DATABASE }}.{{ ASPECTS_VIDEO_PLAYBACK_EVENTS_TABLE }}"
+TMP_TABLE_NEW = f"{DESTINATION_TABLE}_tmp_{revision}"
+TMP_TABLE_ORIG = f"{DESTINATION_TABLE}_tmp_mergetree_{revision}"
+
+
+def upgrade():
+    # 1. Create our new table with the desired engine
+    op.execute(
+        f"""
+        CREATE OR REPLACE TABLE {TMP_TABLE_NEW} (
+            `event_id` UUID NOT NULL,
+            `emission_time` DateTime64(6) NOT NULL,
+            `actor_id` String NOT NULL,
+            `object_id` String NOT NULL,
+            `course_id` String NOT NULL,
+            `org` String NOT NULL,
+            `verb_id` LowCardinality(String) NOT NULL,
+            `video_position` Float32 NOT NULL
+        ) ENGINE = ReplacingMergeTree
+        PRIMARY KEY (org, course_id, verb_id)
+        ORDER BY (org, course_id, verb_id, actor_id, object_id, emission_time);
+        """
+    )
+    # 2. Swap both tables in a single rename statement.
+    op.execute(
+        f"""
+        RENAME TABLE {DESTINATION_TABLE} 
+         TO {TMP_TABLE_ORIG}, 
+         {TMP_TABLE_NEW}
+         TO {DESTINATION_TABLE};
+        """
+    )
+    # 3. Copy the contents of the old table to the new one. We can't just attach
+    #    the old volume here because we're changing the ORDER BY to allow the
+    #    replacement to work. This step can take a long time because of this.
+    op.execute(
+        f"""
+        INSERT INTO {DESTINATION_TABLE} 
+        SELECT * FROM {TMP_TABLE_ORIG};
+        """
+    )
+    # 4. Force deduplication of the existing data and may take a very long time
+    #    on a larger dataset, but since Aspects isn't in production anywhere yet this
+    #    seems like a reasonable thing to do. If you're looking at this as fodder for
+    #    a future migration, make sure to understand the potential issues here.
+    op.execute(
+        f"""
+        OPTIMIZE TABLE {DESTINATION_TABLE} FINAL;
+        """
+    )
+    # 5. Drop the renamed version of the original table.
+    op.execute(
+        f"""
+        DROP TABLE {TMP_TABLE_ORIG};
+        """
+    )
+
+
+def downgrade():
+    # 1. Create a new table with the old engine
+    op.execute(
+        f"""
+        CREATE OR REPLACE TABLE {TMP_TABLE_ORIG} (
+            `event_id` UUID NOT NULL,
+            `emission_time` DateTime64(6) NOT NULL,
+            `actor_id` String NOT NULL,
+            `object_id` String NOT NULL,
+            `course_id` String NOT NULL,
+            `org` String NOT NULL,
+            `verb_id` LowCardinality(String) NOT NULL,
+            `video_position` Float32 NOT NULL
+        ) ENGINE = MergeTree
+        PRIMARY KEY (org, course_id, verb_id)
+        ORDER BY (org, course_id, verb_id, actor_id);
+        """
+    )
+    # 2. Swap both tables in a single rename statement.
+    op.execute(
+        f"""
+        RENAME TABLE {DESTINATION_TABLE}
+         TO {TMP_TABLE_NEW}, 
+         {TMP_TABLE_ORIG}
+         TO {DESTINATION_TABLE};
+        """
+    )
+    # 3. Copy the contents of the old table to the new one. We can't just attach
+    #    the old volume here because we're changing the ORDER BY to allow the
+    #    replacement to work.
+    op.execute(
+        f"""
+        INSERT INTO {DESTINATION_TABLE} 
+        SELECT * FROM {TMP_TABLE_NEW};
+        """
+    )
+    # 4. In some other downgrades from ReplacingMergeTree to MergeTree we do an
+    #    "optimize deduplicate" operation here. However, we're changing the sort order
+    #    in this migration, and the original sort order is not granular enough to
+    #    support deduplication without losing rows, so we do not do that here.
+    #
+    # 5. Drop the renamed version of the original table.
+    op.execute(
+        f"""
+        DROP TABLE {TMP_TABLE_NEW};
+        """
+    )

--- a/tutoraspects/templates/aspects/apps/aspects/migrations/alembic/versions/0013_problem_replacingmergetree.py
+++ b/tutoraspects/templates/aspects/apps/aspects/migrations/alembic/versions/0013_problem_replacingmergetree.py
@@ -1,0 +1,122 @@
+from alembic import op
+import sqlalchemy as sa
+
+revision = "0013"
+down_revision = "0012"
+branch_labels = None
+depends_on = None
+
+DESTINATION_TABLE = "{{ ASPECTS_XAPI_DATABASE }}.{{ ASPECTS_PROBLEM_EVENTS_TABLE }}"
+TMP_TABLE_NEW = f"{DESTINATION_TABLE}_tmp_{revision}"
+TMP_TABLE_ORIG = f"{DESTINATION_TABLE}_tmp_mergetree_{revision}"
+
+
+def upgrade():
+    # 1. Create our new table with the desired engine
+    op.execute(
+        f"""
+        CREATE OR REPLACE TABLE {TMP_TABLE_NEW} (
+            `event_id` UUID NOT NULL,
+            `emission_time` DateTime64(6) NOT NULL,
+            `actor_id` String NOT NULL,
+            `object_id` String NOT NULL,
+            `course_id` String NOT NULL,
+            `org` String NOT NULL,
+            `verb_id` LowCardinality(String) NOT NULL,
+            `responses` String,
+            `scaled_score` String,
+            `success` Bool,
+            `interaction_type` LowCardinality(String),
+            `attempts` Int16
+        ) ENGINE = ReplacingMergeTree
+        PRIMARY KEY (org, course_id, verb_id)
+        ORDER BY (org, course_id, verb_id, actor_id, object_id, emission_time);
+        """
+    )
+    # 2. Swap both tables in a single rename statement.
+    op.execute(
+        f"""
+        RENAME TABLE {DESTINATION_TABLE} 
+         TO {TMP_TABLE_ORIG}, 
+         {TMP_TABLE_NEW}
+         TO {DESTINATION_TABLE};
+        """
+    )
+    # 3. Copy the contents of the old table to the new one. We can't just attach
+    #    the old volume here because we're changing the ORDER BY to allow the
+    #    replacement to work. This step can take a long time because of this.
+    op.execute(
+        f"""
+        INSERT INTO {DESTINATION_TABLE} 
+        SELECT * FROM {TMP_TABLE_ORIG};
+        """
+    )
+    # 4. Force deduplication of the existing data and may take a very long time
+    #    on a larger dataset, but since Aspects isn't in production anywhere yet this
+    #    seems like a reasonable thing to do. If you're looking at this as fodder for
+    #    a future migration, make sure to understand the potential issues here.
+    op.execute(
+        f"""
+        OPTIMIZE TABLE {DESTINATION_TABLE} FINAL;
+        """
+    )
+    # 5. Drop the renamed version of the original table.
+    op.execute(
+        f"""
+        DROP TABLE {TMP_TABLE_ORIG};
+        """
+    )
+
+
+def downgrade():
+    # 1. Create a new table with the old engine
+    op.execute(
+        f"""
+        CREATE OR REPLACE TABLE {TMP_TABLE_ORIG} (
+            `event_id` UUID NOT NULL,
+            `emission_time` DateTime64(6) NOT NULL,
+            `actor_id` String NOT NULL,
+            `object_id` String NOT NULL,
+            `course_id` String NOT NULL,
+            `org` String NOT NULL,
+            `verb_id` LowCardinality(String) NOT NULL,
+            `responses` String,
+            `scaled_score` String,
+            `success` Bool,
+            `interaction_type` LowCardinality(String),
+            `attempts` Int16
+        ) ENGINE = MergeTree
+        PRIMARY KEY (org, course_id, verb_id)
+        ORDER BY (org, course_id, verb_id, actor_id);
+        """
+    )
+    # 2. Swap both tables in a single rename statement.
+    op.execute(
+        f"""
+        RENAME TABLE {DESTINATION_TABLE}
+         TO {TMP_TABLE_NEW}, 
+         {TMP_TABLE_ORIG}
+         TO {DESTINATION_TABLE};
+        """
+    )
+
+    # 3. Copy the contents of the old table to the new one. We can't just attach
+    #    the old volume here because we're changing the ORDER BY to allow the
+    #    replacement to work.
+    op.execute(
+        f"""
+        INSERT INTO {DESTINATION_TABLE} 
+        SELECT * FROM {TMP_TABLE_NEW};
+        """
+    )
+    # 4. In some other downgrades from ReplacingMergeTree to MergeTree we do an
+    #    "optimize deduplicate" operation here. However, we're changing the sort order
+    #    in this migration, and the original sort order is not granular enough to
+    #    support deduplication without losing rows, so we do not do that here.
+    #
+    # 5. Drop the renamed version of the original table.
+    op.execute(
+        f"""
+        DROP TABLE {TMP_TABLE_NEW};
+        """
+    )

--- a/tutoraspects/templates/aspects/apps/aspects/migrations/alembic/versions/0014_navigation_replacingmergetree.py
+++ b/tutoraspects/templates/aspects/apps/aspects/migrations/alembic/versions/0014_navigation_replacingmergetree.py
@@ -1,0 +1,117 @@
+from alembic import op
+import sqlalchemy as sa
+
+revision = "0014"
+down_revision = "0013"
+branch_labels = None
+depends_on = None
+
+DESTINATION_TABLE = "{{ ASPECTS_XAPI_DATABASE }}.{{ ASPECTS_NAVIGATION_EVENTS_TABLE }}"
+TMP_TABLE_NEW = f"{DESTINATION_TABLE}_tmp_{revision}"
+TMP_TABLE_ORIG = f"{DESTINATION_TABLE}_tmp_mergetree_{revision}"
+
+
+def upgrade():
+    # 1. Create our new table with the desired engine
+    op.execute(
+        f"""
+        CREATE OR REPLACE TABLE {TMP_TABLE_NEW} (
+            `event_id` UUID NOT NULL,
+            `emission_time` DateTime64(6) NOT NULL,
+            `actor_id` String NOT NULL,
+            `object_id` String NOT NULL,
+            `course_id` String NOT NULL,
+            `org` String NOT NULL,
+            `verb_id` LowCardinality(String) NOT NULL,
+            `object_type` LowCardinality(String) NOT NULL,
+            `starting_position` Int16,
+            `ending_point` String
+        ) ENGINE = ReplacingMergeTree
+        PRIMARY KEY (org, course_id, object_type)
+        ORDER BY (org, course_id, object_type, actor_id, object_id, emission_time);
+        """
+    )
+    # 2. Swap both tables in a single rename statement.
+    op.execute(
+        f"""
+        RENAME TABLE {DESTINATION_TABLE}
+         TO {TMP_TABLE_ORIG}, 
+         {TMP_TABLE_NEW}
+         TO {DESTINATION_TABLE};
+        """
+    )
+    # 3. Copy the contents of the old table to the new one. We can't just attach
+    #    the old volume here because we're changing the ORDER BY to allow the
+    #    replacement to work.
+    op.execute(
+        f"""
+        INSERT INTO {DESTINATION_TABLE} 
+        SELECT * FROM {TMP_TABLE_ORIG};
+        """
+    )
+    # 4. Force deduplication of the existing data and may take a very long time
+    #    on a larger dataset, but since Aspects isn't in production anywhere yet this
+    #    seems like a reasonable thing to do. If you're looking at this as fodder for
+    #    a future migration, make sure to understand the potential issues here.
+    op.execute(
+        f"""
+        OPTIMIZE TABLE {DESTINATION_TABLE} FINAL;
+        """
+    )
+    # 5. Drop the renamed version of the original table.
+    op.execute(
+        f"""
+        DROP TABLE {TMP_TABLE_ORIG};
+        """
+    )
+
+
+def downgrade():
+    # 1. Create a new table with the old engine
+    op.execute(
+        f"""
+        CREATE OR REPLACE TABLE {TMP_TABLE_ORIG} (
+            `event_id` UUID NOT NULL,
+            `emission_time` DateTime64(6) NOT NULL,
+            `actor_id` String NOT NULL,
+            `object_id` String NOT NULL,
+            `course_id` String NOT NULL,
+            `org` String NOT NULL,
+            `verb_id` LowCardinality(String) NOT NULL,
+            `object_type` LowCardinality(String) NOT NULL,
+            `starting_position` Int16,
+            `ending_point` String
+        ) ENGINE = MergeTree
+        PRIMARY KEY (org, course_id, object_type)
+        ORDER BY (org, course_id, object_type, actor_id);
+        """
+    )
+    # 2. Swap both tables in a single rename statement.
+    op.execute(
+        f"""
+        RENAME TABLE {DESTINATION_TABLE}
+         TO {TMP_TABLE_NEW}, 
+         {TMP_TABLE_ORIG}
+         TO {DESTINATION_TABLE};
+        """
+    )
+    # 3. Copy the contents of the old table to the new one. We can't just attach
+    #    the old volume here because we're changing the ORDER BY to allow the
+    #    replacement to work.
+    op.execute(
+        f"""
+        INSERT INTO {DESTINATION_TABLE} 
+        SELECT * FROM {TMP_TABLE_NEW};
+        """
+    )
+    # 4. In some other downgrades from ReplacingMergeTree to MergeTree we do an
+    #    "optimize deduplicate" operation here. However, we're changing the sort order
+    #    in this migration, and the original sort order is not granular enough to
+    #    support deduplication without losing rows, so we do not do that here.
+    #
+    # 5. Drop the renamed version of the original table.
+    op.execute(
+        f"""
+        DROP TABLE {TMP_TABLE_NEW};
+        """
+    )

--- a/tutoraspects/templates/aspects/apps/vector/file.toml
+++ b/tutoraspects/templates/aspects/apps/vector/file.toml
@@ -5,6 +5,7 @@
 [sources.tracking_log_file]
 type = "file"
 include = ["/var/log/openedx/tracking.log"]
+
 [transforms.openedx_containers]
 type = "filter"
 # no-op filter: created for future-proof compatibility

--- a/tutoraspects/templates/aspects/apps/vector/k8s.toml
+++ b/tutoraspects/templates/aspects/apps/vector/k8s.toml
@@ -7,6 +7,6 @@ type = "kubernetes_logs"
 [transforms.openedx_containers]
 type = "filter"
 inputs = ["kubernetes_logs"]
-condition = '.kubernetes.pod_namespace == "{{ K8S_NAMESPACE }}" && includes(["lms", "cms"], .kubernetes.container_name)'
+condition = '.kubernetes.pod_namespace == "{{ K8S_NAMESPACE }}" && includes(["lms", "cms", "lms-job", "cms-job"], .kubernetes.container_name)'
 
 {% include "aspects/apps/vector/partials/common-post.toml" %}

--- a/tutoraspects/templates/aspects/apps/vector/local.toml
+++ b/tutoraspects/templates/aspects/apps/vector/local.toml
@@ -4,9 +4,10 @@
 # Capture logs from all docker containers
 [sources.docker_logs]
 type = "docker_logs"
+
 [transforms.openedx_containers]
 type = "filter"
 inputs = ["docker_logs"]
-condition = 'includes(["lms", "cms", "lms-worker"], .label."com.docker.compose.service")'
+condition = 'includes(["lms", "cms", "lms-job", "cms-job"], .label."com.docker.compose.service")'
 
 {% include "aspects/apps/vector/partials/common-post.toml" %}

--- a/tutoraspects/templates/aspects/apps/vector/partials/common-post.toml
+++ b/tutoraspects/templates/aspects/apps/vector/partials/common-post.toml
@@ -72,6 +72,13 @@ event_id = parsed_json.id
 drop_on_error = true
 drop_on_abort = true
 
+[transforms.xapi_debug]
+type = "remap"
+inputs = ["xapi"]
+# Time formats: https://docs.rs/chrono/0.4.19/chrono/format/strftime/index.html#specifiers
+source = '''
+.message = parse_json!(.event_str)
+'''
 
 ### Sinks
 
@@ -81,6 +88,12 @@ type = "console"
 inputs = ["tracking_debug"]
 encoding.codec = "json"
 encoding.only_fields = ["time", "message.context.course_id", "message.context.user_id", "message.name"]
+
+[sinks.out_xapi]
+type = "console"
+inputs = ["xapi_debug"]
+encoding.codec = "json"
+encoding.only_fields = ["event_id", "emission_time", "message.verb.id"]
 
 # # Send logs to clickhouse
 [sinks.clickhouse]

--- a/tutoraspects/templates/openedx-assets/queries/dim_course_problems.sql
+++ b/tutoraspects/templates/openedx-assets/queries/dim_course_problems.sql
@@ -12,10 +12,10 @@ with courses as (
         JSON_VALUE(xblock_data_json, '$.block_type') = 'problem'
     {% raw -%}
         {% if filter_values('org') != [] %}
-        and org in {{ filter_values('org') | where_in }}
+        and org in ({{ filter_values('org') | where_in }})
         {% endif %}
         {% if filter_values('problem_name') != [] %}
-        and problem_name in {{ filter_values('problem_name') | where_in }}
+        and problem_name in ({{ filter_values('problem_name') | where_in }})
         {% endif %}
     {%- endraw %}
 )

--- a/tutoraspects/templates/openedx-assets/queries/dim_course_videos.sql
+++ b/tutoraspects/templates/openedx-assets/queries/dim_course_videos.sql
@@ -12,10 +12,10 @@ with courses as (
     {% raw -%}
         JSON_VALUE(xblock_data_json, '$.block_type') = 'video'
         {% if filter_values('org') != [] %}
-        and org in {{ filter_values('org') | where_in }}
+        and org in ({{ filter_values('org') | where_in }})
         {% endif %}
         {% if filter_values('video_name') != [] %}
-        and video_name in {{ filter_values('video_name') | where_in }}
+        and video_name in ({{ filter_values('video_name') | where_in }})
         {% endif %}
     {%- endraw %}
 )

--- a/tutoraspects/templates/openedx-assets/queries/fact_enrollments.sql
+++ b/tutoraspects/templates/openedx-assets/queries/fact_enrollments.sql
@@ -13,7 +13,7 @@ with courses as (
     {% raw -%}
     {% if filter_values('org') != [] %}
     where
-        org in {{ filter_values('org') | where_in }}
+        org in ({{ filter_values('org') | where_in }})
     {% endif %}
     {%- endraw %}
 )

--- a/tutoraspects/templates/openedx-assets/queries/fact_watched_video_segments.sql
+++ b/tutoraspects/templates/openedx-assets/queries/fact_watched_video_segments.sql
@@ -14,7 +14,7 @@ with courses as (
         verb_id = 'https://w3id.org/xapi/video/verbs/played'
         {% raw -%}
         {% if filter_values('org') != [] %}
-        and org in {{ filter_values('org') | where_in }}
+        and org in ({{ filter_values('org') | where_in }})
         {% endif %}
         {%- endraw %}
 ), ends as (
@@ -36,7 +36,7 @@ with courses as (
         )
         {% raw -%}
         {% if filter_values('org') != [] %}
-        and org in {{ filter_values('org') | where_in }}
+        and org in ({{ filter_values('org') | where_in }})
         {% endif %}
         {%- endraw %}
 ), segments as(


### PR DESCRIPTION
This PR contains a new "tutor do" command to wrap bulk transform of tracking log events so that Vector can capture them, as well as various fixes to make the top level materialized view tables "eventually dedupllicated", which can help in certain edge cases with Ralph bulk import as well. 

Right now everything downstream of these tables is a view, and so will pick up deduplication automatically. If we need to start adding other downstream materializations we will need to take this into consideration and make sure to use the "FINAL" keyword or "OPTIMIZE FINAL" in their queries to prevent any duplicate rows trickling downstream.

Closes #127 