### PR TITLE
fix: remove extra parens from dashboard filters (FC-0024)

### DIFF
--- a/tutoraspects/templates/openedx-assets/queries/dim_course_problems.sql
+++ b/tutoraspects/templates/openedx-assets/queries/dim_course_problems.sql
@@ -12,10 +12,10 @@ with courses as (
         location like '%problem+block%'
     {% raw -%}
         {% if filter_values('org') != [] %}
-        and org in ({{ filter_values('org') | where_in }})
+        and org in {{ filter_values('org') | where_in }}
         {% endif %}
         {% if filter_values('problem_name') != [] %}
-        and problem_name in ({{ filter_values('problem_name') | where_in }})
+        and problem_name in {{ filter_values('problem_name') | where_in }}
         {% endif %}
     {%- endraw %}
 )

--- a/tutoraspects/templates/openedx-assets/queries/dim_course_videos.sql
+++ b/tutoraspects/templates/openedx-assets/queries/dim_course_videos.sql
@@ -12,10 +12,10 @@ with courses as (
     {% raw -%}
         location like '%video+block%'
         {% if filter_values('org') != [] %}
-        and org in ({{ filter_values('org') | where_in }})
+        and org in {{ filter_values('org') | where_in }}
         {% endif %}
         {% if filter_values('video_name') != [] %}
-        and video_name in ({{ filter_values('video_name') | where_in }})
+        and video_name in {{ filter_values('video_name') | where_in }}
         {% endif %}
     {%- endraw %}
 )

--- a/tutoraspects/templates/openedx-assets/queries/fact_watched_video_segments.sql
+++ b/tutoraspects/templates/openedx-assets/queries/fact_watched_video_segments.sql
@@ -12,7 +12,7 @@ with starts as (
         verb_id = 'https://w3id.org/xapi/video/verbs/played'
         {% raw -%}
         {% if filter_values('org') != [] %}
-        and org in ({{ filter_values('org') | where_in }})
+        and org in {{ filter_values('org') | where_in }}
         {% endif %}
         {%- endraw %}
 ), ends as (
@@ -34,7 +34,7 @@ with starts as (
         )
         {% raw -%}
         {% if filter_values('org') != [] %}
-        and org in ({{ filter_values('org') | where_in }})
+        and org in {{ filter_values('org') | where_in }}
         {% endif %}
         {%- endraw %}
 ), segments as(


### PR DESCRIPTION
This fixes #258. The `where_in` jinja filter will add parentheses automatically. Since this macro was wrapped in parentheses in a few places, it caused an issue when more than one filter value was selected (though apparently it was fine when only one value was selected).