### PR TITLE
feat: include current day in instructor dashboard (FC-0024)

### DIFF
--- a/tutoraspects/templates/openedx-assets/Instructor_dashboard_9.yaml
+++ b/tutoraspects/templates/openedx-assets/Instructor_dashboard_9.yaml
@@ -1,5 +1,5 @@
 - _file_name: Instructor_dashboard_9.yaml
-  _roles: 
+  _roles:
   - {{ SUPERSET_ROLES_MAPPING.instructor }}
   css: ""
   dashboard_title: Instructor dashboard
@@ -27,9 +27,13 @@
           enableEmptyFilter: false
         defaultDataMask:
           extraFormData:
-            time_range: Last month
+            time_range:
+              'DATEADD(DATETIME("now"), -1, month) : DATEADD(DATETIME("now"),
+              1, day)'
           filterState:
-            value: Last month
+            value:
+              'DATEADD(DATETIME("now"), -1, month) : DATEADD(DATETIME("now"), 1,
+              day)'
         description: ""
         filterType: filter_time
         id: NATIVE_FILTER-zxfszG4xH
@@ -174,7 +178,6 @@
           - 45
           - 46
           - 47
-          - 52
         controlValues:
           defaultToFirstItem: false
           enableEmptyFilter: false
@@ -196,7 +199,6 @@
             - TAB-NR4UTAs9K
         tabsInScope:
           - TAB-NR4UTAs9K
-          - TAB-7PGDduCA7
         targets:
           - column:
               name: problem_name

--- a/tutoraspects/templates/openedx-assets/queries/fact_enrollments_by_day.sql
+++ b/tutoraspects/templates/openedx-assets/queries/fact_enrollments_by_day.sql
@@ -25,7 +25,7 @@ with enrollments_ranked as (
     enrollment_status,
     enrollment_mode,
     emission_time as window_start_at,
-    lagInFrame(emission_time, 1, now()) over (partition by org, course_name, run_name, actor_id order by emission_time desc) as window_end_at
+    lagInFrame(emission_time, 1, now() + interval '1' day) over (partition by org, course_name, run_name, actor_id order by emission_time desc) as window_end_at
   from
     enrollments_ranked
   where
@@ -39,7 +39,7 @@ with enrollments_ranked as (
         enrollment_status,
         enrollment_mode,
         date_trunc('day', window_start_at) as window_start_date,
-        date_trunc('day', coalesce(window_end_at, now())) as window_end_date
+        date_trunc('day', window_end_at) as window_end_date
     from enrollment_windows
 )
 select


### PR DESCRIPTION
This addresses #246. The query for `fact_enrollments_by_day` is also updated to extend the current enrollment status window to tomorrow so that the current days' enrollment status is included, which in turn makes the enrollment status available for the chart. In that same query, I've also confirmed that the call to `lagInFrame` provides a default value and so the call to `coalesce` further down is not needed.