### PR TITLE
fix: add configurable clickhouse volume size

### DIFF
--- a/tutoraspects/patches/k8s-volumes
+++ b/tutoraspects/patches/k8s-volumes
@@ -12,7 +12,7 @@ spec:
     - ReadWriteOnce
   resources:
     requests:
-      storage: 5Gi
+      storage: {{ CLICKHOUSE_K8S_VOLUME_SIZE }}
 {% endif %}
 {% if RUN_SUPERSET %}
 ---

--- a/tutoraspects/plugin.py
+++ b/tutoraspects/plugin.py
@@ -93,6 +93,7 @@ hooks.Filters.CONFIG_DEFAULTS.add_items(
             "{% if CLICKHOUSE_SECURE_CONNECTION %}"
             "{{CLICKHOUSE_HTTPS_PORT}}{% else %}{{CLICKHOUSE_HTTP_PORT}}{% endif %}",
         ),
+        ("CLICKHOUSE_K8S_VOLUME_SIZE", "10Gi"),
         # This can be used to override some configuration values in
         # via "docker_config.xml" file, which will be read from a
         # mount on /etc/clickhouse-server/config.d/ on startup.


### PR DESCRIPTION
This PR creates a setting to allow to control the clickhouse volume size: `CLICKHOUSE_VOLUME_SIZE`