### PR TITLE
refactor: parse course key in MV queries (FC-0024)

### DIFF
--- a/tutoraspects/templates/aspects/apps/aspects/migrations/alembic/versions/0009_prefer_course_key.py
+++ b/tutoraspects/templates/aspects/apps/aspects/migrations/alembic/versions/0009_prefer_course_key.py
@@ -1,0 +1,260 @@
+from alembic import op
+
+revision = "0009"
+down_revision = "0008"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    # n.b. we cann't rename the course_id column to course_key because it is used
+    # as part of the primary key for the MV target tables
+    op.execute("set allow_experimental_alter_materialized_view_structure=1;")
+    op.execute(
+        """
+        ALTER TABLE {{ ASPECTS_XAPI_DATABASE }}.{{ ASPECTS_ENROLLMENT_TRANSFORM_MV }}
+        MODIFY QUERY
+        SELECT
+            event_id,
+            emission_time,
+            actor_id,
+            object_id,
+            splitByString('/', course_id)[-1] as course_id,
+            org,
+            verb_id,
+            JSON_VALUE(event_str, '$.object.definition.extensions."https://w3id.org/xapi/acrossx/extensions/type"') AS enrollment_mode
+        FROM {{ ASPECTS_XAPI_DATABASE }}.{{ ASPECTS_XAPI_TABLE }}
+        WHERE verb_id IN (
+            'http://adlnet.gov/expapi/verbs/registered',
+            'http://id.tincanapi.com/verb/unregistered'
+        );
+    """
+    )
+
+    op.execute(
+        """
+        ALTER TABLE {{ ASPECTS_XAPI_DATABASE }}.{{ ASPECTS_VIDEO_PLAYBACK_TRANSFORM_MV }}
+        MODIFY QUERY
+        SELECT
+            event_id,
+            emission_time,
+            actor_id,
+            object_id,
+            splitByString('/', course_id)[-1] as course_id,
+            org,
+            verb_id,
+            cast(coalesce(
+                nullif(JSON_VALUE(event_str, '$.result.extensions."https://w3id.org/xapi/video/extensions/time"'), ''),
+                nullif(JSON_VALUE(event_str, '$.result.extensions."https://w3id.org/xapi/video/extensions/time-from"'), ''),
+                '0.0'
+            ) as Float32) as video_position
+        FROM {{ ASPECTS_XAPI_DATABASE }}.{{ ASPECTS_XAPI_TABLE }}
+        WHERE verb_id IN (
+            'http://adlnet.gov/expapi/verbs/completed',
+            'http://adlnet.gov/expapi/verbs/initialized',
+            'http://adlnet.gov/expapi/verbs/terminated',
+            'https://w3id.org/xapi/video/verbs/paused',
+            'https://w3id.org/xapi/video/verbs/played',
+            'https://w3id.org/xapi/video/verbs/seeked'
+        );
+    """
+    )
+
+    op.execute(
+        """
+        ALTER TABLE {{ ASPECTS_XAPI_DATABASE }}.{{ ASPECTS_PROBLEM_TRANSFORM_MV }}
+        MODIFY QUERY
+        SELECT
+            event_id,
+            emission_time,
+            actor_id,
+            object_id,
+            splitByString('/', course_id)[-1] as course_id,
+            org,
+            verb_id,
+            JSON_VALUE(event_str, '$.result.response') as responses,
+            JSON_VALUE(event_str, '$.result.score.scaled') as scaled_score,
+            if(
+                verb_id = 'https://w3id.org/xapi/acrossx/verbs/evaluated',
+                cast(JSON_VALUE(event_str, '$.result.success') as Bool),
+                false
+            ) as success,
+            JSON_VALUE(event_str, '$.object.definition.interactionType') as interaction_type,
+            if(
+                verb_id = 'https://w3id.org/xapi/acrossx/verbs/evaluated',
+                cast(JSON_VALUE(event_str, '$.object.definition.extensions."http://id.tincanapi.com/extension/attempt-id"') as Int16),
+                0
+            ) as attempts
+        FROM
+            {{ ASPECTS_XAPI_DATABASE }}.{{ ASPECTS_XAPI_TABLE }}
+        WHERE
+            verb_id in (
+                'https://w3id.org/xapi/acrossx/verbs/evaluated',
+                'http://adlnet.gov/expapi/verbs/passed',
+                'http://adlnet.gov/expapi/verbs/asked'
+            );
+    """
+    )
+
+    op.execute(
+        """
+        ALTER TABLE {{ ASPECTS_XAPI_DATABASE }}.{{ ASPECTS_NAVIGATION_TRANSFORM_MV }}
+        MODIFY QUERY
+        SELECT
+            event_id,
+            emission_time,
+            actor_id,
+            object_id,
+            splitByString('/', course_id)[-1] as course_id,
+            org,
+            verb_id,
+            JSON_VALUE(event_str, '$.object.definition.type') AS object_type,
+            -- clicking a link and selecting a module outline have no starting-position field
+            if (
+                object_type in (
+                    'http://adlnet.gov/expapi/activities/link',
+                    'http://adlnet.gov/expapi/activities/module'
+                ),
+                0,
+                cast(JSON_VALUE(
+                    event_str,
+                    '$.context.extensions."http://id.tincanapi.com/extension/starting-position"'
+                ) as Int16)
+            ) AS starting_position,
+            JSON_VALUE(
+                event_str,
+                '$.context.extensions."http://id.tincanapi.com/extension/ending-point"'
+            ) AS ending_point
+        FROM
+            {{ ASPECTS_XAPI_DATABASE }}.{{ ASPECTS_XAPI_TABLE }}
+        WHERE verb_id IN (
+            'https://w3id.org/xapi/dod-isd/verbs/navigated'
+        );
+        """
+    )
+
+
+def downgrade():
+    op.execute("set allow_experimental_alter_materialized_view_structure=1;")
+    op.execute(
+        """
+        ALTER TABLE {{ ASPECTS_XAPI_DATABASE }}.{{ ASPECTS_ENROLLMENT_TRANSFORM_MV }}
+        MODIFY QUERY
+        SELECT
+            event_id,
+            emission_time,
+            actor_id,
+            object_id,
+            course_id,
+            org,
+            verb_id,
+            JSON_VALUE(event_str, '$.object.definition.extensions."https://w3id.org/xapi/acrossx/extensions/type"') AS enrollment_mode
+        FROM {{ ASPECTS_XAPI_DATABASE }}.{{ ASPECTS_XAPI_TABLE }}
+        WHERE verb_id IN (
+            'http://adlnet.gov/expapi/verbs/registered',
+            'http://id.tincanapi.com/verb/unregistered'
+        );
+    """
+    )
+
+    op.execute(
+        """
+        ALTER TABLE {{ ASPECTS_XAPI_DATABASE }}.{{ ASPECTS_VIDEO_PLAYBACK_TRANSFORM_MV }}
+        MODIFY QUERY
+        SELECT
+            event_id,
+            emission_time,
+            actor_id,
+            object_id,
+            course_id,
+            org,
+            verb_id,
+            cast(coalesce(
+                nullif(JSON_VALUE(event_str, '$.result.extensions."https://w3id.org/xapi/video/extensions/time"'), ''),
+                nullif(JSON_VALUE(event_str, '$.result.extensions."https://w3id.org/xapi/video/extensions/time-from"'), ''),
+                '0.0'
+            ) as Float32) as video_position
+        FROM {{ ASPECTS_XAPI_DATABASE }}.{{ ASPECTS_XAPI_TABLE }}
+        WHERE verb_id IN (
+            'http://adlnet.gov/expapi/verbs/completed',
+            'http://adlnet.gov/expapi/verbs/initialized',
+            'http://adlnet.gov/expapi/verbs/terminated',
+            'https://w3id.org/xapi/video/verbs/paused',
+            'https://w3id.org/xapi/video/verbs/played',
+            'https://w3id.org/xapi/video/verbs/seeked'
+        );
+    """
+    )
+
+    op.execute(
+        """
+        ALTER TABLE {{ ASPECTS_XAPI_DATABASE }}.{{ ASPECTS_PROBLEM_TRANSFORM_MV }}
+        MODIFY QUERY
+        SELECT
+            event_id,
+            emission_time,
+            actor_id,
+            object_id,
+            course_id,
+            org,
+            verb_id,
+            JSON_VALUE(event_str, '$.result.response') as responses,
+            JSON_VALUE(event_str, '$.result.score.scaled') as scaled_score,
+            if(
+                verb_id = 'https://w3id.org/xapi/acrossx/verbs/evaluated',
+                cast(JSON_VALUE(event_str, '$.result.success') as Bool),
+                false
+            ) as success,
+            JSON_VALUE(event_str, '$.object.definition.interactionType') as interaction_type,
+            if(
+                verb_id = 'https://w3id.org/xapi/acrossx/verbs/evaluated',
+                cast(JSON_VALUE(event_str, '$.object.definition.extensions."http://id.tincanapi.com/extension/attempt-id"') as Int16),
+                0
+            ) as attempts
+        FROM
+            {{ ASPECTS_XAPI_DATABASE }}.{{ ASPECTS_XAPI_TABLE }}
+        WHERE
+            verb_id in (
+                'https://w3id.org/xapi/acrossx/verbs/evaluated',
+                'http://adlnet.gov/expapi/verbs/passed',
+                'http://adlnet.gov/expapi/verbs/asked'
+            );
+    """
+    )
+
+    op.execute(
+        """
+        ALTER TABLE {{ ASPECTS_XAPI_DATABASE }}.{{ ASPECTS_NAVIGATION_TRANSFORM_MV }}
+        MODIFY QUERY
+        SELECT
+            event_id,
+            emission_time,
+            actor_id,
+            object_id,
+            course_id,
+            org,
+            verb_id,
+            JSON_VALUE(event_str, '$.object.definition.type') AS object_type,
+            -- clicking a link and selecting a module outline have no starting-position field
+            if (
+                object_type in (
+                    'http://adlnet.gov/expapi/activities/link',
+                    'http://adlnet.gov/expapi/activities/module'
+                ),
+                0,
+                cast(JSON_VALUE(
+                    event_str,
+                    '$.context.extensions."http://id.tincanapi.com/extension/starting-position"'
+                ) as Int16)
+            ) AS starting_position,
+            JSON_VALUE(
+                event_str,
+                '$.context.extensions."http://id.tincanapi.com/extension/ending-point"'
+            ) AS ending_point
+        FROM
+            {{ ASPECTS_XAPI_DATABASE }}.{{ ASPECTS_XAPI_TABLE }}
+        WHERE verb_id IN (
+            'https://w3id.org/xapi/dod-isd/verbs/navigated'
+        );
+        """
+    )

--- a/tutoraspects/templates/aspects/apps/aspects/migrations/alembic/versions/0009_prefer_course_key.py
+++ b/tutoraspects/templates/aspects/apps/aspects/migrations/alembic/versions/0009_prefer_course_key.py
@@ -6,20 +6,82 @@ branch_labels = None
 depends_on = None
 
 
-def upgrade():
-    # n.b. we cann't rename the course_id column to course_key because it is used
-    # as part of the primary key for the MV target tables
-    op.execute("set allow_experimental_alter_materialized_view_structure=1;")
-    op.execute(
-        """
-        ALTER TABLE {{ ASPECTS_XAPI_DATABASE }}.{{ ASPECTS_ENROLLMENT_TRANSFORM_MV }}
-        MODIFY QUERY
+TABLES = {
+    "{{ ASPECTS_XAPI_DATABASE }}.{{ ASPECTS_ENROLLMENT_EVENTS_TABLE }}": """
+        CREATE TABLE IF NOT EXISTS {{ ASPECTS_XAPI_DATABASE }}.{{ ASPECTS_ENROLLMENT_EVENTS_TABLE }} (
+            `event_id` UUID NOT NULL,
+            `emission_time` DateTime64(6) NOT NULL,
+            `actor_id` String NOT NULL,
+            `object_id` String NOT NULL,
+            `course_id` String NOT NULL,
+            `org` String NOT NULL,
+            `verb_id` LowCardinality(String) NOT NULL,
+            `enrollment_mode` LowCardinality(String)
+        ) ENGINE = MergeTree
+        PRIMARY KEY (org, course_id)
+        ORDER BY (org, course_id, actor_id, enrollment_mode, emission_time);
+        """,
+    "{{ ASPECTS_XAPI_DATABASE }}.{{ ASPECTS_VIDEO_PLAYBACK_EVENTS_TABLE }}": """
+        CREATE TABLE IF NOT EXISTS {{ ASPECTS_XAPI_DATABASE }}.{{ ASPECTS_VIDEO_PLAYBACK_EVENTS_TABLE }} (
+            `event_id` UUID NOT NULL,
+            `emission_time` DateTime64(6) NOT NULL,
+            `actor_id` String NOT NULL,
+            `object_id` String NOT NULL,
+            `course_id` String NOT NULL,
+            `org` String NOT NULL,
+            `verb_id` LowCardinality(String) NOT NULL,
+            `video_position` Float32 NOT NULL
+        ) ENGINE = MergeTree
+        PRIMARY KEY (org, course_id, verb_id)
+        ORDER BY (org, course_id, verb_id, actor_id);
+        """,
+    "{{ ASPECTS_XAPI_DATABASE }}.{{ ASPECTS_PROBLEM_EVENTS_TABLE }}": """
+        CREATE TABLE IF NOT EXISTS {{ ASPECTS_XAPI_DATABASE }}.{{ ASPECTS_PROBLEM_EVENTS_TABLE }} (
+            `event_id` UUID NOT NULL,
+            `emission_time` DateTime64(6) NOT NULL,
+            `actor_id` String NOT NULL,
+            `object_id` String NOT NULL,
+            `course_id` String NOT NULL,
+            `org` String NOT NULL,
+            `verb_id` LowCardinality(String) NOT NULL,
+            `responses` String,
+            `scaled_score` String,
+            `success` Bool,
+            `interaction_type` LowCardinality(String),
+            `attempts` Int16
+        ) ENGINE = MergeTree
+        PRIMARY KEY (org, course_id, verb_id)
+        ORDER BY (org, course_id, verb_id, actor_id);
+        """,
+    "{{ ASPECTS_XAPI_DATABASE }}.{{ ASPECTS_NAVIGATION_EVENTS_TABLE }}": """
+        CREATE TABLE IF NOT EXISTS {{ ASPECTS_XAPI_DATABASE }}.{{ ASPECTS_NAVIGATION_EVENTS_TABLE }} (
+            `event_id` UUID NOT NULL,
+            `emission_time` DateTime64(6) NOT NULL,
+            `actor_id` String NOT NULL,
+            `object_id` String NOT NULL,
+            `course_id` String NOT NULL,
+            `org` String NOT NULL,
+            `verb_id` LowCardinality(String) NOT NULL,
+            `object_type` LowCardinality(String) NOT NULL,
+            `starting_position` Int16,
+            `ending_point` String
+        ) ENGINE = MergeTree
+        PRIMARY KEY (org, course_id, object_type)
+        ORDER BY (org, course_id, object_type, actor_id);
+        """,
+}
+
+
+MATERIALIZED_VIEWS = {
+    "{{ ASPECTS_XAPI_DATABASE }}.{{ ASPECTS_ENROLLMENT_TRANSFORM_MV }}": """
+        CREATE MATERIALIZED VIEW IF NOT EXISTS {{ ASPECTS_XAPI_DATABASE }}.{{ ASPECTS_ENROLLMENT_TRANSFORM_MV }}
+            TO {{ ASPECTS_XAPI_DATABASE }}.{{ ASPECTS_ENROLLMENT_EVENTS_TABLE }} AS
         SELECT
             event_id,
             emission_time,
             actor_id,
             object_id,
-            splitByString('/', course_id)[-1] as course_id,
+            course_id,
             org,
             verb_id,
             JSON_VALUE(event_str, '$.object.definition.extensions."https://w3id.org/xapi/acrossx/extensions/type"') AS enrollment_mode
@@ -28,19 +90,16 @@ def upgrade():
             'http://adlnet.gov/expapi/verbs/registered',
             'http://id.tincanapi.com/verb/unregistered'
         );
-    """
-    )
-
-    op.execute(
-        """
-        ALTER TABLE {{ ASPECTS_XAPI_DATABASE }}.{{ ASPECTS_VIDEO_PLAYBACK_TRANSFORM_MV }}
-        MODIFY QUERY
+        """,
+    "{{ ASPECTS_XAPI_DATABASE }}.{{ ASPECTS_VIDEO_PLAYBACK_TRANSFORM_MV }}": """
+        CREATE MATERIALIZED VIEW IF NOT EXISTS {{ ASPECTS_XAPI_DATABASE }}.{{ ASPECTS_VIDEO_PLAYBACK_TRANSFORM_MV }}
+            TO {{ ASPECTS_XAPI_DATABASE }}.{{ ASPECTS_VIDEO_PLAYBACK_EVENTS_TABLE }} AS
         SELECT
             event_id,
             emission_time,
             actor_id,
             object_id,
-            splitByString('/', course_id)[-1] as course_id,
+            course_id,
             org,
             verb_id,
             cast(coalesce(
@@ -57,19 +116,16 @@ def upgrade():
             'https://w3id.org/xapi/video/verbs/played',
             'https://w3id.org/xapi/video/verbs/seeked'
         );
-    """
-    )
-
-    op.execute(
-        """
-        ALTER TABLE {{ ASPECTS_XAPI_DATABASE }}.{{ ASPECTS_PROBLEM_TRANSFORM_MV }}
-        MODIFY QUERY
+        """,
+    "{{ ASPECTS_XAPI_DATABASE }}.{{ ASPECTS_PROBLEM_TRANSFORM_MV }}": """
+        CREATE MATERIALIZED VIEW IF NOT EXISTS {{ ASPECTS_XAPI_DATABASE }}.{{ ASPECTS_PROBLEM_TRANSFORM_MV }}
+            TO {{ ASPECTS_XAPI_DATABASE }}.{{ ASPECTS_PROBLEM_EVENTS_TABLE }} AS
         SELECT
             event_id,
             emission_time,
             actor_id,
             object_id,
-            splitByString('/', course_id)[-1] as course_id,
+            course_id,
             org,
             verb_id,
             JSON_VALUE(event_str, '$.result.response') as responses,
@@ -93,19 +149,16 @@ def upgrade():
                 'http://adlnet.gov/expapi/verbs/passed',
                 'http://adlnet.gov/expapi/verbs/asked'
             );
-    """
-    )
-
-    op.execute(
-        """
-        ALTER TABLE {{ ASPECTS_XAPI_DATABASE }}.{{ ASPECTS_NAVIGATION_TRANSFORM_MV }}
-        MODIFY QUERY
+        """,
+    "{{ ASPECTS_XAPI_DATABASE }}.{{ ASPECTS_NAVIGATION_TRANSFORM_MV }}": """
+        CREATE MATERIALIZED VIEW IF NOT EXISTS {{ ASPECTS_XAPI_DATABASE }}.{{ ASPECTS_NAVIGATION_TRANSFORM_MV }}
+        TO {{ ASPECTS_XAPI_DATABASE }}.{{ ASPECTS_NAVIGATION_EVENTS_TABLE }} AS
         SELECT
             event_id,
             emission_time,
             actor_id,
             object_id,
-            splitByString('/', course_id)[-1] as course_id,
+            course_id,
             org,
             verb_id,
             JSON_VALUE(event_str, '$.object.definition.type') AS object_type,
@@ -130,131 +183,31 @@ def upgrade():
         WHERE verb_id IN (
             'https://w3id.org/xapi/dod-isd/verbs/navigated'
         );
-        """
-    )
+        """,
+}
+
+
+def upgrade():
+    # drop the tables and MVs and create new ones, with course_id
+    # replaced by course_key
+    for name, ddl in TABLES.items():
+        op.execute(f"DROP TABLE IF EXISTS {name}")
+        op.execute(ddl.replace("course_id", "course_key"))
+
+    for name, query in MATERIALIZED_VIEWS.items():
+        op.execute(f"DROP TABLE {name}")
+        op.execute(
+            query.replace(
+                "course_id", "splitByString('/', course_id)[-1] AS course_key"
+            )
+        )
 
 
 def downgrade():
-    op.execute("set allow_experimental_alter_materialized_view_structure=1;")
-    op.execute(
-        """
-        ALTER TABLE {{ ASPECTS_XAPI_DATABASE }}.{{ ASPECTS_ENROLLMENT_TRANSFORM_MV }}
-        MODIFY QUERY
-        SELECT
-            event_id,
-            emission_time,
-            actor_id,
-            object_id,
-            course_id,
-            org,
-            verb_id,
-            JSON_VALUE(event_str, '$.object.definition.extensions."https://w3id.org/xapi/acrossx/extensions/type"') AS enrollment_mode
-        FROM {{ ASPECTS_XAPI_DATABASE }}.{{ ASPECTS_XAPI_TABLE }}
-        WHERE verb_id IN (
-            'http://adlnet.gov/expapi/verbs/registered',
-            'http://id.tincanapi.com/verb/unregistered'
-        );
-    """
-    )
+    for name, ddl in TABLES.items():
+        op.execute(f"DROP TABLE IF EXISTS {name}")
+        op.execute(ddl)
 
-    op.execute(
-        """
-        ALTER TABLE {{ ASPECTS_XAPI_DATABASE }}.{{ ASPECTS_VIDEO_PLAYBACK_TRANSFORM_MV }}
-        MODIFY QUERY
-        SELECT
-            event_id,
-            emission_time,
-            actor_id,
-            object_id,
-            course_id,
-            org,
-            verb_id,
-            cast(coalesce(
-                nullif(JSON_VALUE(event_str, '$.result.extensions."https://w3id.org/xapi/video/extensions/time"'), ''),
-                nullif(JSON_VALUE(event_str, '$.result.extensions."https://w3id.org/xapi/video/extensions/time-from"'), ''),
-                '0.0'
-            ) as Float32) as video_position
-        FROM {{ ASPECTS_XAPI_DATABASE }}.{{ ASPECTS_XAPI_TABLE }}
-        WHERE verb_id IN (
-            'http://adlnet.gov/expapi/verbs/completed',
-            'http://adlnet.gov/expapi/verbs/initialized',
-            'http://adlnet.gov/expapi/verbs/terminated',
-            'https://w3id.org/xapi/video/verbs/paused',
-            'https://w3id.org/xapi/video/verbs/played',
-            'https://w3id.org/xapi/video/verbs/seeked'
-        );
-    """
-    )
-
-    op.execute(
-        """
-        ALTER TABLE {{ ASPECTS_XAPI_DATABASE }}.{{ ASPECTS_PROBLEM_TRANSFORM_MV }}
-        MODIFY QUERY
-        SELECT
-            event_id,
-            emission_time,
-            actor_id,
-            object_id,
-            course_id,
-            org,
-            verb_id,
-            JSON_VALUE(event_str, '$.result.response') as responses,
-            JSON_VALUE(event_str, '$.result.score.scaled') as scaled_score,
-            if(
-                verb_id = 'https://w3id.org/xapi/acrossx/verbs/evaluated',
-                cast(JSON_VALUE(event_str, '$.result.success') as Bool),
-                false
-            ) as success,
-            JSON_VALUE(event_str, '$.object.definition.interactionType') as interaction_type,
-            if(
-                verb_id = 'https://w3id.org/xapi/acrossx/verbs/evaluated',
-                cast(JSON_VALUE(event_str, '$.object.definition.extensions."http://id.tincanapi.com/extension/attempt-id"') as Int16),
-                0
-            ) as attempts
-        FROM
-            {{ ASPECTS_XAPI_DATABASE }}.{{ ASPECTS_XAPI_TABLE }}
-        WHERE
-            verb_id in (
-                'https://w3id.org/xapi/acrossx/verbs/evaluated',
-                'http://adlnet.gov/expapi/verbs/passed',
-                'http://adlnet.gov/expapi/verbs/asked'
-            );
-    """
-    )
-
-    op.execute(
-        """
-        ALTER TABLE {{ ASPECTS_XAPI_DATABASE }}.{{ ASPECTS_NAVIGATION_TRANSFORM_MV }}
-        MODIFY QUERY
-        SELECT
-            event_id,
-            emission_time,
-            actor_id,
-            object_id,
-            course_id,
-            org,
-            verb_id,
-            JSON_VALUE(event_str, '$.object.definition.type') AS object_type,
-            -- clicking a link and selecting a module outline have no starting-position field
-            if (
-                object_type in (
-                    'http://adlnet.gov/expapi/activities/link',
-                    'http://adlnet.gov/expapi/activities/module'
-                ),
-                0,
-                cast(JSON_VALUE(
-                    event_str,
-                    '$.context.extensions."http://id.tincanapi.com/extension/starting-position"'
-                ) as Int16)
-            ) AS starting_position,
-            JSON_VALUE(
-                event_str,
-                '$.context.extensions."http://id.tincanapi.com/extension/ending-point"'
-            ) AS ending_point
-        FROM
-            {{ ASPECTS_XAPI_DATABASE }}.{{ ASPECTS_XAPI_TABLE }}
-        WHERE verb_id IN (
-            'https://w3id.org/xapi/dod-isd/verbs/navigated'
-        );
-        """
-    )
+    for name, query in MATERIALIZED_VIEWS.items():
+        op.execute(f"DROP TABLE IF EXISTS {name}")
+        op.execute(query)

--- a/tutoraspects/templates/aspects/apps/aspects/migrations/alembic/versions/0009_prefer_course_key.py
+++ b/tutoraspects/templates/aspects/apps/aspects/migrations/alembic/versions/0009_prefer_course_key.py
@@ -28,7 +28,7 @@ CREATE TABLE IF NOT EXISTS {{ ASPECTS_XAPI_DATABASE }}.{{ ASPECTS_ENROLLMENT_EVE
     `org` String NOT NULL,
     `verb_id` LowCardinality(String) NOT NULL,
     `enrollment_mode` LowCardinality(String)
-) ENGINE = MergeTree
+) ENGINE = ReplacingMergeTree
 PRIMARY KEY (org, course_id)
 ORDER BY (org, course_id, actor_id, enrollment_mode, emission_time);
 """
@@ -43,7 +43,7 @@ CREATE TABLE IF NOT EXISTS {{ ASPECTS_XAPI_DATABASE }}.{{ ASPECTS_ENROLLMENT_EVE
     `org` String NOT NULL,
     `verb_id` LowCardinality(String) NOT NULL,
     `enrollment_mode` LowCardinality(String)
-) ENGINE = MergeTree
+) ENGINE = ReplacingMergeTree
 PRIMARY KEY (org, course_key)
 ORDER BY (org, course_key, actor_id, enrollment_mode, emission_time);
 """
@@ -92,7 +92,7 @@ CREATE TABLE IF NOT EXISTS {{ ASPECTS_XAPI_DATABASE }}.{{ ASPECTS_VIDEO_PLAYBACK
     `org` String NOT NULL,
     `verb_id` LowCardinality(String) NOT NULL,
     `video_position` Float32 NOT NULL
-) ENGINE = MergeTree
+) ENGINE = ReplacingMergeTree
 PRIMARY KEY (org, course_id, verb_id)
 ORDER BY (org, course_id, verb_id, actor_id);
 """
@@ -107,7 +107,7 @@ CREATE TABLE IF NOT EXISTS {{ ASPECTS_XAPI_DATABASE }}.{{ ASPECTS_VIDEO_PLAYBACK
     `org` String NOT NULL,
     `verb_id` LowCardinality(String) NOT NULL,
     `video_position` Float32 NOT NULL
-) ENGINE = MergeTree
+) ENGINE = ReplacingMergeTree
 PRIMARY KEY (org, course_key, verb_id)
 ORDER BY (org, course_key, verb_id, actor_id);
 """
@@ -176,7 +176,7 @@ CREATE TABLE IF NOT EXISTS {{ ASPECTS_XAPI_DATABASE }}.{{ ASPECTS_PROBLEM_EVENTS
     `success` Bool,
     `interaction_type` LowCardinality(String),
     `attempts` Int16
-) ENGINE = MergeTree
+) ENGINE = ReplacingMergeTree
 PRIMARY KEY (org, course_id, verb_id)
 ORDER BY (org, course_id, verb_id, actor_id);
 """
@@ -195,7 +195,7 @@ CREATE TABLE IF NOT EXISTS {{ ASPECTS_XAPI_DATABASE }}.{{ ASPECTS_PROBLEM_EVENTS
     `success` Bool,
     `interaction_type` LowCardinality(String),
     `attempts` Int16
-) ENGINE = MergeTree
+) ENGINE = ReplacingMergeTree
 PRIMARY KEY (org, course_key, verb_id)
 ORDER BY (org, course_key, verb_id, actor_id);
 """
@@ -276,7 +276,7 @@ CREATE TABLE IF NOT EXISTS {{ ASPECTS_XAPI_DATABASE }}.{{ ASPECTS_NAVIGATION_EVE
     `object_type` LowCardinality(String) NOT NULL,
     `starting_position` Int16,
     `ending_point` String
-) ENGINE = MergeTree
+) ENGINE = ReplacingMergeTree
 PRIMARY KEY (org, course_id, object_type)
 ORDER BY (org, course_id, object_type, actor_id);
 """
@@ -293,7 +293,7 @@ CREATE TABLE IF NOT EXISTS {{ ASPECTS_XAPI_DATABASE }}.{{ ASPECTS_NAVIGATION_EVE
     `object_type` LowCardinality(String) NOT NULL,
     `starting_position` Int16,
     `ending_point` String
-) ENGINE = MergeTree
+) ENGINE = ReplacingMergeTree
 PRIMARY KEY (org, course_key, object_type)
 ORDER BY (org, course_key, object_type, actor_id);
 """
@@ -407,7 +407,7 @@ def migrate(table_name, mv_name, table_ddl, mv_query):
     # - load data into the new table using the new MV query
     # - create the materialized view using the new query
     op.execute(f"DROP TABLE IF EXISTS {table_name}")
-    op.execute(f"DROP TABLE IF EXISTS {mv_name}")
+    op.execute(f"DROP VIEW IF EXISTS {mv_name}")
     op.execute(table_ddl)
     op.execute(f"INSERT INTO {table_name} {mv_query}")
     mv_ddl = (

--- a/tutoraspects/templates/aspects/apps/aspects/migrations/alembic/versions/0009_prefer_course_key.py
+++ b/tutoraspects/templates/aspects/apps/aspects/migrations/alembic/versions/0009_prefer_course_key.py
@@ -1,3 +1,5 @@
+from dataclasses import dataclass
+
 from alembic import op
 
 revision = "0009"
@@ -6,208 +8,430 @@ branch_labels = None
 depends_on = None
 
 
-TABLES = {
-    "{{ ASPECTS_XAPI_DATABASE }}.{{ ASPECTS_ENROLLMENT_EVENTS_TABLE }}": """
-        CREATE TABLE IF NOT EXISTS {{ ASPECTS_XAPI_DATABASE }}.{{ ASPECTS_ENROLLMENT_EVENTS_TABLE }} (
-            `event_id` UUID NOT NULL,
-            `emission_time` DateTime64(6) NOT NULL,
-            `actor_id` String NOT NULL,
-            `object_id` String NOT NULL,
-            `course_id` String NOT NULL,
-            `org` String NOT NULL,
-            `verb_id` LowCardinality(String) NOT NULL,
-            `enrollment_mode` LowCardinality(String)
-        ) ENGINE = MergeTree
-        PRIMARY KEY (org, course_id)
-        ORDER BY (org, course_id, actor_id, enrollment_mode, emission_time);
-        """,
-    "{{ ASPECTS_XAPI_DATABASE }}.{{ ASPECTS_VIDEO_PLAYBACK_EVENTS_TABLE }}": """
-        CREATE TABLE IF NOT EXISTS {{ ASPECTS_XAPI_DATABASE }}.{{ ASPECTS_VIDEO_PLAYBACK_EVENTS_TABLE }} (
-            `event_id` UUID NOT NULL,
-            `emission_time` DateTime64(6) NOT NULL,
-            `actor_id` String NOT NULL,
-            `object_id` String NOT NULL,
-            `course_id` String NOT NULL,
-            `org` String NOT NULL,
-            `verb_id` LowCardinality(String) NOT NULL,
-            `video_position` Float32 NOT NULL
-        ) ENGINE = MergeTree
-        PRIMARY KEY (org, course_id, verb_id)
-        ORDER BY (org, course_id, verb_id, actor_id);
-        """,
-    "{{ ASPECTS_XAPI_DATABASE }}.{{ ASPECTS_PROBLEM_EVENTS_TABLE }}": """
-        CREATE TABLE IF NOT EXISTS {{ ASPECTS_XAPI_DATABASE }}.{{ ASPECTS_PROBLEM_EVENTS_TABLE }} (
-            `event_id` UUID NOT NULL,
-            `emission_time` DateTime64(6) NOT NULL,
-            `actor_id` String NOT NULL,
-            `object_id` String NOT NULL,
-            `course_id` String NOT NULL,
-            `org` String NOT NULL,
-            `verb_id` LowCardinality(String) NOT NULL,
-            `responses` String,
-            `scaled_score` String,
-            `success` Bool,
-            `interaction_type` LowCardinality(String),
-            `attempts` Int16
-        ) ENGINE = MergeTree
-        PRIMARY KEY (org, course_id, verb_id)
-        ORDER BY (org, course_id, verb_id, actor_id);
-        """,
-    "{{ ASPECTS_XAPI_DATABASE }}.{{ ASPECTS_NAVIGATION_EVENTS_TABLE }}": """
-        CREATE TABLE IF NOT EXISTS {{ ASPECTS_XAPI_DATABASE }}.{{ ASPECTS_NAVIGATION_EVENTS_TABLE }} (
-            `event_id` UUID NOT NULL,
-            `emission_time` DateTime64(6) NOT NULL,
-            `actor_id` String NOT NULL,
-            `object_id` String NOT NULL,
-            `course_id` String NOT NULL,
-            `org` String NOT NULL,
-            `verb_id` LowCardinality(String) NOT NULL,
-            `object_type` LowCardinality(String) NOT NULL,
-            `starting_position` Int16,
-            `ending_point` String
-        ) ENGINE = MergeTree
-        PRIMARY KEY (org, course_id, object_type)
-        ORDER BY (org, course_id, object_type, actor_id);
-        """,
-}
+@dataclass
+class MvMigration:
+    table_name: str
+    old_ddl: str
+    new_ddl: str
+    mv_name: str
+    old_mv_query: str
+    new_mv_query: str
 
 
-MATERIALIZED_VIEWS = {
-    "{{ ASPECTS_XAPI_DATABASE }}.{{ ASPECTS_ENROLLMENT_TRANSFORM_MV }}": """
-        CREATE MATERIALIZED VIEW IF NOT EXISTS {{ ASPECTS_XAPI_DATABASE }}.{{ ASPECTS_ENROLLMENT_TRANSFORM_MV }}
-            TO {{ ASPECTS_XAPI_DATABASE }}.{{ ASPECTS_ENROLLMENT_EVENTS_TABLE }} AS
-        SELECT
-            event_id,
-            emission_time,
-            actor_id,
-            object_id,
-            course_id,
-            org,
-            verb_id,
-            JSON_VALUE(event_str, '$.object.definition.extensions."https://w3id.org/xapi/acrossx/extensions/type"') AS enrollment_mode
-        FROM {{ ASPECTS_XAPI_DATABASE }}.{{ ASPECTS_XAPI_TABLE }}
-        WHERE verb_id IN (
-            'http://adlnet.gov/expapi/verbs/registered',
-            'http://id.tincanapi.com/verb/unregistered'
-        );
-        """,
-    "{{ ASPECTS_XAPI_DATABASE }}.{{ ASPECTS_VIDEO_PLAYBACK_TRANSFORM_MV }}": """
-        CREATE MATERIALIZED VIEW IF NOT EXISTS {{ ASPECTS_XAPI_DATABASE }}.{{ ASPECTS_VIDEO_PLAYBACK_TRANSFORM_MV }}
-            TO {{ ASPECTS_XAPI_DATABASE }}.{{ ASPECTS_VIDEO_PLAYBACK_EVENTS_TABLE }} AS
-        SELECT
-            event_id,
-            emission_time,
-            actor_id,
-            object_id,
-            course_id,
-            org,
-            verb_id,
-            cast(coalesce(
-                nullif(JSON_VALUE(event_str, '$.result.extensions."https://w3id.org/xapi/video/extensions/time"'), ''),
-                nullif(JSON_VALUE(event_str, '$.result.extensions."https://w3id.org/xapi/video/extensions/time-from"'), ''),
-                '0.0'
-            ) as Float32) as video_position
-        FROM {{ ASPECTS_XAPI_DATABASE }}.{{ ASPECTS_XAPI_TABLE }}
-        WHERE verb_id IN (
-            'http://adlnet.gov/expapi/verbs/completed',
-            'http://adlnet.gov/expapi/verbs/initialized',
-            'http://adlnet.gov/expapi/verbs/terminated',
-            'https://w3id.org/xapi/video/verbs/paused',
-            'https://w3id.org/xapi/video/verbs/played',
-            'https://w3id.org/xapi/video/verbs/seeked'
-        );
-        """,
-    "{{ ASPECTS_XAPI_DATABASE }}.{{ ASPECTS_PROBLEM_TRANSFORM_MV }}": """
-        CREATE MATERIALIZED VIEW IF NOT EXISTS {{ ASPECTS_XAPI_DATABASE }}.{{ ASPECTS_PROBLEM_TRANSFORM_MV }}
-            TO {{ ASPECTS_XAPI_DATABASE }}.{{ ASPECTS_PROBLEM_EVENTS_TABLE }} AS
-        SELECT
-            event_id,
-            emission_time,
-            actor_id,
-            object_id,
-            course_id,
-            org,
-            verb_id,
-            JSON_VALUE(event_str, '$.result.response') as responses,
-            JSON_VALUE(event_str, '$.result.score.scaled') as scaled_score,
-            if(
-                verb_id = 'https://w3id.org/xapi/acrossx/verbs/evaluated',
-                cast(JSON_VALUE(event_str, '$.result.success') as Bool),
-                false
-            ) as success,
-            JSON_VALUE(event_str, '$.object.definition.interactionType') as interaction_type,
-            if(
-                verb_id = 'https://w3id.org/xapi/acrossx/verbs/evaluated',
-                cast(JSON_VALUE(event_str, '$.object.definition.extensions."http://id.tincanapi.com/extension/attempt-id"') as Int16),
-                0
-            ) as attempts
-        FROM
-            {{ ASPECTS_XAPI_DATABASE }}.{{ ASPECTS_XAPI_TABLE }}
-        WHERE
-            verb_id in (
-                'https://w3id.org/xapi/acrossx/verbs/evaluated',
-                'http://adlnet.gov/expapi/verbs/passed',
-                'http://adlnet.gov/expapi/verbs/asked'
-            );
-        """,
-    "{{ ASPECTS_XAPI_DATABASE }}.{{ ASPECTS_NAVIGATION_TRANSFORM_MV }}": """
-        CREATE MATERIALIZED VIEW IF NOT EXISTS {{ ASPECTS_XAPI_DATABASE }}.{{ ASPECTS_NAVIGATION_TRANSFORM_MV }}
-        TO {{ ASPECTS_XAPI_DATABASE }}.{{ ASPECTS_NAVIGATION_EVENTS_TABLE }} AS
-        SELECT
-            event_id,
-            emission_time,
-            actor_id,
-            object_id,
-            course_id,
-            org,
-            verb_id,
-            JSON_VALUE(event_str, '$.object.definition.type') AS object_type,
-            -- clicking a link and selecting a module outline have no starting-position field
-            if (
-                object_type in (
-                    'http://adlnet.gov/expapi/activities/link',
-                    'http://adlnet.gov/expapi/activities/module'
-                ),
-                0,
-                cast(JSON_VALUE(
-                    event_str,
-                    '$.context.extensions."http://id.tincanapi.com/extension/starting-position"'
-                ) as Int16)
-            ) AS starting_position,
-            JSON_VALUE(
-                event_str,
-                '$.context.extensions."http://id.tincanapi.com/extension/ending-point"'
-            ) AS ending_point
-        FROM
-            {{ ASPECTS_XAPI_DATABASE }}.{{ ASPECTS_XAPI_TABLE }}
-        WHERE verb_id IN (
-            'https://w3id.org/xapi/dod-isd/verbs/navigated'
-        );
-        """,
-}
+OLD_ENROLLMENT_DDL = """
+CREATE TABLE IF NOT EXISTS {{ ASPECTS_XAPI_DATABASE }}.{{ ASPECTS_ENROLLMENT_EVENTS_TABLE }} (
+    `event_id` UUID NOT NULL,
+    `emission_time` DateTime64(6) NOT NULL,
+    `actor_id` String NOT NULL,
+    `object_id` String NOT NULL,
+    `course_id` String NOT NULL,
+    `org` String NOT NULL,
+    `verb_id` LowCardinality(String) NOT NULL,
+    `enrollment_mode` LowCardinality(String)
+) ENGINE = MergeTree
+PRIMARY KEY (org, course_id)
+ORDER BY (org, course_id, actor_id, enrollment_mode, emission_time);
+"""
+
+NEW_ENROLLMENT_DDL = """
+CREATE TABLE IF NOT EXISTS {{ ASPECTS_XAPI_DATABASE }}.{{ ASPECTS_ENROLLMENT_EVENTS_TABLE }} (
+    `event_id` UUID NOT NULL,
+    `emission_time` DateTime64(6) NOT NULL,
+    `actor_id` String NOT NULL,
+    `object_id` String NOT NULL,
+    `course_key` String NOT NULL,
+    `org` String NOT NULL,
+    `verb_id` LowCardinality(String) NOT NULL,
+    `enrollment_mode` LowCardinality(String)
+) ENGINE = MergeTree
+PRIMARY KEY (org, course_key)
+ORDER BY (org, course_key, actor_id, enrollment_mode, emission_time);
+"""
+
+OLD_ENROLLMENT_QUERY = """
+SELECT
+    event_id,
+    emission_time,
+    actor_id,
+    object_id,
+    course_id,
+    org,
+    verb_id,
+    JSON_VALUE(event_str, '$.object.definition.extensions."https://w3id.org/xapi/acrossx/extensions/type"') AS enrollment_mode
+FROM {{ ASPECTS_XAPI_DATABASE }}.{{ ASPECTS_XAPI_TABLE }}
+WHERE verb_id IN (
+    'http://adlnet.gov/expapi/verbs/registered',
+    'http://id.tincanapi.com/verb/unregistered'
+);
+"""
+
+NEW_ENROLLMENT_QUERY = """
+SELECT
+    event_id,
+    emission_time,
+    actor_id,
+    object_id,
+    splitByString('/', course_id)[-1] AS course_key,
+    org,
+    verb_id,
+    JSON_VALUE(event_str, '$.object.definition.extensions."https://w3id.org/xapi/acrossx/extensions/type"') AS enrollment_mode
+FROM {{ ASPECTS_XAPI_DATABASE }}.{{ ASPECTS_XAPI_TABLE }}
+WHERE verb_id IN (
+    'http://adlnet.gov/expapi/verbs/registered',
+    'http://id.tincanapi.com/verb/unregistered'
+);
+"""
+
+OLD_VIDEO_DDL = """
+CREATE TABLE IF NOT EXISTS {{ ASPECTS_XAPI_DATABASE }}.{{ ASPECTS_VIDEO_PLAYBACK_EVENTS_TABLE }} (
+    `event_id` UUID NOT NULL,
+    `emission_time` DateTime64(6) NOT NULL,
+    `actor_id` String NOT NULL,
+    `object_id` String NOT NULL,
+    `course_id` String NOT NULL,
+    `org` String NOT NULL,
+    `verb_id` LowCardinality(String) NOT NULL,
+    `video_position` Float32 NOT NULL
+) ENGINE = MergeTree
+PRIMARY KEY (org, course_id, verb_id)
+ORDER BY (org, course_id, verb_id, actor_id);
+"""
+
+NEW_VIDEO_DDL = """
+CREATE TABLE IF NOT EXISTS {{ ASPECTS_XAPI_DATABASE }}.{{ ASPECTS_VIDEO_PLAYBACK_EVENTS_TABLE }} (
+    `event_id` UUID NOT NULL,
+    `emission_time` DateTime64(6) NOT NULL,
+    `actor_id` String NOT NULL,
+    `object_id` String NOT NULL,
+    `course_key` String NOT NULL,
+    `org` String NOT NULL,
+    `verb_id` LowCardinality(String) NOT NULL,
+    `video_position` Float32 NOT NULL
+) ENGINE = MergeTree
+PRIMARY KEY (org, course_key, verb_id)
+ORDER BY (org, course_key, verb_id, actor_id);
+"""
+
+OLD_VIDEO_QUERY = """
+SELECT
+    event_id,
+    emission_time,
+    actor_id,
+    object_id,
+    course_id,
+    org,
+    verb_id,
+    cast(coalesce(
+        nullif(JSON_VALUE(event_str, '$.result.extensions."https://w3id.org/xapi/video/extensions/time"'), ''),
+        nullif(JSON_VALUE(event_str, '$.result.extensions."https://w3id.org/xapi/video/extensions/time-from"'), ''),
+        '0.0'
+    ) as Float32) as video_position
+FROM {{ ASPECTS_XAPI_DATABASE }}.{{ ASPECTS_XAPI_TABLE }}
+WHERE verb_id IN (
+    'http://adlnet.gov/expapi/verbs/completed',
+    'http://adlnet.gov/expapi/verbs/initialized',
+    'http://adlnet.gov/expapi/verbs/terminated',
+    'https://w3id.org/xapi/video/verbs/paused',
+    'https://w3id.org/xapi/video/verbs/played',
+    'https://w3id.org/xapi/video/verbs/seeked'
+);
+"""
+
+NEW_VIDEO_QUERY = """
+SELECT
+    event_id,
+    emission_time,
+    actor_id,
+    object_id,
+    splitByString('/', course_id)[-1] AS course_key,
+    org,
+    verb_id,
+    cast(coalesce(
+        nullif(JSON_VALUE(event_str, '$.result.extensions."https://w3id.org/xapi/video/extensions/time"'), ''),
+        nullif(JSON_VALUE(event_str, '$.result.extensions."https://w3id.org/xapi/video/extensions/time-from"'), ''),
+        '0.0'
+    ) as Float32) as video_position
+FROM {{ ASPECTS_XAPI_DATABASE }}.{{ ASPECTS_XAPI_TABLE }}
+WHERE verb_id IN (
+    'http://adlnet.gov/expapi/verbs/completed',
+    'http://adlnet.gov/expapi/verbs/initialized',
+    'http://adlnet.gov/expapi/verbs/terminated',
+    'https://w3id.org/xapi/video/verbs/paused',
+    'https://w3id.org/xapi/video/verbs/played',
+    'https://w3id.org/xapi/video/verbs/seeked'
+);
+"""
+
+OLD_PROBLEM_DDL = """
+CREATE TABLE IF NOT EXISTS {{ ASPECTS_XAPI_DATABASE }}.{{ ASPECTS_PROBLEM_EVENTS_TABLE }} (
+    `event_id` UUID NOT NULL,
+    `emission_time` DateTime64(6) NOT NULL,
+    `actor_id` String NOT NULL,
+    `object_id` String NOT NULL,
+    `course_id` String NOT NULL,
+    `org` String NOT NULL,
+    `verb_id` LowCardinality(String) NOT NULL,
+    `responses` String,
+    `scaled_score` String,
+    `success` Bool,
+    `interaction_type` LowCardinality(String),
+    `attempts` Int16
+) ENGINE = MergeTree
+PRIMARY KEY (org, course_id, verb_id)
+ORDER BY (org, course_id, verb_id, actor_id);
+"""
+
+NEW_PROBLEM_DDL = """
+CREATE TABLE IF NOT EXISTS {{ ASPECTS_XAPI_DATABASE }}.{{ ASPECTS_PROBLEM_EVENTS_TABLE }} (
+    `event_id` UUID NOT NULL,
+    `emission_time` DateTime64(6) NOT NULL,
+    `actor_id` String NOT NULL,
+    `object_id` String NOT NULL,
+    `course_key` String NOT NULL,
+    `org` String NOT NULL,
+    `verb_id` LowCardinality(String) NOT NULL,
+    `responses` String,
+    `scaled_score` String,
+    `success` Bool,
+    `interaction_type` LowCardinality(String),
+    `attempts` Int16
+) ENGINE = MergeTree
+PRIMARY KEY (org, course_key, verb_id)
+ORDER BY (org, course_key, verb_id, actor_id);
+"""
+
+OLD_PROBLEM_QUERY = """
+SELECT
+    event_id,
+    emission_time,
+    actor_id,
+    object_id,
+    course_id,
+    org,
+    verb_id,
+    JSON_VALUE(event_str, '$.result.response') as responses,
+    JSON_VALUE(event_str, '$.result.score.scaled') as scaled_score,
+    if(
+        verb_id = 'https://w3id.org/xapi/acrossx/verbs/evaluated',
+        cast(JSON_VALUE(event_str, '$.result.success') as Bool),
+        false
+    ) as success,
+    JSON_VALUE(event_str, '$.object.definition.interactionType') as interaction_type,
+    if(
+        verb_id = 'https://w3id.org/xapi/acrossx/verbs/evaluated',
+        cast(JSON_VALUE(event_str, '$.object.definition.extensions."http://id.tincanapi.com/extension/attempt-id"') as Int16),
+        0
+    ) as attempts
+FROM
+    {{ ASPECTS_XAPI_DATABASE }}.{{ ASPECTS_XAPI_TABLE }}
+WHERE
+    verb_id in (
+        'https://w3id.org/xapi/acrossx/verbs/evaluated',
+        'http://adlnet.gov/expapi/verbs/passed',
+        'http://adlnet.gov/expapi/verbs/asked'
+    );
+"""
+
+NEW_PROBLEM_QUERY = """
+SELECT
+    event_id,
+    emission_time,
+    actor_id,
+    object_id,
+    splitByString('/', course_id)[-1] AS course_key,
+    org,
+    verb_id,
+    JSON_VALUE(event_str, '$.result.response') as responses,
+    JSON_VALUE(event_str, '$.result.score.scaled') as scaled_score,
+    if(
+        verb_id = 'https://w3id.org/xapi/acrossx/verbs/evaluated',
+        cast(JSON_VALUE(event_str, '$.result.success') as Bool),
+        false
+    ) as success,
+    JSON_VALUE(event_str, '$.object.definition.interactionType') as interaction_type,
+    if(
+        verb_id = 'https://w3id.org/xapi/acrossx/verbs/evaluated',
+        cast(JSON_VALUE(event_str, '$.object.definition.extensions."http://id.tincanapi.com/extension/attempt-id"') as Int16),
+        0
+    ) as attempts
+FROM
+    {{ ASPECTS_XAPI_DATABASE }}.{{ ASPECTS_XAPI_TABLE }}
+WHERE
+    verb_id in (
+        'https://w3id.org/xapi/acrossx/verbs/evaluated',
+        'http://adlnet.gov/expapi/verbs/passed',
+        'http://adlnet.gov/expapi/verbs/asked'
+    );
+"""
+
+OLD_NAVIGATION_DDL = """
+CREATE TABLE IF NOT EXISTS {{ ASPECTS_XAPI_DATABASE }}.{{ ASPECTS_NAVIGATION_EVENTS_TABLE }} (
+    `event_id` UUID NOT NULL,
+    `emission_time` DateTime64(6) NOT NULL,
+    `actor_id` String NOT NULL,
+    `object_id` String NOT NULL,
+    `course_id` String NOT NULL,
+    `org` String NOT NULL,
+    `verb_id` LowCardinality(String) NOT NULL,
+    `object_type` LowCardinality(String) NOT NULL,
+    `starting_position` Int16,
+    `ending_point` String
+) ENGINE = MergeTree
+PRIMARY KEY (org, course_id, object_type)
+ORDER BY (org, course_id, object_type, actor_id);
+"""
+
+NEW_NAVIGATION_DDL = """
+CREATE TABLE IF NOT EXISTS {{ ASPECTS_XAPI_DATABASE }}.{{ ASPECTS_NAVIGATION_EVENTS_TABLE }} (
+    `event_id` UUID NOT NULL,
+    `emission_time` DateTime64(6) NOT NULL,
+    `actor_id` String NOT NULL,
+    `object_id` String NOT NULL,
+    `course_key` String NOT NULL,
+    `org` String NOT NULL,
+    `verb_id` LowCardinality(String) NOT NULL,
+    `object_type` LowCardinality(String) NOT NULL,
+    `starting_position` Int16,
+    `ending_point` String
+) ENGINE = MergeTree
+PRIMARY KEY (org, course_key, object_type)
+ORDER BY (org, course_key, object_type, actor_id);
+"""
+
+OLD_NAVIGATION_QUERY = """
+SELECT
+    event_id,
+    emission_time,
+    actor_id,
+    object_id,
+    course_id,
+    org,
+    verb_id,
+    JSON_VALUE(event_str, '$.object.definition.type') AS object_type,
+    -- clicking a link and selecting a module outline have no starting-position field
+    if (
+        object_type in (
+            'http://adlnet.gov/expapi/activities/link',
+            'http://adlnet.gov/expapi/activities/module'
+        ),
+        0,
+        cast(JSON_VALUE(
+            event_str,
+            '$.context.extensions."http://id.tincanapi.com/extension/starting-position"'
+        ) as Int16)
+    ) AS starting_position,
+    JSON_VALUE(
+        event_str,
+        '$.context.extensions."http://id.tincanapi.com/extension/ending-point"'
+    ) AS ending_point
+FROM
+    {{ ASPECTS_XAPI_DATABASE }}.{{ ASPECTS_XAPI_TABLE }}
+WHERE verb_id IN (
+    'https://w3id.org/xapi/dod-isd/verbs/navigated'
+);
+"""
+
+NEW_NAVIGATION_QUERY = """
+SELECT
+    event_id,
+    emission_time,
+    actor_id,
+    object_id,
+    splitByString('/', course_id)[-1] AS course_key,
+    org,
+    verb_id,
+    JSON_VALUE(event_str, '$.object.definition.type') AS object_type,
+    -- clicking a link and selecting a module outline have no starting-position field
+    if (
+        object_type in (
+            'http://adlnet.gov/expapi/activities/link',
+            'http://adlnet.gov/expapi/activities/module'
+        ),
+        0,
+        cast(JSON_VALUE(
+            event_str,
+            '$.context.extensions."http://id.tincanapi.com/extension/starting-position"'
+        ) as Int16)
+    ) AS starting_position,
+    JSON_VALUE(
+        event_str,
+        '$.context.extensions."http://id.tincanapi.com/extension/ending-point"'
+    ) AS ending_point
+FROM
+    {{ ASPECTS_XAPI_DATABASE }}.{{ ASPECTS_XAPI_TABLE }}
+WHERE verb_id IN (
+    'https://w3id.org/xapi/dod-isd/verbs/navigated'
+);
+"""
+
+MIGRATIONS = [
+    MvMigration(
+        "{{ ASPECTS_XAPI_DATABASE }}.{{ ASPECTS_ENROLLMENT_EVENTS_TABLE }}",
+        OLD_ENROLLMENT_DDL,
+        NEW_ENROLLMENT_DDL,
+        "{{ ASPECTS_XAPI_DATABASE }}.{{ ASPECTS_ENROLLMENT_TRANSFORM_MV }}",
+        OLD_ENROLLMENT_QUERY,
+        NEW_ENROLLMENT_QUERY,
+    ),
+    MvMigration(
+        "{{ ASPECTS_XAPI_DATABASE }}.{{ ASPECTS_VIDEO_PLAYBACK_EVENTS_TABLE }}",
+        OLD_VIDEO_DDL,
+        NEW_VIDEO_DDL,
+        "{{ ASPECTS_XAPI_DATABASE }}.{{ ASPECTS_VIDEO_PLAYBACK_TRANSFORM_MV }}",
+        OLD_VIDEO_QUERY,
+        NEW_VIDEO_QUERY,
+    ),
+    MvMigration(
+        "{{ ASPECTS_XAPI_DATABASE }}.{{ ASPECTS_PROBLEM_EVENTS_TABLE }}",
+        OLD_PROBLEM_DDL,
+        NEW_PROBLEM_DDL,
+        "{{ ASPECTS_XAPI_DATABASE }}.{{ ASPECTS_PROBLEM_TRANSFORM_MV }}",
+        OLD_PROBLEM_QUERY,
+        NEW_PROBLEM_QUERY,
+    ),
+    MvMigration(
+        "{{ ASPECTS_XAPI_DATABASE }}.{{ ASPECTS_NAVIGATION_EVENTS_TABLE }}",
+        OLD_NAVIGATION_DDL,
+        NEW_NAVIGATION_DDL,
+        "{{ ASPECTS_XAPI_DATABASE }}.{{ ASPECTS_NAVIGATION_TRANSFORM_MV }}",
+        OLD_NAVIGATION_QUERY,
+        NEW_NAVIGATION_QUERY,
+    ),
+]
+
+
+def migrate(table_name, mv_name, table_ddl, mv_query):
+    # for each table and materialized view to migrate:
+    # - drop the existing table and materialized view if they exist
+    # - create the new table
+    # - load data into the new table using the new MV query
+    # - create the materialized view using the new query
+    op.execute(f"DROP TABLE IF EXISTS {table_name}")
+    op.execute(f"DROP TABLE IF EXISTS {mv_name}")
+    op.execute(table_ddl)
+    op.execute(f"INSERT INTO {table_name} {mv_query}")
+    mv_ddl = (
+        f"CREATE MATERIALIZED VIEW IF NOT EXISTS {mv_name} "
+        f"TO {table_name} AS {mv_query}"
+    )
+    op.execute(mv_ddl)
 
 
 def upgrade():
-    # drop the tables and MVs and create new ones, with course_id
-    # replaced by course_key
-    for name, ddl in TABLES.items():
-        op.execute(f"DROP TABLE IF EXISTS {name}")
-        op.execute(ddl.replace("course_id", "course_key"))
-
-    for name, query in MATERIALIZED_VIEWS.items():
-        op.execute(f"DROP TABLE {name}")
-        op.execute(
-            query.replace(
-                "course_id", "splitByString('/', course_id)[-1] AS course_key"
-            )
+    for migration in MIGRATIONS:
+        migrate(
+            migration.table_name,
+            migration.mv_name,
+            migration.new_ddl,
+            migration.new_mv_query,
         )
 
 
 def downgrade():
-    for name, ddl in TABLES.items():
-        op.execute(f"DROP TABLE IF EXISTS {name}")
-        op.execute(ddl)
-
-    for name, query in MATERIALIZED_VIEWS.items():
-        op.execute(f"DROP TABLE IF EXISTS {name}")
-        op.execute(query)
+    for migration in MIGRATIONS:
+        migrate(
+            migration.table_name,
+            migration.mv_name,
+            migration.old_ddl,
+            migration.old_mv_query,
+        )

--- a/tutoraspects/templates/openedx-assets/queries/fact_enrollments.sql
+++ b/tutoraspects/templates/openedx-assets/queries/fact_enrollments.sql
@@ -4,7 +4,7 @@ with courses as (
     select
         emission_time,
         org,
-        course_id as course_key,
+        course_key,
         actor_id,
         enrollment_mode,
         splitByString('/', verb_id)[-1] as enrollment_status

--- a/tutoraspects/templates/openedx-assets/queries/fact_enrollments.sql
+++ b/tutoraspects/templates/openedx-assets/queries/fact_enrollments.sql
@@ -4,7 +4,7 @@ with courses as (
     select
         emission_time,
         org,
-        splitByString('/', course_id)[-1] as course_key,
+        course_id as course_key,
         actor_id,
         enrollment_mode,
         splitByString('/', verb_id)[-1] as enrollment_status

--- a/tutoraspects/templates/openedx-assets/queries/fact_learner_problem_summary.sql
+++ b/tutoraspects/templates/openedx-assets/queries/fact_learner_problem_summary.sql
@@ -3,7 +3,7 @@ with course_problems as (
 ), summary as (
     select
         org,
-        course_id as course_key,
+        course_key,
         problem_id,
         actor_id,
         success,

--- a/tutoraspects/templates/openedx-assets/queries/fact_learner_problem_summary.sql
+++ b/tutoraspects/templates/openedx-assets/queries/fact_learner_problem_summary.sql
@@ -3,7 +3,7 @@ with course_problems as (
 ), summary as (
     select
         org,
-        splitByString('/', course_id)[-1] as course_key,
+        course_id as course_key,
         problem_id,
         actor_id,
         success,

--- a/tutoraspects/templates/openedx-assets/queries/fact_problem_responses.sql
+++ b/tutoraspects/templates/openedx-assets/queries/fact_problem_responses.sql
@@ -4,7 +4,7 @@ with course_problems as (
     select
         emission_time,
         org,
-        splitByString('/', course_id)[-1] as course_key,
+        course_id as course_key,
         problem_id,
         actor_id,
         responses,

--- a/tutoraspects/templates/openedx-assets/queries/fact_problem_responses.sql
+++ b/tutoraspects/templates/openedx-assets/queries/fact_problem_responses.sql
@@ -4,7 +4,7 @@ with course_problems as (
     select
         emission_time,
         org,
-        course_id as course_key,
+        course_key,
         problem_id,
         actor_id,
         responses,

--- a/tutoraspects/templates/openedx-assets/queries/fact_transcript_usage.sql
+++ b/tutoraspects/templates/openedx-assets/queries/fact_transcript_usage.sql
@@ -4,7 +4,7 @@ with videos as (
     select
         emission_time,
         org,
-        course_id as course_key,
+        course_key,
         video_id,
         actor_id
     from

--- a/tutoraspects/templates/openedx-assets/queries/fact_transcript_usage.sql
+++ b/tutoraspects/templates/openedx-assets/queries/fact_transcript_usage.sql
@@ -4,7 +4,7 @@ with videos as (
     select
         emission_time,
         org,
-        splitByString('/', course_id)[-1] as course_key,
+        course_id as course_key,
         video_id,
         actor_id
     from

--- a/tutoraspects/templates/openedx-assets/queries/fact_video_plays.sql
+++ b/tutoraspects/templates/openedx-assets/queries/fact_video_plays.sql
@@ -4,7 +4,7 @@ with videos as (
     select
         emission_time,
         org,
-        splitByString('/course/', course_id)[-1] as course_key,
+        course_id as course_key,
         actor_id,
         video_id
     from

--- a/tutoraspects/templates/openedx-assets/queries/fact_video_plays.sql
+++ b/tutoraspects/templates/openedx-assets/queries/fact_video_plays.sql
@@ -4,7 +4,7 @@ with videos as (
     select
         emission_time,
         org,
-        course_id as course_key,
+        course_key,
         actor_id,
         video_id
     from

--- a/tutoraspects/templates/openedx-assets/queries/fact_watched_video_segments.sql
+++ b/tutoraspects/templates/openedx-assets/queries/fact_watched_video_segments.sql
@@ -4,7 +4,7 @@ with courses as (
     select
         emission_time,
         org,
-        course_id,
+        course_key,
         splitByString('/xblock/', object_id)[-1] as video_id,
         actor_id,
         verb_id,
@@ -21,7 +21,7 @@ with courses as (
     select
         emission_time,
         org,
-        course_id,
+        course_key,
         splitByString('/xblock/', object_id)[-1] as video_id,
         actor_id,
         verb_id,
@@ -42,7 +42,7 @@ with courses as (
 ), segments as(
     select
         starts.org as org,
-        starts.course_id as course_key,
+        starts.course_key as course_key,
         starts.video_id as video_id,
         starts.actor_id,
         cast(starts.video_position as Int32) as start_position,
@@ -54,7 +54,7 @@ with courses as (
         starts
         left asof join ends
             on (starts.org = ends.org
-                and starts.course_id = ends.course_id
+                and starts.course_key = ends.course_key
                 and starts.video_id = ends.video_id
                 and starts.actor_id = ends.actor_id
                 and starts.emission_time < ends.emission_time)

--- a/tutoraspects/templates/openedx-assets/queries/fact_watched_video_segments.sql
+++ b/tutoraspects/templates/openedx-assets/queries/fact_watched_video_segments.sql
@@ -42,7 +42,7 @@ with courses as (
 ), segments as(
     select
         starts.org as org,
-        splitByString('/', starts.course_id)[-1] as course_key,
+        starts.course_id as course_key,
         starts.video_id as video_id,
         starts.actor_id,
         cast(starts.video_position as Int32) as start_position,


### PR DESCRIPTION
Adds an alembic migration to update the materialized view queries. The course key is parsed from the `course_id` field in order to match the data in the `event_sink` tables.

This also updates all the Superset assets to use the new field. I don't think there are any required changes to the dbt models