### PR TITLE
fix: remove security context for vector daemonset

### DIFF
--- a/tutoraspects/patches/k8s-deployments
+++ b/tutoraspects/patches/k8s-deployments
@@ -470,11 +470,6 @@ spec:
       labels:
         name: vector
     spec:
-      securityContext:
-        runAsUser: 1000
-        runAsGroup: 1000
-        fsGroup: 1000
-        fsGroupChangePolicy: "OnRootMismatch"
       serviceAccountName: vector
       containers:
         - name: vector

--- a/tutoraspects/templates/aspects/apps/vector/k8s.toml
+++ b/tutoraspects/templates/aspects/apps/vector/k8s.toml
@@ -4,11 +4,10 @@
 # Capture logs from kubernetes
 [sources.kubernetes_logs]
 type = "kubernetes_logs"
-extra_label_selector = "app.kubernetes.io/name=lms"
 extra_namespace_label_selector = "kubernetes.io/metadata.name={{ K8S_NAMESPACE }}"
 [transforms.openedx_containers]
 type = "filter"
 inputs = ["kubernetes_logs"]
-condition = '.kubernetes.pod_namespace == "{{ K8S_NAMESPACE }}" && includes(["lms", "cms", "lms-job", "cms-job"], .kubernetes.container_name)'
+condition = '.kubernetes.pod_namespace == "{{ K8S_NAMESPACE }}" && includes(["lms", "cms", "lms-job", "cms-job", "lms-worker", "cms-worker"], .kubernetes.container_name)'
 
 {% include "aspects/apps/vector/partials/common-post.toml" %}

--- a/tutoraspects/templates/aspects/apps/vector/partials/common-post.toml
+++ b/tutoraspects/templates/aspects/apps/vector/partials/common-post.toml
@@ -44,7 +44,7 @@ inputs = ["openedx_containers"]
 # Time formats: https://docs.rs/chrono/0.4.19/chrono/format/strftime/index.html#specifiers
 
 source = '''
-parsed, err_regex = parse_regex(.message, r'^.* \[xapi_tracking\] [^{}]* (?P<tracking_message>\{.*$)')
+parsed, err_regex = parse_regex(.message, r'^.* \[xapi_tracking\] [^{}]* (?P<tracking_message>\{.*\})$')
 if err_regex != null {
   abort
 }


### PR DESCRIPTION
## Description

This PR fixes an issue with the Vector DaemonSetPermission:

Before this change:

```
2023-07-27T12:19:43.653668Z ERROR vector::internal_events::file::source: Failed reading file for fingerprinting. file=/var/log/pods/san-sebastian-openedx_lms-76b7b5cd4f-n75m6_f3d8bd6f-8f21-4a7c-a9f6-6d87000ae255/lms/0.log error=Permission denied (os error 13) error_code="reading_fingerprint" error_type="reader_failed" stage="receiving" internal_log_rate_limit=true
2023-07-27T14:00:08.514452Z ERROR vector::internal_events::file::source: Failed reading file for fingerprinting. file=/var/log/pods/san-sebastian-openedx_lms-76b7b5cd4f-n75m6_f3d8bd6f-8f21-4a7c-a9f6-6d87000ae255/lms/0.log error=Permission denied (os error 13) error_code="reading_fingerprint" error_type="reader_failed" stage="receiving" internal_log_rate_limit=true
2023-07-27T14:01:10.006951Z ERROR vector::internal_events::file::source: Failed reading file for fingerprinting. file=/var/log/pods/san-sebastian-openedx_lms-76b7b5cd4f-n75m6_f3d8bd6f-8f21-4a7c-a9f6-6d87000ae255/lms/0.log error=Permission denied (os error 13) error_code="reading_fingerprint" error_type="reader_failed" stage="receiving" internal_log_rate_limit=true
```

After this change:

```
{"message":{"context":{"course_id":"","user_id":5},"name":"/"},"time":"2023-07-27T14:47:55.782670Z"}
{"message":{"context":{"course_id":"","user_id":5},"name":"/dashboard"},"time":"2023-07-27T14:47:57.429976Z"}
{"message":{"context":{"course_id":"","user_id":5},"name":"/api/mfe_config/v1"},"time":"2023-07-27T14:48:09.577735Z"}
```

This PR corrects the xAPI parser regex and includes the lms and cms workers for the kubernetes logs:

```
{"emission_time":"2023-07-27T15:48:04.946554+00:00","event_id":"9fb78bd4-c543-588e-94f8-706122b557cb","message":{"verb":{"id":"http://adlnet.gov/expapi/verbs/initialized"}}}
{"emission_time":"2023-07-27T15:48:08.432797+00:00","event_id":"201ac886-d35d-5ebb-a7bf-410e9d6b011d","message":{"verb":{"id":"https://w3id.org/xapi/video/verbs/played"}}}
```

And those are emitted correctly to the database:

![image](https://github.com/openedx/tutor-contrib-aspects/assets/33465240/6416e655-fb74-49bd-9c17-511e1c5f6bf1)
