### PR TITLE
Fg/fix o auth token refresh

### DIFF
--- a/tutoraspects/templates/aspects/apps/superset/pythonpath/openedx_sso_security_manager.py
+++ b/tutoraspects/templates/aspects/apps/superset/pythonpath/openedx_sso_security_manager.py
@@ -80,20 +80,16 @@ class OpenEdxSsoSecurityManager(SupersetSecurityManager):
         """
         Retrieves the oauth token from the session.
         If the access token is expired, it will try to refresh it using the refresh token.
-        Returns an empty dict if there is no session or the token couldn't be refreshed.
         """
         token = session.get("oauth_token", {})
 
         if token:
-            # Check if the token is expired
             if self.is_token_expired(token):
-                # Try to refresh the token
                 try:
                     new_token = self.refresh_token(token)
                 except OAuthError as e:
                     raise OAuthError(f"Failed to refresh the token: {e}")
 
-                # Update the session with the new token
                 session["oauth_token"] = new_token
 
         refreshed_token = session.get("oauth_token", {})
@@ -113,7 +109,6 @@ class OpenEdxSsoSecurityManager(SupersetSecurityManager):
         provider = session.get("oauth_provider")
         oauth_remote = self.oauth_remotes.get(provider)
         
-        # Checks if the OAuth remote object exists.
         if not oauth_remote:
             raise Exception("No OAuth remote object found")
 

--- a/tutoraspects/templates/aspects/apps/superset/pythonpath/openedx_sso_security_manager.py
+++ b/tutoraspects/templates/aspects/apps/superset/pythonpath/openedx_sso_security_manager.py
@@ -112,23 +112,26 @@ class OpenEdxSsoSecurityManager(SupersetSecurityManager):
         """
         provider = session.get("oauth_provider")
         oauth_remote = self.oauth_remotes.get(provider)
+        
         # Checks if the OAuth remote object exists.
-        if oauth_remote:
-            refresh_token = token.get('refresh_token')
-            lms_root_url = current_app.config["OPENEDX_LMS_ROOT_URL"]
-            refresh_url = f'{lms_root_url}/oauth2/access_token/'
+        if not oauth_remote:
+            raise Exception("No OAuth remote object found")
 
-            data = {
-                'client_id': oauth_remote.client_id,
-                'client_secret': oauth_remote.client_secret,
-                'grant_type': 'refresh_token',
-                'refresh_token': refresh_token,
-                'token_type': 'JWT'
-            }
-            response = requests.post(refresh_url, data=data)
-            if response.status_code == 200:
-                new_token = response.json()
-                return new_token
+        refresh_token = token.get('refresh_token')
+        lms_root_url = current_app.config["OPENEDX_LMS_ROOT_URL"]
+        refresh_url = f'{lms_root_url}/oauth2/access_token/'
+
+        data = {
+            'client_id': oauth_remote.client_id,
+            'client_secret': oauth_remote.client_secret,
+            'grant_type': 'refresh_token',
+            'refresh_token': refresh_token,
+            'token_type': 'JWT'
+        }
+        response = requests.post(refresh_url, data=data)
+        if response.status_code == 200:
+            new_token = response.json()
+            return new_token
         return token
 
     @property

--- a/tutoraspects/templates/aspects/apps/superset/pythonpath/openedx_sso_security_manager.py
+++ b/tutoraspects/templates/aspects/apps/superset/pythonpath/openedx_sso_security_manager.py
@@ -83,14 +83,18 @@ class OpenEdxSsoSecurityManager(SupersetSecurityManager):
         """
         token = session.get("oauth_token", {})
 
-        if token:
-            if self.is_token_expired(token):
-                try:
-                    new_token = self.refresh_token(token)
-                except OAuthError as e:
-                    raise OAuthError(f"Failed to refresh the token: {e}")
+        if not token:
+            raise Exception("No OAuth token found.")
 
-                session["oauth_token"] = new_token
+        if not self.is_token_expired(token):
+            return token
+            
+        try:
+            new_token = self.refresh_token(token)
+        except OAuthError as e:
+            raise OAuthError(f"Failed to refresh the token: {e}")
+
+        session["oauth_token"] = new_token
 
         refreshed_token = session.get("oauth_token", {})
         return refreshed_token

--- a/tutoraspects/templates/aspects/apps/superset/pythonpath/openedx_sso_security_manager.py
+++ b/tutoraspects/templates/aspects/apps/superset/pythonpath/openedx_sso_security_manager.py
@@ -83,13 +83,10 @@ class OpenEdxSsoSecurityManager(SupersetSecurityManager):
         Returns an empty dict if there is no session or the token couldn't be refreshed.
         """
         token = session.get("oauth_token", {})
-        print('\n\n')
-        print(f'Original token: {token}')  # Debug line
 
         if token:
             # Check if the token is expired
             if self.is_token_expired(token):
-                print('Token is expired, refreshing...')  # Debug line
                 # Try to refresh the token
                 try:
                     new_token = self.refresh_token(token)
@@ -101,7 +98,6 @@ class OpenEdxSsoSecurityManager(SupersetSecurityManager):
                 session["oauth_token"] = new_token
 
         refreshed_token = session.get("oauth_token", {})
-        print(f'Refreshed token: {refreshed_token}')  # Debug line
         return refreshed_token
 
     def is_token_expired(self, token):
@@ -110,8 +106,6 @@ class OpenEdxSsoSecurityManager(SupersetSecurityManager):
         """
         # The token is expired if the current time is greater than the expiry time
         is_expired = time.time() > token.get('expires_at', 0)
-        is_expired = True # Debug Line
-        print(f'Is token expired? {is_expired}')  # Debug line
         return is_expired
 
     def refresh_token(self, token):
@@ -134,12 +128,9 @@ class OpenEdxSsoSecurityManager(SupersetSecurityManager):
                 'token_type': 'JWT'
             }
             response = requests.post(refresh_url, data=data)
-            print(response.content)  # Debug line
             if response.status_code == 200:
                 new_token = response.json()
-                print('New token obtained:', new_token)  # Debug line
                 return new_token
-            print('status_code: ', response.status_code)  # Debug line
         return token
 
     @property

--- a/tutoraspects/templates/aspects/apps/superset/pythonpath/openedx_sso_security_manager.py
+++ b/tutoraspects/templates/aspects/apps/superset/pythonpath/openedx_sso_security_manager.py
@@ -91,8 +91,7 @@ class OpenEdxSsoSecurityManager(SupersetSecurityManager):
                 try:
                     new_token = self.refresh_token(token)
                 except OAuthError as e:
-                    logging.error("Failed to refresh the token: {}".format(e))
-                    new_token = {}
+                    raise OAuthError(f"Failed to refresh the token: {e}")
 
                 # Update the session with the new token
                 session["oauth_token"] = new_token
@@ -104,7 +103,6 @@ class OpenEdxSsoSecurityManager(SupersetSecurityManager):
         """
         Checks if the given token is expired.
         """
-        # The token is expired if the current time is greater than the expiry time
         is_expired = time.time() > token.get('expires_at', 0)
         return is_expired
 
@@ -119,7 +117,7 @@ class OpenEdxSsoSecurityManager(SupersetSecurityManager):
             refresh_token = token.get('refresh_token')
             lms_root_url = current_app.config["OPENEDX_LMS_ROOT_URL"]
             refresh_url = f'{lms_root_url}/oauth2/access_token/'
-            # Sets up the data to be sent with the POST request.
+
             data = {
                 'client_id': oauth_remote.client_id,
                 'client_secret': oauth_remote.client_secret,


### PR DESCRIPTION
## fix: OAuth token refresh error #152

This pull request implements the functionality of refreshing OAuth tokens when they have expired, enhancing the OAuth2 authentication process.

#### Changes include:

_refresh_token_ function: This function is designed to refresh the OAuth tokens when they have expired. It sends a POST request to the LMS's oauth2/access_token/ endpoint with the necessary data to refresh the token. If the request is successful (HTTP 200), it returns a new token; otherwise, it returns the original token.

_is_token_expired_ function: This is a helper function that checks whether the OAuth token is expired. It compares the token's expiration time with the current time to determine the token's status.

_get_oauth_token_ function: Updated this function to make use of is_token_expired and refresh_token. When an OAuth token is retrieved, it checks whether the token is expired. If it is, the token is refreshed.

#### To verify the functionality of this PR:

1. Allow a token to expire.
2. Initiate a request that requires OAuth authentication.
3. Verify that the is_token_expired function correctly identifies the expired token.
4. Verify that the refresh_token function is triggered and that it returns a new token when the original token is expired.
5. Confirm that get_oauth_token successfully retrieves a refreshed token when the original is expired.

Please review and provide feedback.

Feel free to further modify as needed.

fixes #152 