### PR TITLE
chore: bump xapi-db-load to 0.5 (FC-0024)

### DIFF
--- a/tutoraspects/templates/aspects/build/aspects/requirements.txt
+++ b/tutoraspects/templates/aspects/build/aspects/requirements.txt
@@ -4,4 +4,4 @@ clickhouse-sqlalchemy==0.1.9
 # dbt packages
 dbt-core==1.4.0
 dbt-clickhouse==1.4.1
-git+https://github.com/openedx/xapi-db-load@0.4#egg=xapi-db-load==0.4
+git+https://github.com/openedx/xapi-db-load@0.5#egg=xapi-db-load==0.5


### PR DESCRIPTION
Now that xapi-db-load has a new release, let's use it in this plugin!