### PR TITLE
fix: use DateTime instead of DateTime64 for datasets

### DIFF
--- a/tutoraspects/templates/openedx-assets/fact_enrollments.yaml
+++ b/tutoraspects/templates/openedx-assets/fact_enrollments.yaml
@@ -11,7 +11,7 @@
     is_active: true
     is_dttm: true
     python_date_format: null
-    type: DateTime64(6)
+    type: DateTime
     verbose_name: null
   - advanced_data_type: null
     column_name: enrollment_mode

--- a/tutoraspects/templates/openedx-assets/fact_problem_responses.yaml
+++ b/tutoraspects/templates/openedx-assets/fact_problem_responses.yaml
@@ -11,7 +11,7 @@
       is_active: true
       is_dttm: true
       python_date_format: null
-      type: DateTime64(6)
+      type: DateTime
       verbose_name: null
     - advanced_data_type: null
       column_name: org

--- a/tutoraspects/templates/openedx-assets/fact_transcript_usage.yaml
+++ b/tutoraspects/templates/openedx-assets/fact_transcript_usage.yaml
@@ -11,7 +11,7 @@
     is_active: true
     is_dttm: true
     python_date_format: null
-    type: DateTime64(6)
+    type: DateTime
     verbose_name: null
   - advanced_data_type: null
     column_name: org

--- a/tutoraspects/templates/openedx-assets/fact_video_plays.yaml
+++ b/tutoraspects/templates/openedx-assets/fact_video_plays.yaml
@@ -11,7 +11,7 @@
     is_active: true
     is_dttm: true
     python_date_format: null
-    type: DateTime64(6)
+    type: DateTime
     verbose_name: null
   - advanced_data_type: null
     column_name: org

--- a/tutoraspects/templates/openedx-assets/fact_watched_video_segments.yaml
+++ b/tutoraspects/templates/openedx-assets/fact_watched_video_segments.yaml
@@ -11,7 +11,7 @@
       is_active: true
       is_dttm: true
       python_date_format: null
-      type: DateTime64(6)
+      type: DateTime
       verbose_name: null
     - advanced_data_type: null
       column_name: segment_start

--- a/tutoraspects/templates/openedx-assets/xapi_events_all_parsed.yaml
+++ b/tutoraspects/templates/openedx-assets/xapi_events_all_parsed.yaml
@@ -59,7 +59,7 @@
     is_active: true
     is_dttm: true
     python_date_format: null
-    type: DateTime64(6)
+    type: DateTime
     verbose_name: null
   - advanced_data_type: null
     column_name: event_id


### PR DESCRIPTION
Some Superset assets needed to be updated to match the new DateTime columns