### PR TITLE
chore: Upgrade xapi-db-load to 0.6

### DIFF
--- a/tutoraspects/templates/aspects/build/aspects/requirements.txt
+++ b/tutoraspects/templates/aspects/build/aspects/requirements.txt
@@ -4,4 +4,4 @@ clickhouse-sqlalchemy==0.1.9
 # dbt packages
 dbt-core==1.4.0
 dbt-clickhouse==1.4.1
-git+https://github.com/openedx/xapi-db-load@0.5#egg=xapi-db-load==0.5
+git+https://github.com/openedx/xapi-db-load@0.6#egg=xapi-db-load==0.6


### PR DESCRIPTION
Makes fake data more realistic, allows date configuration and reduces the default date span from 10 yrs to 1.