### PR TITLE
fix: upgrade event-routing-backends to 5.5.4

### DIFF
--- a/tutoraspects/plugin.py
+++ b/tutoraspects/plugin.py
@@ -47,7 +47,7 @@ hooks.Filters.CONFIG_DEFAULTS.add_items(
             "OPENEDX_EXTRA_PIP_REQUIREMENTS",
             [
                 "openedx-event-sink-clickhouse==0.1.1",
-                "edx-event-routing-backends==5.5.0",
+                "edx-event-routing-backends==5.5.4",
             ],
         ),
         # ClickHouse xAPI settings


### PR DESCRIPTION
This PR upgrade ERB to 5.5.4. Includes the following fixes:

[fix: catch null weighted_possible](https://github.com/openedx/event-routing-backends/commit/4a66fb02dc5a08e5945fff623391ae42fbcd39d9)
[fix: Divide by 0 errors on problem interaction events](https://github.com/openedx/event-routing-backends/commit/71d364ade573f472721748bf9c50c4b4dafb7b4c)
[feat: upgrade to Django 4.2](https://github.com/openedx/event-routing-backends/commit/cf7fa198378cadd658925b925ab77ec202dee2b2)
[fix: Caliper transform of video events without duration](https://github.com/openedx/event-routing-backends/commit/bc672fb3235de28db43025ed4c897c2c57d334c9)