### PR TITLE
fix: deduplicate video timeline events (FC-0024)

### DIFF
--- a/tutoraspects/templates/openedx-assets/queries/fact_watched_video_segments.sql
+++ b/tutoraspects/templates/openedx-assets/queries/fact_watched_video_segments.sql
@@ -71,7 +71,9 @@ with courses as (
     from
         segments
         join courses
-            on (segments.org = courses.org and segments.course_key = courses.course_key)
+            on (segments.org = courses.org
+                and segments.course_key = courses.course_key
+                and segments.video_id = courses.video_id)
 )
 
 select


### PR DESCRIPTION
There was a missing join key that caused duplicate rows to be returned as part of the video timeline query. This resulted in inflated metrics for watched video segments.