### PR TITLE
feat!: reorder MVs and change data types (FC-0024)

### DIFF
--- a/tutoraspects/templates/aspects/apps/aspects/migrations/alembic/versions/0011_reorder_mvs.py
+++ b/tutoraspects/templates/aspects/apps/aspects/migrations/alembic/versions/0011_reorder_mvs.py
@@ -1,0 +1,451 @@
+from dataclasses import dataclass
+
+from alembic import op
+
+revision = "0011"
+down_revision = "0010"
+branch_labels = None
+depends_on = None
+
+
+@dataclass
+class MvMigration:
+    table_name: str
+    old_ddl: str
+    new_ddl: str
+    mv_name: str
+    old_mv_query: str
+    new_mv_query: str
+
+
+OLD_ENROLLMENT_DDL = """
+CREATE OR REPLACE TABLE {{ ASPECTS_XAPI_DATABASE }}.{{ ASPECTS_ENROLLMENT_EVENTS_TABLE }} (
+    `event_id` UUID NOT NULL,
+    `emission_time` DateTime64(6) NOT NULL,
+    `actor_id` String NOT NULL,
+    `object_id` String NOT NULL,
+    `course_key` String NOT NULL,
+    `org` String NOT NULL,
+    `verb_id` LowCardinality(String) NOT NULL,
+    `enrollment_mode` LowCardinality(String)
+) ENGINE = ReplacingMergeTree
+PRIMARY KEY (org, course_key)
+ORDER BY (org, course_key, actor_id, enrollment_mode, emission_time);
+"""
+
+
+NEW_ENROLLMENT_DDL = """
+CREATE OR REPLACE TABLE {{ ASPECTS_XAPI_DATABASE }}.{{ ASPECTS_ENROLLMENT_EVENTS_TABLE }} (
+    `event_id` UUID NOT NULL,
+    `emission_time` DateTime NOT NULL,
+    `actor_id` String NOT NULL,
+    `object_id` String NOT NULL,
+    `course_key` String NOT NULL,
+    `org` String NOT NULL,
+    `verb_id` LowCardinality(String) NOT NULL,
+    `enrollment_mode` LowCardinality(String)
+) ENGINE = ReplacingMergeTree
+PRIMARY KEY (org, course_key)
+ORDER BY (org, course_key, actor_id, emission_time, enrollment_mode, event_id);
+"""
+
+
+OLD_ENROLLMENT_QUERY = """
+SELECT
+    event_id,
+    emission_time,
+    actor_id,
+    object_id,
+    splitByString('/', course_id)[-1] AS course_key,
+    org,
+    verb_id,
+    JSON_VALUE(event_str, '$.object.definition.extensions."https://w3id.org/xapi/acrossx/extensions/type"') AS enrollment_mode
+FROM {{ ASPECTS_XAPI_DATABASE }}.{{ ASPECTS_XAPI_TABLE }}
+WHERE verb_id IN (
+    'http://adlnet.gov/expapi/verbs/registered',
+    'http://id.tincanapi.com/verb/unregistered'
+);
+"""
+
+
+NEW_ENROLLMENT_QUERY = """
+SELECT
+    event_id,
+    cast(emission_time as DateTime) as emission_time,
+    actor_id,
+    object_id,
+    splitByString('/', course_id)[-1] AS course_key,
+    org,
+    verb_id,
+    JSON_VALUE(event_str, '$.object.definition.extensions."https://w3id.org/xapi/acrossx/extensions/type"') AS enrollment_mode
+FROM {{ ASPECTS_XAPI_DATABASE }}.{{ ASPECTS_XAPI_TABLE }}
+WHERE verb_id IN (
+    'http://adlnet.gov/expapi/verbs/registered',
+    'http://id.tincanapi.com/verb/unregistered'
+);
+"""
+
+
+OLD_VIDEO_DDL = """
+CREATE OR REPLACE TABLE {{ ASPECTS_XAPI_DATABASE }}.{{ ASPECTS_VIDEO_PLAYBACK_EVENTS_TABLE }} (
+    `event_id` UUID NOT NULL,
+    `emission_time` DateTime64(6) NOT NULL,
+    `actor_id` String NOT NULL,
+    `object_id` String NOT NULL,
+    `course_key` String NOT NULL,
+    `org` String NOT NULL,
+    `verb_id` LowCardinality(String) NOT NULL,
+    `video_position` Float32 NOT NULL
+) ENGINE = ReplacingMergeTree
+PRIMARY KEY (org, course_key, verb_id)
+ORDER BY (org, course_key, verb_id, actor_id);
+"""
+
+
+NEW_VIDEO_DDL = """
+CREATE OR REPLACE TABLE {{ ASPECTS_XAPI_DATABASE }}.{{ ASPECTS_VIDEO_PLAYBACK_EVENTS_TABLE }} (
+    `event_id` UUID NOT NULL,
+    `emission_time` DateTime NOT NULL,
+    `actor_id` String NOT NULL,
+    `object_id` String NOT NULL,
+    `course_key` String NOT NULL,
+    `org` String NOT NULL,
+    `verb_id` LowCardinality(String) NOT NULL,
+    `video_position` UInt32 NOT NULL
+) ENGINE = ReplacingMergeTree
+PRIMARY KEY (org, course_key, verb_id)
+ORDER BY (org, course_key, verb_id, actor_id, emission_time, video_position, event_id);
+"""
+
+
+OLD_VIDEO_QUERY = """
+SELECT
+    event_id,
+    emission_time,
+    actor_id,
+    object_id,
+    splitByString('/', course_id)[-1] AS course_key,
+    org,
+    verb_id,
+    cast(coalesce(
+        nullif(JSON_VALUE(event_str, '$.result.extensions."https://w3id.org/xapi/video/extensions/time"'), ''),
+        nullif(JSON_VALUE(event_str, '$.result.extensions."https://w3id.org/xapi/video/extensions/time-from"'), ''),
+        '0.0'
+    ) as Float32) as video_position
+FROM {{ ASPECTS_XAPI_DATABASE }}.{{ ASPECTS_XAPI_TABLE }}
+WHERE verb_id IN (
+    'http://adlnet.gov/expapi/verbs/completed',
+    'http://adlnet.gov/expapi/verbs/initialized',
+    'http://adlnet.gov/expapi/verbs/terminated',
+    'https://w3id.org/xapi/video/verbs/paused',
+    'https://w3id.org/xapi/video/verbs/played',
+    'https://w3id.org/xapi/video/verbs/seeked'
+);
+"""
+
+NEW_VIDEO_QUERY = """
+SELECT
+    event_id,
+    cast(emission_time as DateTime) as emission_time,
+    actor_id,
+    object_id,
+    splitByString('/', course_id)[-1] AS course_key,
+    org,
+    verb_id,
+    ceil(cast(coalesce(
+        nullif(JSON_VALUE(event_str, '$.result.extensions."https://w3id.org/xapi/video/extensions/time"'), ''),
+        nullif(JSON_VALUE(event_str, '$.result.extensions."https://w3id.org/xapi/video/extensions/time-from"'), ''),
+        '0.0'
+    ) as Decimal32(2))) as video_position
+FROM {{ ASPECTS_XAPI_DATABASE }}.{{ ASPECTS_XAPI_TABLE }}
+WHERE verb_id IN (
+    'http://adlnet.gov/expapi/verbs/completed',
+    'http://adlnet.gov/expapi/verbs/initialized',
+    'http://adlnet.gov/expapi/verbs/terminated',
+    'https://w3id.org/xapi/video/verbs/paused',
+    'https://w3id.org/xapi/video/verbs/played',
+    'https://w3id.org/xapi/video/verbs/seeked'
+);
+"""
+
+
+OLD_PROBLEM_DDL = """
+CREATE OR REPLACE TABLE {{ ASPECTS_XAPI_DATABASE }}.{{ ASPECTS_PROBLEM_EVENTS_TABLE }} (
+    `event_id` UUID NOT NULL,
+    `emission_time` DateTime64(6) NOT NULL,
+    `actor_id` String NOT NULL,
+    `object_id` String NOT NULL,
+    `course_key` String NOT NULL,
+    `org` String NOT NULL,
+    `verb_id` LowCardinality(String) NOT NULL,
+    `responses` String,
+    `scaled_score` String,
+    `success` Bool,
+    `interaction_type` LowCardinality(String),
+    `attempts` Int16
+) ENGINE = ReplacingMergeTree
+PRIMARY KEY (org, course_key, verb_id)
+ORDER BY (org, course_key, verb_id, actor_id);
+"""
+
+
+NEW_PROBLEM_DDL = """
+CREATE OR REPLACE TABLE {{ ASPECTS_XAPI_DATABASE }}.{{ ASPECTS_PROBLEM_EVENTS_TABLE }} (
+    `event_id` UUID NOT NULL,
+    `emission_time` DateTime NOT NULL,
+    `actor_id` String NOT NULL,
+    `object_id` String NOT NULL,
+    `course_key` String NOT NULL,
+    `org` String NOT NULL,
+    `verb_id` LowCardinality(String) NOT NULL,
+    `responses` String,
+    `scaled_score` String,
+    `success` Bool,
+    `interaction_type` LowCardinality(String),
+    `attempts` Int16
+) ENGINE = ReplacingMergeTree
+PRIMARY KEY (org, course_key, verb_id)
+ORDER BY (org, course_key, verb_id, actor_id, emission_time, object_id, responses, success, event_id);
+"""
+
+
+OLD_PROBLEM_QUERY = """
+SELECT
+    event_id,
+    emission_time,
+    actor_id,
+    object_id,
+    splitByString('/', course_id)[-1] AS course_key,
+    org,
+    verb_id,
+    JSON_VALUE(event_str, '$.result.response') as responses,
+    JSON_VALUE(event_str, '$.result.score.scaled') as scaled_score,
+    if(
+        verb_id = 'https://w3id.org/xapi/acrossx/verbs/evaluated',
+        cast(JSON_VALUE(event_str, '$.result.success') as Bool),
+        false
+    ) as success,
+    JSON_VALUE(event_str, '$.object.definition.interactionType') as interaction_type,
+    if(
+        verb_id = 'https://w3id.org/xapi/acrossx/verbs/evaluated',
+        cast(JSON_VALUE(event_str, '$.object.definition.extensions."http://id.tincanapi.com/extension/attempt-id"') as Int16),
+        0
+    ) as attempts
+FROM
+    {{ ASPECTS_XAPI_DATABASE }}.{{ ASPECTS_XAPI_TABLE }}
+WHERE
+    verb_id in (
+        'https://w3id.org/xapi/acrossx/verbs/evaluated',
+        'http://adlnet.gov/expapi/verbs/passed',
+        'http://adlnet.gov/expapi/verbs/asked'
+    );
+"""
+
+
+NEW_PROBLEM_QUERY = """
+SELECT
+    event_id,
+    cast(emission_time as DateTime) as emission_time,
+    actor_id,
+    object_id,
+    splitByString('/', course_id)[-1] AS course_key,
+    org,
+    verb_id,
+    JSON_VALUE(event_str, '$.result.response') as responses,
+    JSON_VALUE(event_str, '$.result.score.scaled') as scaled_score,
+    if(
+        verb_id = 'https://w3id.org/xapi/acrossx/verbs/evaluated',
+        cast(JSON_VALUE(event_str, '$.result.success') as Bool),
+        false
+    ) as success,
+    JSON_VALUE(event_str, '$.object.definition.interactionType') as interaction_type,
+    if(
+        verb_id = 'https://w3id.org/xapi/acrossx/verbs/evaluated',
+        cast(JSON_VALUE(event_str, '$.object.definition.extensions."http://id.tincanapi.com/extension/attempt-id"') as Int16),
+        0
+    ) as attempts
+FROM
+    {{ ASPECTS_XAPI_DATABASE }}.{{ ASPECTS_XAPI_TABLE }}
+WHERE
+    verb_id in (
+        'https://w3id.org/xapi/acrossx/verbs/evaluated',
+        'http://adlnet.gov/expapi/verbs/passed',
+        'http://adlnet.gov/expapi/verbs/asked'
+    );
+"""
+
+
+OLD_NAVIGATION_DDL = """
+CREATE OR REPLACE TABLE {{ ASPECTS_XAPI_DATABASE }}.{{ ASPECTS_NAVIGATION_EVENTS_TABLE }} (
+    `event_id` UUID NOT NULL,
+    `emission_time` DateTime64(6) NOT NULL,
+    `actor_id` String NOT NULL,
+    `object_id` String NOT NULL,
+    `course_key` String NOT NULL,
+    `org` String NOT NULL,
+    `verb_id` LowCardinality(String) NOT NULL,
+    `object_type` LowCardinality(String) NOT NULL,
+    `starting_position` Int16,
+    `ending_point` String
+) ENGINE = ReplacingMergeTree
+PRIMARY KEY (org, course_key, object_type)
+ORDER BY (org, course_key, object_type, actor_id);
+"""
+
+
+NEW_NAVIGATION_DDL = """
+CREATE OR REPLACE TABLE {{ ASPECTS_XAPI_DATABASE }}.{{ ASPECTS_NAVIGATION_EVENTS_TABLE }} (
+    `event_id` UUID NOT NULL,
+    `emission_time` DateTime NOT NULL,
+    `actor_id` String NOT NULL,
+    `object_id` String NOT NULL,
+    `course_key` String NOT NULL,
+    `org` String NOT NULL,
+    `verb_id` LowCardinality(String) NOT NULL,
+    `object_type` LowCardinality(String) NOT NULL,
+    `starting_position` Int16,
+    `ending_point` String
+) ENGINE = ReplacingMergeTree
+PRIMARY KEY (org, course_key, object_type)
+ORDER BY (org, course_key, object_type, actor_id, emission_time, starting_position, event_id);
+"""
+
+
+OLD_NAVIGATION_QUERY = """
+SELECT
+    event_id,
+    emission_time,
+    actor_id,
+    object_id,
+    splitByString('/', course_id)[-1] AS course_key,
+    org,
+    verb_id,
+    JSON_VALUE(event_str, '$.object.definition.type') AS object_type,
+    -- clicking a link and selecting a module outline have no starting-position field
+    if (
+        object_type in (
+            'http://adlnet.gov/expapi/activities/link',
+            'http://adlnet.gov/expapi/activities/module'
+        ),
+        0,
+        cast(JSON_VALUE(
+            event_str,
+            '$.context.extensions."http://id.tincanapi.com/extension/starting-position"'
+        ) as Int16)
+    ) AS starting_position,
+    JSON_VALUE(
+        event_str,
+        '$.context.extensions."http://id.tincanapi.com/extension/ending-point"'
+    ) AS ending_point
+FROM
+    {{ ASPECTS_XAPI_DATABASE }}.{{ ASPECTS_XAPI_TABLE }}
+WHERE verb_id IN (
+    'https://w3id.org/xapi/dod-isd/verbs/navigated'
+);
+"""
+
+
+NEW_NAVIGATION_QUERY = """
+SELECT
+    event_id,
+    cast(emission_time as DateTime) as emission_time,
+    actor_id,
+    object_id,
+    splitByString('/', course_id)[-1] AS course_key,
+    org,
+    verb_id,
+    JSON_VALUE(event_str, '$.object.definition.type') AS object_type,
+    -- clicking a link and selecting a module outline have no starting-position field
+    if (
+        object_type in (
+            'http://adlnet.gov/expapi/activities/link',
+            'http://adlnet.gov/expapi/activities/module'
+        ),
+        0,
+        cast(JSON_VALUE(
+            event_str,
+            '$.context.extensions."http://id.tincanapi.com/extension/starting-position"'
+        ) as Int16)
+    ) AS starting_position,
+    JSON_VALUE(
+        event_str,
+        '$.context.extensions."http://id.tincanapi.com/extension/ending-point"'
+    ) AS ending_point
+FROM
+    {{ ASPECTS_XAPI_DATABASE }}.{{ ASPECTS_XAPI_TABLE }}
+WHERE verb_id IN (
+    'https://w3id.org/xapi/dod-isd/verbs/navigated'
+);
+"""
+
+MIGRATIONS = [
+    MvMigration(
+        "{{ ASPECTS_XAPI_DATABASE }}.{{ ASPECTS_ENROLLMENT_EVENTS_TABLE }}",
+        OLD_ENROLLMENT_DDL,
+        NEW_ENROLLMENT_DDL,
+        "{{ ASPECTS_XAPI_DATABASE }}.{{ ASPECTS_ENROLLMENT_TRANSFORM_MV }}",
+        OLD_ENROLLMENT_QUERY,
+        NEW_ENROLLMENT_QUERY,
+    ),
+    MvMigration(
+        "{{ ASPECTS_XAPI_DATABASE }}.{{ ASPECTS_VIDEO_PLAYBACK_EVENTS_TABLE }}",
+        OLD_VIDEO_DDL,
+        NEW_VIDEO_DDL,
+        "{{ ASPECTS_XAPI_DATABASE }}.{{ ASPECTS_VIDEO_PLAYBACK_TRANSFORM_MV }}",
+        OLD_VIDEO_QUERY,
+        NEW_VIDEO_QUERY,
+    ),
+    MvMigration(
+        "{{ ASPECTS_XAPI_DATABASE }}.{{ ASPECTS_PROBLEM_EVENTS_TABLE }}",
+        OLD_PROBLEM_DDL,
+        NEW_PROBLEM_DDL,
+        "{{ ASPECTS_XAPI_DATABASE }}.{{ ASPECTS_PROBLEM_TRANSFORM_MV }}",
+        OLD_PROBLEM_QUERY,
+        NEW_PROBLEM_QUERY,
+    ),
+    MvMigration(
+        "{{ ASPECTS_XAPI_DATABASE }}.{{ ASPECTS_NAVIGATION_EVENTS_TABLE }}",
+        OLD_NAVIGATION_DDL,
+        NEW_NAVIGATION_DDL,
+        "{{ ASPECTS_XAPI_DATABASE }}.{{ ASPECTS_NAVIGATION_TRANSFORM_MV }}",
+        OLD_NAVIGATION_QUERY,
+        NEW_NAVIGATION_QUERY,
+    ),
+]
+
+
+def migrate(table_name, mv_name, table_ddl, mv_query):
+    # for each table and materialized view to migrate:
+    # - drop the existing table and materialized view if they exist
+    # - create the new table
+    # - load data into the new table using the new MV query
+    # - create the materialized view using the new query
+    op.execute(f"DROP TABLE IF EXISTS {table_name}")
+    op.execute(f"DROP VIEW IF EXISTS {mv_name}")
+    op.execute(table_ddl)
+    op.execute(f"INSERT INTO {table_name} {mv_query}")
+    mv_ddl = (
+        f"CREATE MATERIALIZED VIEW IF NOT EXISTS {mv_name} "
+        f"TO {table_name} AS {mv_query}"
+    )
+    op.execute(mv_ddl)
+
+
+def upgrade():
+    for migration in MIGRATIONS:
+        migrate(
+            migration.table_name,
+            migration.mv_name,
+            migration.new_ddl,
+            migration.new_mv_query,
+        )
+
+
+def downgrade():
+    for migration in MIGRATIONS:
+        migrate(
+            migration.table_name,
+            migration.mv_name,
+            migration.old_ddl,
+            migration.old_mv_query,
+        )

--- a/tutoraspects/templates/aspects/apps/aspects/migrations/alembic/versions/0013_reorder_mvs.py
+++ b/tutoraspects/templates/aspects/apps/aspects/migrations/alembic/versions/0013_reorder_mvs.py
@@ -1,9 +1,18 @@
+"""
+Updates:
+1. The ORDER BY clauses for each top-level materialized view include more relevant
+   fields. Since these tables now use the ReplacingMergeTree engine, the ORDER BY
+   fields are used to determine whether a row needs to be updated.
+2. The video playback events MV now uses an integer for the video position
+3. The emission_time fields now use the DateTime type, as we do not need sub-second
+   granularity and so can save space by using a smaller data type.
+"""
 from dataclasses import dataclass
 
 from alembic import op
 
-revision = "0011"
-down_revision = "0010"
+revision = "0013"
+down_revision = "0012"
 branch_labels = None
 depends_on = None
 
@@ -46,7 +55,7 @@ CREATE OR REPLACE TABLE {{ ASPECTS_XAPI_DATABASE }}.{{ ASPECTS_ENROLLMENT_EVENTS
     `enrollment_mode` LowCardinality(String)
 ) ENGINE = ReplacingMergeTree
 PRIMARY KEY (org, course_key)
-ORDER BY (org, course_key, actor_id, emission_time, enrollment_mode, event_id);
+ORDER BY (org, course_key, emission_time, actor_id, enrollment_mode, event_id);
 """
 
 
@@ -114,7 +123,7 @@ CREATE OR REPLACE TABLE {{ ASPECTS_XAPI_DATABASE }}.{{ ASPECTS_VIDEO_PLAYBACK_EV
     `video_position` UInt32 NOT NULL
 ) ENGINE = ReplacingMergeTree
 PRIMARY KEY (org, course_key, verb_id)
-ORDER BY (org, course_key, verb_id, actor_id, emission_time, video_position, event_id);
+ORDER BY (org, course_key, verb_id, emission_time, actor_id, video_position, event_id);
 """
 
 
@@ -205,7 +214,7 @@ CREATE OR REPLACE TABLE {{ ASPECTS_XAPI_DATABASE }}.{{ ASPECTS_PROBLEM_EVENTS_TA
     `attempts` Int16
 ) ENGINE = ReplacingMergeTree
 PRIMARY KEY (org, course_key, verb_id)
-ORDER BY (org, course_key, verb_id, actor_id, emission_time, object_id, responses, success, event_id);
+ORDER BY (org, course_key, verb_id, emission_time, actor_id, object_id, responses, success, event_id);
 """
 
 
@@ -307,7 +316,7 @@ CREATE OR REPLACE TABLE {{ ASPECTS_XAPI_DATABASE }}.{{ ASPECTS_NAVIGATION_EVENTS
     `ending_point` String
 ) ENGINE = ReplacingMergeTree
 PRIMARY KEY (org, course_key, object_type)
-ORDER BY (org, course_key, object_type, actor_id, emission_time, starting_position, event_id);
+ORDER BY (org, course_key, object_type, emission_time, actor_id, starting_position, event_id);
 """
 
 


### PR DESCRIPTION
Updates the top-level materialized views in the following ways:
1. Adds fields to the `ORDER BY` clause to ensure the entire dataset is migrated during table updates
2. Truncates `emission_time` from `DateTime64(6)`, which stores nanosecond granularity, to `DateTime`, which stores second granularity
3. Stores video positions as `UInt32` (via `Decimal32(2)`) to avoid the imprecise `Float32` type