### PR TITLE
fix: add cache wrapper for can_view_courses filter

### DIFF
--- a/tutoraspects/templates/aspects/apps/superset/pythonpath/openedx_sso_security_manager.py
+++ b/tutoraspects/templates/aspects/apps/superset/pythonpath/openedx_sso_security_manager.py
@@ -3,7 +3,7 @@ from collections import namedtuple
 
 import jwt
 from authlib.common.urls import add_params_to_qs, add_params_to_uri
-from flask import current_app, session, request
+from flask import current_app, session
 from superset.security import SupersetSecurityManager
 from superset.utils.memoized import memoized
 

--- a/tutoraspects/templates/aspects/apps/superset/pythonpath/superset_config_docker.py
+++ b/tutoraspects/templates/aspects/apps/superset/pythonpath/superset_config_docker.py
@@ -86,8 +86,15 @@ FEATURE_FLAGS = {
 # Add this custom template processor which returns the list of courses the current user can access
 from openedx_jinja_filters import *
 
+def can_view_courses_wrapper(*args, **kwargs):
+    from superset.utils.cache import memoized_func
+    from superset.extensions import cache_manager
+
+    return memoized_func(key="{username}", cache=cache_manager.cache)(can_view_courses)(*args, **kwargs)
+    
+
 JINJA_CONTEXT_ADDONS = {
-    'can_view_courses': can_view_courses,
+    'can_view_courses': can_view_courses_wrapper,
     {% for filter in SUPERSET_EXTRA_JINJA_FILTERS %}'{{ filter }}': {{filter}},{% endfor %}
 }
 


### PR DESCRIPTION
This PR adds a cache wrapper for the `can_view_courses` function. The cache can be configured using the superset `data_cache`

It also removes the caching for the `get_courses` function such that people will get the latest courses at login.