### PR TITLE
Fixes for Vector bulk loading

### DIFF
--- a/tutoraspects/commands_v1.py
+++ b/tutoraspects/commands_v1.py
@@ -101,9 +101,22 @@ def dump_courses_to_clickhouse(options) -> list[tuple[str, str]]:
     return [("cms", f"./manage.py cms dump_courses_to_clickhouse {options}")]
 
 
+# pylint: disable=line-too-long
+# Ex: tutor local do transform-tracking-logs --options "--source_provider LOCAL --source_config '{\"key\": \"/openedx/data/\", \"prefix\": \"tracking.log\", \"container\": \"logs\"}' --destination_provider LRS --transformer_type xapi"
+# Ex: tutor local do transform-tracking-logs --options "--source_provider MINIO --source_config '{\"key\": \"openedx\", \"secret\": \"h3SIhXAqDDxJAP6TcXklNxro\", \"container\": \"openedx\", \"prefix\": \"/tracking_logs\", \"host\": \"files.local.overhang.io\", \"secure\": false}' --destination_provider LRS --transformer_type xapi"
+@click.command(context_settings={"ignore_unknown_options": True})
+@click.option("--options", default="", type=click.UNPROCESSED)
+def transform_tracking_logs(options) -> list[tuple[str, str]]:
+    """
+    Job that proxies the dump_courses_to_clickhouse commands.
+    """
+    return [("lms", f"./manage.py lms transform_tracking_logs {options}")]
+
+
 COMMANDS = (
     load_xapi_test_data,
     dbt,
     alembic,
     dump_courses_to_clickhouse,
+    transform_tracking_logs,
 )

--- a/tutoraspects/patches/local-docker-compose-jobs-services
+++ b/tutoraspects/patches/local-docker-compose-jobs-services
@@ -7,10 +7,11 @@ aspects-job:
   volumes:
     - ../../env/plugins/aspects/apps/aspects:/app/aspects
     - ../../env/plugins/aspects/apps/aspects/scripts/:/app/aspects/scripts:ro
-  depends_on:
-    - superset {% if RUN_CLICKHOUSE%}
+  {% if RUN_SUPERSET or RUN_CLICKHOUSE or RUN_RALPH %}depends_on:{% if RUN_SUPERSET %}
+    - superset{% endif %}{% if RUN_CLICKHOUSE%}
     - clickhouse{% endif %}{% if RUN_RALPH %}
     - ralph{% endif %}
+  {% endif %}
 clickhouse-job:
     image: {{DOCKER_IMAGE_CLICKHOUSE}}
     {% if RUN_CLICKHOUSE%}depends_on:

--- a/tutoraspects/templates/aspects/apps/aspects/migrations/README.rst
+++ b/tutoraspects/templates/aspects/apps/aspects/migrations/README.rst
@@ -10,7 +10,7 @@ Aspects interface for Alembic
 -----------------------------
 
 The Aspects project provides a custom interface for Alembic. This interface is
-available in the command line with the subcommand ``tutor local|dev alembic do -c "custom command"``.
+available in the command line with the subcommand ``tutor local|dev do alembic -c "custom command"``.
 
 For example, to run the command ``alembic upgrade head`` in the dev environment, you would run::
 
@@ -26,9 +26,10 @@ Create a new migration::
     tutor dev do alembic -c "revision -m 'migration message'"
 
 Run migrations::
-    
+
     tutor dev do alembic -c "upgrade head"
 
 Rollback migrations::
 
     tutor dev do alembic -c "downgrade -1"
+

--- a/tutoraspects/templates/aspects/apps/aspects/migrations/alembic/versions/0011_vector_replacingmergetree_xapi_raw.py
+++ b/tutoraspects/templates/aspects/apps/aspects/migrations/alembic/versions/0011_vector_replacingmergetree_xapi_raw.py
@@ -1,0 +1,114 @@
+from alembic import op
+
+
+revision = "0011"
+down_revision = "0010"
+branch_labels = None
+depends_on = None
+
+DESTINATION_TABLE = "{{ ASPECTS_VECTOR_DATABASE }}.{{ ASPECTS_VECTOR_RAW_XAPI_TABLE }}"
+TMP_TABLE_NEW = f"{DESTINATION_TABLE}_tmp_{revision}"
+TMP_TABLE_ORIG = f"{DESTINATION_TABLE}_tmp_mergetree_{revision}"
+
+
+def upgrade():
+    # 1. Create our new table with the desired engine
+    op.execute(
+        f"""
+        CREATE OR REPLACE TABLE {TMP_TABLE_NEW}
+        (
+            event_id      UUID,
+            emission_time DateTime64(6),
+            event_str     String
+        )
+        engine = ReplacingMergeTree
+        PRIMARY KEY (emission_time)
+        ORDER BY (emission_time, event_id);
+        """
+    )
+    # 2. Attach our table to the existing partitions of the old MergeTree table.
+    #    This works because our "order by" is the same. It should be instant no matter
+    #    the size of the table since it's not copying anything.
+    op.execute(
+        f"""
+        ALTER TABLE {TMP_TABLE_NEW}
+        ATTACH PARTITION tuple() FROM 
+        {DESTINATION_TABLE};
+        """
+    )
+    # 3. Swap both tables in a single rename statement.
+    op.execute(
+        f"""
+        RENAME TABLE {DESTINATION_TABLE}
+         TO {TMP_TABLE_ORIG}, 
+         {TMP_TABLE_NEW}
+         TO {DESTINATION_TABLE};
+        """
+    )
+    # 4. Force deduplication of the existing data and may take a very long time
+    #    on a larger dataset, but since Aspects isn't in production anywhere yet this
+    #    seems like a reasonable thing to do. If you're looking at this as fodder for
+    #    a future migration, make sure to understand the potential issues here.
+    op.execute(
+        f"""
+        OPTIMIZE TABLE {DESTINATION_TABLE} FINAL;
+        """
+    )
+    # 5. Drop the renamed version of the original table.
+    op.execute(
+        f"""
+        DROP TABLE {TMP_TABLE_ORIG};
+        """
+    )
+
+
+def downgrade():
+    # 1. Create a new table with the old engine
+    op.execute(
+        f"""
+        CREATE TABLE IF NOT EXISTS {TMP_TABLE_ORIG}
+        (
+            event_id      UUID,
+            emission_time DateTime64(6),
+            event_str     String
+        )
+        engine = MergeTree
+        PRIMARY KEY (emission_time)
+        ORDER BY (emission_time, event_id);
+        """
+    )
+    # 2. Attach our table to the existing partitions of the ReplacingMergeTree table.
+    #    This works because our "order by" is the same. It should be instant no matter
+    #    the size of the table since it's not copying anything.
+    op.execute(
+        f"""
+        ALTER TABLE {TMP_TABLE_ORIG}
+        ATTACH PARTITION tuple() FROM 
+        {DESTINATION_TABLE};
+        """
+    )
+    # 3. Swap both tables in a single rename statement.
+    op.execute(
+        f"""
+        RENAME TABLE {DESTINATION_TABLE}
+         TO {TMP_TABLE_NEW}, 
+         {TMP_TABLE_ORIG}
+         TO {DESTINATION_TABLE};
+        """
+    )
+    # 4. Force deduplication of the existing data and may take a very long time
+    #    on a larger dataset, but since Aspects isn't in production anywhere yet this
+    #    seems like a reasonable thing to do. If you're looking at this as fodder for
+    #    a future migration, make sure to understand the potential issues here.
+    op.execute(
+        f"""
+        OPTIMIZE TABLE {DESTINATION_TABLE} 
+        FINAL DEDUPLICATE;
+        """
+    )
+    # 5. Drop the renamed version of the original table.
+    op.execute(
+        f"""
+        DROP TABLE {TMP_TABLE_NEW};
+        """
+    )

--- a/tutoraspects/templates/aspects/apps/aspects/migrations/alembic/versions/0012_vector_replacingmergetree_xapi_parsed.py
+++ b/tutoraspects/templates/aspects/apps/aspects/migrations/alembic/versions/0012_vector_replacingmergetree_xapi_parsed.py
@@ -1,0 +1,197 @@
+from alembic import op
+
+revision = "0012"
+down_revision = "0011"
+branch_labels = None
+depends_on = None
+
+DESTINATION_TABLE = "{{ ASPECTS_XAPI_DATABASE }}.{{ ASPECTS_XAPI_TABLE }}"
+TMP_TABLE_NEW = f"{DESTINATION_TABLE}_tmp_{revision}"
+TMP_TABLE_ORIG = f"{DESTINATION_TABLE}_tmp_mergetree_{revision}"
+
+
+def upgrade():
+    # 1. Create our new temp table with the desired changes
+    op.execute(
+        f"""
+        CREATE OR REPLACE TABLE {TMP_TABLE_NEW}
+        (
+            event_id      UUID,
+            verb_id       String,
+            actor_id      String,
+            object_id     String,
+            org           String,
+            course_id     String,
+            emission_time DateTime,
+            event_str     String
+        )
+        ENGINE = ReplacingMergeTree 
+        PRIMARY KEY (org, course_id, emission_time, verb_id, actor_id, event_id)
+        ORDER BY (org, course_id, emission_time, verb_id, actor_id, event_id);
+        """
+    )
+    # 2. Swap both tables in a single rename statement. New data will flow into
+    #    the new table now and cascade through the MVs and downstream tables per normal.
+    op.execute(
+        f"""
+        RENAME TABLE {DESTINATION_TABLE} 
+         TO {TMP_TABLE_ORIG}, 
+         {TMP_TABLE_NEW}
+         TO {DESTINATION_TABLE};
+        """
+    )
+    # 3. Copy in all existing rows from the parent raw table. This will cascade through
+    #    the system and duplicate rows downstream, but the alternative is to potentially
+    #    lose rows in this table while performing a copy. Downstream tables at this
+    #    point are all ReplacingMergeTree, we will force them all do dedupe at the end.
+    #
+    #    This is the SQL from the current version of the materialized view that
+    #    populates this table.
+    op.execute(
+        f"""
+        INSERT INTO {DESTINATION_TABLE}
+        SELECT
+        event_id as event_id,
+        JSON_VALUE(event_str, '$.verb.id') as verb_id,
+        COALESCE(
+            NULLIF(JSON_VALUE(event_str, '$.actor.account.name'), ''),
+            NULLIF(JSON_VALUE(event_str, '$.actor.mbox'), ''),
+            JSON_VALUE(event_str, '$.actor.mbox_sha1sum')
+        ) as actor_id,
+        JSON_VALUE(event_str, '$.object.id') as object_id,
+        if(
+            JSON_VALUE(
+                event_str,
+                '$.context.contextActivities.parent[0].definition.type')
+                    = 'http://adlnet.gov/expapi/activities/course',
+                JSON_VALUE(event_str, '$.context.contextActivities.parent[0].id'),
+                JSON_VALUE(event_str, '$.object.id')
+            ) as course_id,
+        get_org_from_course_url(course_id) as org,
+        emission_time as emission_time,
+        event_str as event_str
+        FROM {{ ASPECTS_XAPI_DATABASE }}.{{ ASPECTS_RAW_XAPI_TABLE }};
+        """
+    )
+    # 5. Force deduplication of the existing data. This may take a very long time
+    #    on a larger dataset, but since Aspects isn't in production anywhere yet this
+    #    seems like a reasonable thing to do. If you're looking at this as fodder for
+    #    a future migration, make sure to understand the potential issues here.
+    optimize()
+
+    # 6. Drop the renamed version of the original table.
+    op.execute(
+        f"""
+        DROP TABLE {TMP_TABLE_ORIG};
+        """
+    )
+
+
+def downgrade():
+    # 1. Create a new table with the old engine
+    op.execute(
+        f"""
+        CREATE OR REPLACE TABLE {TMP_TABLE_ORIG}
+        (
+            event_id      UUID,
+            verb_id       String,
+            actor_id      String,
+            object_id     String,
+            org           String,
+            course_id     String,
+            emission_time DateTime64(6),
+            event_str     String
+        )
+        ENGINE = MergeTree 
+        PRIMARY KEY (org, course_id, verb_id, actor_id, emission_time, event_id)
+        ORDER BY (org, course_id, verb_id, actor_id, emission_time, event_id);
+        """
+    )
+    # 2. Swap both tables in a single rename statement. New data will flow into
+    #    the new table now and cascade through the MVs and downstream tables per normal.
+    op.execute(
+        f"""
+        RENAME TABLE {DESTINATION_TABLE} 
+         TO {TMP_TABLE_NEW}, 
+         {TMP_TABLE_ORIG}
+         TO {DESTINATION_TABLE};
+        """
+    )
+    # 3. Copy in all existing rows from the parent raw table. This will cascade through
+    #    the system and duplicate rows downstream, but the alternative is to potentially
+    #    lose rows in this table while performing a copy. Downstream tables at this
+    #    point are all ReplacingMergeTree, we will force them all do dedupe at the end.
+    #
+    #    This is the SQL from the current version of the materialized view that
+    #    populates this table.
+    op.execute(
+        f"""
+        INSERT INTO {DESTINATION_TABLE}
+        SELECT
+        event_id as event_id,
+        JSON_VALUE(event_str, '$.verb.id') as verb_id,
+        COALESCE(
+            NULLIF(JSON_VALUE(event_str, '$.actor.account.name'), ''),
+            NULLIF(JSON_VALUE(event_str, '$.actor.mbox'), ''),
+            JSON_VALUE(event_str, '$.actor.mbox_sha1sum')
+        ) as actor_id,
+        JSON_VALUE(event_str, '$.object.id') as object_id,
+        if(
+            JSON_VALUE(
+                event_str,
+                '$.context.contextActivities.parent[0].definition.type')
+                    = 'http://adlnet.gov/expapi/activities/course',
+                JSON_VALUE(event_str, '$.context.contextActivities.parent[0].id'),
+                JSON_VALUE(event_str, '$.object.id')
+            ) as course_id,
+        get_org_from_course_url(course_id) as org,
+        emission_time as emission_time,
+        event_str as event_str
+        FROM {{ ASPECTS_XAPI_DATABASE }}.{{ ASPECTS_RAW_XAPI_TABLE }};
+        """
+    )
+    # 5. Force deduplication of the existing data. This may take a very long time
+    #    on a larger dataset, but since Aspects isn't in production anywhere yet this
+    #    seems like a reasonable thing to do. If you're looking at this as fodder for
+    #    a future migration, make sure to understand the potential issues here.
+    optimize()
+
+    # 6. Drop the renamed version of the original table.
+    op.execute(
+        f"""
+        DROP TABLE {TMP_TABLE_NEW};
+        """
+    )
+
+
+def optimize():
+    op.execute(
+        f"""
+        OPTIMIZE TABLE {DESTINATION_TABLE} FINAL;
+        """
+    )
+    op.execute(
+        f"""
+        OPTIMIZE TABLE {{ ASPECTS_XAPI_DATABASE }}.{{ ASPECTS_ENROLLMENT_EVENTS_TABLE }}
+        FINAL;
+        """
+    )
+    op.execute(
+        f"""
+        OPTIMIZE TABLE 
+        {{ ASPECTS_XAPI_DATABASE }}.{{ ASPECTS_VIDEO_PLAYBACK_EVENTS_TABLE }}
+        FINAL;
+        """
+    )
+    op.execute(
+        f"""
+        OPTIMIZE TABLE {{ ASPECTS_XAPI_DATABASE }}.{{ ASPECTS_PROBLEM_EVENTS_TABLE }}
+        FINAL;
+        """
+    )
+    op.execute(
+        f"""
+        OPTIMIZE TABLE {{ ASPECTS_XAPI_DATABASE }}.{{ ASPECTS_NAVIGATION_EVENTS_TABLE }}
+        FINAL;
+        """
+    )

--- a/tutoraspects/templates/aspects/apps/vector/file.toml
+++ b/tutoraspects/templates/aspects/apps/vector/file.toml
@@ -5,6 +5,7 @@
 [sources.tracking_log_file]
 type = "file"
 include = ["/var/log/openedx/tracking.log"]
+
 [transforms.openedx_containers]
 type = "filter"
 # no-op filter: created for future-proof compatibility

--- a/tutoraspects/templates/aspects/apps/vector/k8s.toml
+++ b/tutoraspects/templates/aspects/apps/vector/k8s.toml
@@ -9,6 +9,6 @@ extra_namespace_label_selector = "kubernetes.io/metadata.name={{ K8S_NAMESPACE }
 [transforms.openedx_containers]
 type = "filter"
 inputs = ["kubernetes_logs"]
-condition = '.kubernetes.pod_namespace == "{{ K8S_NAMESPACE }}" && includes(["lms", "cms"], .kubernetes.container_name)'
+condition = '.kubernetes.pod_namespace == "{{ K8S_NAMESPACE }}" && includes(["lms", "cms", "lms-job", "cms-job"], .kubernetes.container_name)'
 
 {% include "aspects/apps/vector/partials/common-post.toml" %}

--- a/tutoraspects/templates/aspects/apps/vector/local.toml
+++ b/tutoraspects/templates/aspects/apps/vector/local.toml
@@ -4,9 +4,10 @@
 # Capture logs from all docker containers
 [sources.docker_logs]
 type = "docker_logs"
+
 [transforms.openedx_containers]
 type = "filter"
 inputs = ["docker_logs"]
-condition = 'includes(["lms", "cms", "lms-worker"], .label."com.docker.compose.service")'
+condition = 'includes(["lms", "cms", "lms-job", "cms-job"], .label."com.docker.compose.service")'
 
 {% include "aspects/apps/vector/partials/common-post.toml" %}

--- a/tutoraspects/templates/aspects/apps/vector/partials/common-post.toml
+++ b/tutoraspects/templates/aspects/apps/vector/partials/common-post.toml
@@ -72,6 +72,13 @@ event_id = parsed_json.id
 drop_on_error = true
 drop_on_abort = true
 
+[transforms.xapi_debug]
+type = "remap"
+inputs = ["xapi"]
+# Time formats: https://docs.rs/chrono/0.4.19/chrono/format/strftime/index.html#specifiers
+source = '''
+.message = parse_json!(.event_str)
+'''
 
 ### Sinks
 
@@ -81,6 +88,12 @@ type = "console"
 inputs = ["tracking_debug"]
 encoding.codec = "json"
 encoding.only_fields = ["time", "message.context.course_id", "message.context.user_id", "message.name"]
+
+[sinks.out_xapi]
+type = "console"
+inputs = ["xapi_debug"]
+encoding.codec = "json"
+encoding.only_fields = ["event_id", "emission_time", "message.verb.id"]
 
 # # Send logs to clickhouse
 [sinks.clickhouse]

--- a/tutoraspects/templates/openedx-assets/queries/dim_course_problems.sql
+++ b/tutoraspects/templates/openedx-assets/queries/dim_course_problems.sql
@@ -12,10 +12,10 @@ with courses as (
         JSON_VALUE(xblock_data_json, '$.block_type') = 'problem'
     {% raw -%}
         {% if filter_values('org') != [] %}
-        and org in {{ filter_values('org') | where_in }}
+        and org in ({{ filter_values('org') | where_in }})
         {% endif %}
         {% if filter_values('problem_name') != [] %}
-        and problem_name in {{ filter_values('problem_name') | where_in }}
+        and problem_name in ({{ filter_values('problem_name') | where_in }})
         {% endif %}
     {%- endraw %}
 )

--- a/tutoraspects/templates/openedx-assets/queries/dim_course_videos.sql
+++ b/tutoraspects/templates/openedx-assets/queries/dim_course_videos.sql
@@ -12,10 +12,10 @@ with courses as (
     {% raw -%}
         JSON_VALUE(xblock_data_json, '$.block_type') = 'video'
         {% if filter_values('org') != [] %}
-        and org in {{ filter_values('org') | where_in }}
+        and org in ({{ filter_values('org') | where_in }})
         {% endif %}
         {% if filter_values('video_name') != [] %}
-        and video_name in {{ filter_values('video_name') | where_in }}
+        and video_name in ({{ filter_values('video_name') | where_in }})
         {% endif %}
     {%- endraw %}
 )

--- a/tutoraspects/templates/openedx-assets/queries/fact_enrollments.sql
+++ b/tutoraspects/templates/openedx-assets/queries/fact_enrollments.sql
@@ -13,7 +13,7 @@ with courses as (
     {% raw -%}
     {% if filter_values('org') != [] %}
     where
-        org in {{ filter_values('org') | where_in }}
+        org in ({{ filter_values('org') | where_in }})
     {% endif %}
     {%- endraw %}
 )

--- a/tutoraspects/templates/openedx-assets/queries/fact_watched_video_segments.sql
+++ b/tutoraspects/templates/openedx-assets/queries/fact_watched_video_segments.sql
@@ -14,7 +14,7 @@ with courses as (
         verb_id = 'https://w3id.org/xapi/video/verbs/played'
         {% raw -%}
         {% if filter_values('org') != [] %}
-        and org in {{ filter_values('org') | where_in }}
+        and org in ({{ filter_values('org') | where_in }})
         {% endif %}
         {%- endraw %}
 ), ends as (
@@ -36,7 +36,7 @@ with courses as (
         )
         {% raw -%}
         {% if filter_values('org') != [] %}
-        and org in {{ filter_values('org') | where_in }}
+        and org in ({{ filter_values('org') | where_in }})
         {% endif %}
         {%- endraw %}
 ), segments as(


### PR DESCRIPTION
This PR contains a new "tutor do" command to wrap bulk transform of tracking log events so that Vector can capture them, as well as various fixes to make the top level materialized view tables "eventually dedupllicated", which can help in certain edge cases with Ralph bulk import as well.

Right now everything downstream of these tables is a view, and so will pick up deduplication automatically. If we need to start adding other downstream materializations we will need to take this into consideration and make sure to use the "FINAL" keyword or "OPTIMIZE FINAL" in their queries to prevent any duplicate rows trickling downstream.

Closes https://github.com/openedx/tutor-contrib-aspects/issues/127