### PR TITLE
fix: specify insertion order in migration 0012 (FC-0024)

### DIFF
--- a/tutoraspects/templates/aspects/apps/aspects/migrations/alembic/versions/0012_vector_replacingmergetree_xapi_parsed.py
+++ b/tutoraspects/templates/aspects/apps/aspects/migrations/alembic/versions/0012_vector_replacingmergetree_xapi_parsed.py
@@ -50,6 +50,7 @@ def upgrade():
     op.execute(
         f"""
         INSERT INTO {DESTINATION_TABLE}
+        (event_id, verb_id, actor_id, object_id, course_id, org, emission_time, event_str)
         SELECT
         event_id as event_id,
         JSON_VALUE(event_str, '$.verb.id') as verb_id,
@@ -127,6 +128,7 @@ def downgrade():
     op.execute(
         f"""
         INSERT INTO {DESTINATION_TABLE}
+        (event_id, verb_id, actor_id, object_id, course_id, org, emission_time, event_str)
         SELECT
         event_id as event_id,
         JSON_VALUE(event_str, '$.verb.id') as verb_id,


### PR DESCRIPTION
ClickHouse materialized views insert data into the target table by referring to column names. However, when inserting data directly into the target table, it relies on column _order_ for the insertion. The query for the materialized views does not have the same ordering of org and course_id as the target table, and so when inserting data the order should be made explicit.