### PR TITLE
chore: Upgrade openedx-event-sink-clickhouse to 0.1.1

### DIFF
--- a/tutoraspects/plugin.py
+++ b/tutoraspects/plugin.py
@@ -46,7 +46,7 @@ hooks.Filters.CONFIG_DEFAULTS.add_items(
         (
             "OPENEDX_EXTRA_PIP_REQUIREMENTS",
             [
-                "openedx-event-sink-clickhouse==0.1.0",
+                "openedx-event-sink-clickhouse==0.1.1",
                 "edx-event-routing-backends==5.5.0",
             ],
         ),


### PR DESCRIPTION
Fixes an issue with unicode in course names and blocks causing course sync to fail.