### PR TITLE
chore: Upgrade event-routing-backends to 5.5.5

### DIFF
--- a/tutoraspects/plugin.py
+++ b/tutoraspects/plugin.py
@@ -47,7 +47,7 @@ hooks.Filters.CONFIG_DEFAULTS.add_items(
             "OPENEDX_EXTRA_PIP_REQUIREMENTS",
             [
                 "openedx-event-sink-clickhouse==0.1.1",
-                "edx-event-routing-backends==5.5.4",
+                "edx-event-routing-backends==5.5.5",
             ],
         ),
         # ClickHouse xAPI settings


### PR DESCRIPTION
Retries failed download chunks in bulk transform.