### PR TITLE
fix: update timestamp type in enrollment_by_day (FC-0024)

### DIFF
--- a/tutoraspects/templates/openedx-assets/queries/fact_enrollments_by_day.sql
+++ b/tutoraspects/templates/openedx-assets/queries/fact_enrollments_by_day.sql
@@ -21,7 +21,7 @@ with enrollments as (
     enrollment_status,
     enrollment_mode,
     emission_time as window_start_at,
-    lagInFrame(emission_time, 1, now64(6)) over (partition by org, course_name, run_name, actor_id order by emission_time desc) as window_end_at
+    lagInFrame(emission_time, 1, now()) over (partition by org, course_name, run_name, actor_id order by emission_time desc) as window_end_at
   from
     enrollments_ranked
   where


### PR DESCRIPTION
We're no longer using such high-precision timestamps for emission_time in the MVs. This should be the last issue related to the timestamp change.