### PR TITLE
fix: Adapted transform_tracking_logs command for enhanced CLI integration

### DIFF
--- a/tutoraspects/commands_v0.py
+++ b/tutoraspects/commands_v0.py
@@ -172,11 +172,14 @@ def transform_tracking_logs(context, **kwargs) -> None:
 
     options = []
     for arg, value in kwargs.items():
-        if value:
+        if not value:
+            continue
+        if arg == 'dry_run':
+            options.append(f"--{arg}")
+        elif arg == 'source_config' or arg == 'destination_config':
+            options.append(f"--{arg} '{value}'")
+        else:
             options.append(f"--{arg} {value}")
-
-    if 'dry_run' in kwargs and kwargs['dry_run']:
-        options.append("--dry_run")
 
     options_str = " ".join(options)
 

--- a/tutoraspects/commands_v0.py
+++ b/tutoraspects/commands_v0.py
@@ -170,22 +170,17 @@ def transform_tracking_logs(context, **kwargs) -> None:
     config = tutor_config.load(context.root)
     runner = context.job_runner(config)
 
-    options = (
-        f"--source_provider {kwargs['source_provider']} "
-        f"--source_config {kwargs['source_config']} "
-        f"--destination_provider {kwargs['destination_provider']} "
-        f"--transformer_type {kwargs['transformer_type']}"
-    )    
-    
-    if 'destination_config' in kwargs and kwargs['destination_config']:
-        options += f" --destination_config {kwargs['destination_config']}"
-        
-    options += f" --batch_size {kwargs['batch_size']} --sleep_between_batches_secs {kwargs['sleep_between_batches_secs']}"
+    options = []
+    for arg, value in kwargs.items():
+        if value:
+            options.append(f"--{arg} {value}")
 
     if 'dry_run' in kwargs and kwargs['dry_run']:
-        options += " --dry_run"
+        options.append("--dry_run")
 
-    command = f"./manage.py lms transform_tracking_logs {options}"
+    options_str = " ".join(options)
+
+    command = f"./manage.py lms transform_tracking_logs {options_str}"
     
     runner.run_job("lms", command)
 

--- a/tutoraspects/commands_v0.py
+++ b/tutoraspects/commands_v0.py
@@ -111,56 +111,56 @@ def dump_courses_to_clickhouse(context, options) -> None:
 # Ex: tutor local do transform-tracking-logs --options "--source_provider MINIO --source_config '{\"key\": \"openedx\", \"secret\": \"h3SIhXAqDDxJAP6TcXklNxro\", \"container\": \"openedx\", \"prefix\": \"/tracking_logs\", \"host\": \"files.local.overhang.io\", \"secure\": false}' --destination_provider LRS --transformer_type xapi"
 @click.command(help="Uses event-routing-backends to replay tracking logs.")
 @click.option(
-    '--source_provider', 
-    type=str, 
-    required=True, 
-    help="An Apache Libcloud provider. This is mandatory."
+    "--source_provider",
+    type=str,
+    required=True,
+    help="An Apache Libcloud provider. This is mandatory.",
 )
 @click.option(
-    '--source_config', 
-    type=str, 
-    required=True, 
-    help="A JSON dictionary of configuration for the source provider. This is mandatory."
+    "--source_config",
+    type=str,
+    required=True,
+    help="A JSON dictionary of configuration for the source provider. This is mandatory.",
 )
 @click.option(
-    '--destination_provider', 
-    type=str, 
-    default="LRS", 
-    help="Either 'LRS' or an Apache Libcloud provider. The default is 'LRS'."
+    "--destination_provider",
+    type=str,
+    default="LRS",
+    help="Either 'LRS' or an Apache Libcloud provider. The default is 'LRS'.",
 )
 @click.option(
-    '--destination_config', 
-    type=str, 
+    "--destination_config",
+    type=str,
     help=(
         "A JSON dictionary of configuration for the destination provider. "
         "Optional if 'LRS' is used as the destination_provider."
-    )
+    ),
 )
 @click.option(
-    '--transformer_type', 
-    type=click.Choice(['xapi', 'caliper']), 
-    required=True, 
-    help="The type of transformation to perform, either 'xapi' or 'caliper'. This is mandatory."
+    "--transformer_type",
+    type=click.Choice(["xapi", "caliper"]),
+    required=True,
+    help="The type of transformation to perform, either 'xapi' or 'caliper'. This is mandatory.",
 )
 @click.option(
-    '--batch_size', 
-    type=int, 
-    default=10000, 
-    help="The batch size. The default is 10000."
+    "--batch_size",
+    type=int,
+    default=10000,
+    help="The batch size. The default is 10000.",
 )
 @click.option(
-    '--sleep_between_batches_secs', 
-    type=float, 
-    default=10.0, 
-    help="The amount of time (in seconds) to sleep between sending batches. Default is 10.0 seconds."
+    "--sleep_between_batches_secs",
+    type=float,
+    default=10.0,
+    help="The amount of time (in seconds) to sleep between sending batches. Default is 10.0 seconds.",
 )
 @click.option(
-    '--dry_run', 
-    is_flag=True, 
+    "--dry_run",
+    is_flag=True,
     help=(
         "A flag to determine if this is a dry run. If present, all lines from all files "
         "will be attempted to be transformed, but won't be sent to the destination."
-    )
+    ),
 )
 @click.pass_obj
 def transform_tracking_logs(context, **kwargs) -> None:
@@ -174,9 +174,9 @@ def transform_tracking_logs(context, **kwargs) -> None:
     for arg, value in kwargs.items():
         if not value:
             continue
-        if arg == 'dry_run':
+        if arg == "dry_run":
             options.append(f"--{arg}")
-        elif arg == 'source_config' or arg == 'destination_config':
+        elif arg == "source_config" or arg == "destination_config":
             options.append(f"--{arg} '{value}'")
         else:
             options.append(f"--{arg} {value}")
@@ -184,7 +184,7 @@ def transform_tracking_logs(context, **kwargs) -> None:
     options_str = " ".join(options)
 
     command = f"./manage.py lms transform_tracking_logs {options_str}"
-    
+
     runner.run_job("lms", command)
 
 

--- a/tutoraspects/commands_v0.py
+++ b/tutoraspects/commands_v0.py
@@ -176,7 +176,7 @@ def transform_tracking_logs(context, **kwargs) -> None:
             continue
         if arg == "dry_run":
             options.append(f"--{arg}")
-        elif arg == "source_config" or arg == "destination_config":
+        elif arg in ("source_config", "destination_config"):
             options.append(f"--{arg} '{value}'")
         else:
             options.append(f"--{arg} {value}")

--- a/tutoraspects/commands_v0.py
+++ b/tutoraspects/commands_v0.py
@@ -110,18 +110,83 @@ def dump_courses_to_clickhouse(context, options) -> None:
 # pylint: disable=line-too-long
 # Ex: tutor local do transform-tracking-logs --options "--source_provider MINIO --source_config '{\"key\": \"openedx\", \"secret\": \"h3SIhXAqDDxJAP6TcXklNxro\", \"container\": \"openedx\", \"prefix\": \"/tracking_logs\", \"host\": \"files.local.overhang.io\", \"secure\": false}' --destination_provider LRS --transformer_type xapi"
 @click.command(help="Uses event-routing-backends to replay tracking logs.")
-@click.option("--options", default="")
+@click.option(
+    '--source_provider', 
+    type=str, 
+    required=True, 
+    help="An Apache Libcloud provider. This is mandatory."
+)
+@click.option(
+    '--source_config', 
+    type=str, 
+    required=True, 
+    help="A JSON dictionary of configuration for the source provider. This is mandatory."
+)
+@click.option(
+    '--destination_provider', 
+    type=str, 
+    default="LRS", 
+    help="Either 'LRS' or an Apache Libcloud provider. The default is 'LRS'."
+)
+@click.option(
+    '--destination_config', 
+    type=str, 
+    help=(
+        "A JSON dictionary of configuration for the destination provider. "
+        "Optional if 'LRS' is used as the destination_provider."
+    )
+)
+@click.option(
+    '--transformer_type', 
+    type=click.Choice(['xapi', 'caliper']), 
+    required=True, 
+    help="The type of transformation to perform, either 'xapi' or 'caliper'. This is mandatory."
+)
+@click.option(
+    '--batch_size', 
+    type=int, 
+    default=10000, 
+    help="The batch size. The default is 10000."
+)
+@click.option(
+    '--sleep_between_batches_secs', 
+    type=float, 
+    default=10.0, 
+    help="The amount of time (in seconds) to sleep between sending batches. Default is 10.0 seconds."
+)
+@click.option(
+    '--dry_run', 
+    is_flag=True, 
+    help=(
+        "A flag to determine if this is a dry run. If present, all lines from all files "
+        "will be attempted to be transformed, but won't be sent to the destination."
+    )
+)
 @click.pass_obj
-def transform_tracking_logs(context, options) -> None:
+def transform_tracking_logs(context, **kwargs) -> None:
     """
     Job that proxies the dump_courses_to_clickhouse commands.
     """
     config = tutor_config.load(context.root)
     runner = context.job_runner(config)
 
-    command = f"""
-    ./manage.py lms transform_tracking_logs {options}
-    """
+    options = (
+        f"--source_provider {kwargs['source_provider']} "
+        f"--source_config {kwargs['source_config']} "
+        f"--destination_provider {kwargs['destination_provider']} "
+        f"--transformer_type {kwargs['transformer_type']}"
+    )    
+    
+    if 'destination_config' in kwargs and kwargs['destination_config']:
+        options += f" --destination_config {kwargs['destination_config']}"
+        
+    options += f" --batch_size {kwargs['batch_size']} --sleep_between_batches_secs {kwargs['sleep_between_batches_secs']}"
+
+    if 'dry_run' in kwargs and kwargs['dry_run']:
+        options += " --dry_run"
+
+    command = f"./manage.py lms transform_tracking_logs {options}"
+    
     runner.run_job("lms", command)
 
 

--- a/tutoraspects/commands_v1.py
+++ b/tutoraspects/commands_v1.py
@@ -168,7 +168,7 @@ def transform_tracking_logs(**kwargs) -> list[tuple[str, str]]:
             continue
         if arg == "dry_run":
             options.append(f"--{arg}")
-        elif arg == "source_config" or arg == "destination_config":
+        elif arg in ("source_config", "destination_config"):
             options.append(f"--{arg} '{value}'")
         else:
             options.append(f"--{arg} {value}")

--- a/tutoraspects/commands_v1.py
+++ b/tutoraspects/commands_v1.py
@@ -162,22 +162,17 @@ def transform_tracking_logs(**kwargs) -> list[tuple[str, str]]:
     Job that proxies the transform_tracking_logs commands.
     """
 
-    options = (
-        f"--source_provider {kwargs['source_provider']} "
-        f"--source_config {kwargs['source_config']} "
-        f"--destination_provider {kwargs['destination_provider']} "
-        f"--transformer_type {kwargs['transformer_type']}"
-    )    
-
-    if 'destination_config' in kwargs and kwargs['destination_config']:
-        options += f" --destination_config {kwargs['destination_config']}"
-        
-    options += f" --batch_size {kwargs['batch_size']} --sleep_between_batches_secs {kwargs['sleep_between_batches_secs']}"
+    options = []
+    for arg, value in kwargs.items():
+        if value:
+            options.append(f"--{arg} {value}")
 
     if 'dry_run' in kwargs and kwargs['dry_run']:
-        options += " --dry_run"
+        options.append("--dry_run")
 
-    command = f"./manage.py lms transform_tracking_logs {options}"
+    options_str = " ".join(options)
+
+    command = f"./manage.py lms transform_tracking_logs {options_str}"
     
     return [("lms", command)]
 

--- a/tutoraspects/commands_v1.py
+++ b/tutoraspects/commands_v1.py
@@ -105,12 +105,81 @@ def dump_courses_to_clickhouse(options) -> list[tuple[str, str]]:
 # Ex: tutor local do transform-tracking-logs --options "--source_provider LOCAL --source_config '{\"key\": \"/openedx/data/\", \"prefix\": \"tracking.log\", \"container\": \"logs\"}' --destination_provider LRS --transformer_type xapi"
 # Ex: tutor local do transform-tracking-logs --options "--source_provider MINIO --source_config '{\"key\": \"openedx\", \"secret\": \"h3SIhXAqDDxJAP6TcXklNxro\", \"container\": \"openedx\", \"prefix\": \"/tracking_logs\", \"host\": \"files.local.overhang.io\", \"secure\": false}' --destination_provider LRS --transformer_type xapi"
 @click.command(context_settings={"ignore_unknown_options": True})
-@click.option("--options", default="", type=click.UNPROCESSED)
-def transform_tracking_logs(options) -> list[tuple[str, str]]:
+@click.option(
+    '--source_provider', 
+    type=str, 
+    required=True, 
+    help="An Apache Libcloud provider. This is mandatory."
+)
+@click.option(
+    '--source_config', 
+    type=str, 
+    required=True, 
+    help="A JSON dictionary of configuration for the source provider. This is mandatory."
+)
+@click.option(
+    '--destination_provider', 
+    type=str, 
+    default="LRS", 
+    help="Either 'LRS' or an Apache Libcloud provider. The default is 'LRS'."
+)
+@click.option(
+    '--destination_config', 
+    type=str, 
+    help=(
+        "A JSON dictionary of configuration for the destination provider. "
+        "Optional if 'LRS' is used as the destination_provider."
+    )
+)
+@click.option(
+    '--transformer_type', 
+    type=click.Choice(['xapi', 'caliper']), 
+    required=True, 
+    help="The type of transformation to perform, either 'xapi' or 'caliper'. This is mandatory."
+)
+@click.option(
+    '--batch_size', 
+    type=int, 
+    default=10000, 
+    help="The batch size. The default is 10000."
+)
+@click.option(
+    '--sleep_between_batches_secs', 
+    type=float, 
+    default=10.0, 
+    help="The amount of time (in seconds) to sleep between sending batches. Default is 10.0 seconds."
+)
+@click.option(
+    '--dry_run', 
+    is_flag=True, 
+    help=(
+        "A flag to determine if this is a dry run. If present, all lines from all files "
+        "will be attempted to be transformed, but won't be sent to the destination."
+    )
+)
+def transform_tracking_logs(**kwargs) -> list[tuple[str, str]]:
     """
-    Job that proxies the dump_courses_to_clickhouse commands.
+    Job that proxies the transform_tracking_logs commands.
     """
-    return [("lms", f"./manage.py lms transform_tracking_logs {options}")]
+
+    options = (
+        f"--source_provider {kwargs['source_provider']} "
+        f"--source_config {kwargs['source_config']} "
+        f"--destination_provider {kwargs['destination_provider']} "
+        f"--transformer_type {kwargs['transformer_type']}"
+    )    
+
+    if 'destination_config' in kwargs and kwargs['destination_config']:
+        options += f" --destination_config {kwargs['destination_config']}"
+        
+    options += f" --batch_size {kwargs['batch_size']} --sleep_between_batches_secs {kwargs['sleep_between_batches_secs']}"
+
+    if 'dry_run' in kwargs and kwargs['dry_run']:
+        options += " --dry_run"
+
+    command = f"./manage.py lms transform_tracking_logs {options}"
+    
+    return [("lms", command)]
 
 
 COMMANDS = (

--- a/tutoraspects/commands_v1.py
+++ b/tutoraspects/commands_v1.py
@@ -164,11 +164,14 @@ def transform_tracking_logs(**kwargs) -> list[tuple[str, str]]:
 
     options = []
     for arg, value in kwargs.items():
-        if value:
+        if not value:
+            continue
+        if arg == 'dry_run':
+            options.append(f"--{arg}")
+        elif arg == 'source_config' or arg == 'destination_config':
+            options.append(f"--{arg} '{value}'")
+        else:
             options.append(f"--{arg} {value}")
-
-    if 'dry_run' in kwargs and kwargs['dry_run']:
-        options.append("--dry_run")
 
     options_str = " ".join(options)
 

--- a/tutoraspects/commands_v1.py
+++ b/tutoraspects/commands_v1.py
@@ -106,56 +106,56 @@ def dump_courses_to_clickhouse(options) -> list[tuple[str, str]]:
 # Ex: tutor local do transform-tracking-logs --options "--source_provider MINIO --source_config '{\"key\": \"openedx\", \"secret\": \"h3SIhXAqDDxJAP6TcXklNxro\", \"container\": \"openedx\", \"prefix\": \"/tracking_logs\", \"host\": \"files.local.overhang.io\", \"secure\": false}' --destination_provider LRS --transformer_type xapi"
 @click.command(context_settings={"ignore_unknown_options": True})
 @click.option(
-    '--source_provider', 
-    type=str, 
-    required=True, 
-    help="An Apache Libcloud provider. This is mandatory."
+    "--source_provider",
+    type=str,
+    required=True,
+    help="An Apache Libcloud provider. This is mandatory.",
 )
 @click.option(
-    '--source_config', 
-    type=str, 
-    required=True, 
-    help="A JSON dictionary of configuration for the source provider. This is mandatory."
+    "--source_config",
+    type=str,
+    required=True,
+    help="A JSON dictionary of configuration for the source provider. This is mandatory.",
 )
 @click.option(
-    '--destination_provider', 
-    type=str, 
-    default="LRS", 
-    help="Either 'LRS' or an Apache Libcloud provider. The default is 'LRS'."
+    "--destination_provider",
+    type=str,
+    default="LRS",
+    help="Either 'LRS' or an Apache Libcloud provider. The default is 'LRS'.",
 )
 @click.option(
-    '--destination_config', 
-    type=str, 
+    "--destination_config",
+    type=str,
     help=(
         "A JSON dictionary of configuration for the destination provider. "
         "Optional if 'LRS' is used as the destination_provider."
-    )
+    ),
 )
 @click.option(
-    '--transformer_type', 
-    type=click.Choice(['xapi', 'caliper']), 
-    required=True, 
-    help="The type of transformation to perform, either 'xapi' or 'caliper'. This is mandatory."
+    "--transformer_type",
+    type=click.Choice(["xapi", "caliper"]),
+    required=True,
+    help="The type of transformation to perform, either 'xapi' or 'caliper'. This is mandatory.",
 )
 @click.option(
-    '--batch_size', 
-    type=int, 
-    default=10000, 
-    help="The batch size. The default is 10000."
+    "--batch_size",
+    type=int,
+    default=10000,
+    help="The batch size. The default is 10000.",
 )
 @click.option(
-    '--sleep_between_batches_secs', 
-    type=float, 
-    default=10.0, 
-    help="The amount of time (in seconds) to sleep between sending batches. Default is 10.0 seconds."
+    "--sleep_between_batches_secs",
+    type=float,
+    default=10.0,
+    help="The amount of time (in seconds) to sleep between sending batches. Default is 10.0 seconds.",
 )
 @click.option(
-    '--dry_run', 
-    is_flag=True, 
+    "--dry_run",
+    is_flag=True,
     help=(
         "A flag to determine if this is a dry run. If present, all lines from all files "
         "will be attempted to be transformed, but won't be sent to the destination."
-    )
+    ),
 )
 def transform_tracking_logs(**kwargs) -> list[tuple[str, str]]:
     """
@@ -166,9 +166,9 @@ def transform_tracking_logs(**kwargs) -> list[tuple[str, str]]:
     for arg, value in kwargs.items():
         if not value:
             continue
-        if arg == 'dry_run':
+        if arg == "dry_run":
             options.append(f"--{arg}")
-        elif arg == 'source_config' or arg == 'destination_config':
+        elif arg == "source_config" or arg == "destination_config":
             options.append(f"--{arg} '{value}'")
         else:
             options.append(f"--{arg} {value}")
@@ -176,7 +176,7 @@ def transform_tracking_logs(**kwargs) -> list[tuple[str, str]]:
     options_str = " ".join(options)
 
     command = f"./manage.py lms transform_tracking_logs {options_str}"
-    
+
     return [("lms", command)]
 
 


### PR DESCRIPTION
### **Adaptation of _transform_tracking_logs_ Command**

**Description:**

This pull request introduces a series of click options to the transform_tracking_logs command, enhancing its versatility and user-friendliness.

**Objective:**

The primary goal of these additions is to provide a clearer and more structured way for users to interact with the transform_tracking_logs command. By allowing explicit configuration via command-line options, we make the functionality more transparent and easier to customize.

Changes Made:

- Refactored to utilize kwargs, simplifying the command signature.
- Enhanced readability by breaking long input into many @click.option.


**How to Test:**

The command can be tested by running something like this:

```
`tutor k8s do transform-tracking-logs \
    --source_provider LOCAL \
    --source_config '{"key": "/openedx/data/", "container": "logs", "prefix": "tracking.log"}' \
    --destination_provider LRS \
    --transformer_type xapi \
    --batch_size 5000 \
    --sleep_between_batches_secs 5.0 \
    --dry_run`
```