### PR TITLE
refactor: use course_key index in dashboard queries (FC-0033)

### DIFF
--- a/tutoraspects/templates/openedx-assets/assets/datasets/fact_enrollments.yaml
+++ b/tutoraspects/templates/openedx-assets/assets/datasets/fact_enrollments.yaml
@@ -38,6 +38,18 @@ columns:
   type: String
   verbose_name: null
 - advanced_data_type: null
+  column_name: course_key
+  description: null
+  expression: null
+  extra: null
+  filterable: true
+  groupby: true
+  is_active: true
+  is_dttm: false
+  python_date_format: null
+  type: String
+  verbose_name: null
+- advanced_data_type: null
   column_name: course_name
   description: null
   expression: null

--- a/tutoraspects/templates/openedx-assets/assets/datasets/fact_enrollments.yaml
+++ b/tutoraspects/templates/openedx-assets/assets/datasets/fact_enrollments.yaml
@@ -103,8 +103,8 @@ metrics:
   warning_text: null
 offset: 0
 params: null
-schema: {{ DBT_PROFILE_TARGET_DATABASE }}
-sql: null
+schema: null
+sql: "{% include 'openedx-assets/queries/fact_enrollments.sql' %}"
 table_name: fact_enrollments
 template_params: {}
 uuid: a234545d-08ff-480d-8361-961c3d15f14f

--- a/tutoraspects/templates/openedx-assets/assets/datasets/fact_enrollments_by_day.yaml
+++ b/tutoraspects/templates/openedx-assets/assets/datasets/fact_enrollments_by_day.yaml
@@ -38,6 +38,18 @@ columns:
   type: String
   verbose_name: null
 - advanced_data_type: null
+  column_name: course_key
+  description: null
+  expression: null
+  extra: null
+  filterable: true
+  groupby: true
+  is_active: true
+  is_dttm: false
+  python_date_format: null
+  type: String
+  verbose_name: null
+- advanced_data_type: null
   column_name: course_name
   description: null
   expression: null

--- a/tutoraspects/templates/openedx-assets/assets/datasets/fact_learner_problem_summary.yaml
+++ b/tutoraspects/templates/openedx-assets/assets/datasets/fact_learner_problem_summary.yaml
@@ -127,8 +127,8 @@ metrics:
   warning_text: null
 offset: 0
 params: null
-schema: {{ DBT_PROFILE_TARGET_DATABASE }}
-sql: null
+schema: null
+sql: "{% include 'openedx-assets/queries/fact_learner_problem_summary.sql' %}"
 table_name: fact_learner_problem_summary
 template_params: null
 uuid: 9362354c-1541-43c2-b769-da9818236298

--- a/tutoraspects/templates/openedx-assets/assets/datasets/fact_learner_problem_summary.yaml
+++ b/tutoraspects/templates/openedx-assets/assets/datasets/fact_learner_problem_summary.yaml
@@ -74,6 +74,18 @@ columns:
   type: String
   verbose_name: null
 - advanced_data_type: null
+  column_name: course_key
+  description: null
+  expression: null
+  extra: null
+  filterable: true
+  groupby: true
+  is_active: true
+  is_dttm: false
+  python_date_format: null
+  type: String
+  verbose_name: null
+- advanced_data_type: null
   column_name: course_name
   description: null
   expression: null

--- a/tutoraspects/templates/openedx-assets/assets/datasets/fact_problem_responses.yaml
+++ b/tutoraspects/templates/openedx-assets/assets/datasets/fact_problem_responses.yaml
@@ -127,8 +127,8 @@ metrics:
   warning_text: null
 offset: 0
 params: null
-schema: {{ DBT_PROFILE_TARGET_DATABASE }}
-sql: null
+schema: null
+sql: "{% include 'openedx-assets/queries/fact_problem_responses.sql' %}"
 table_name: fact_problem_responses
 template_params: null
 uuid: 511dd5f1-3925-4e9e-ad8a-a227b5680047

--- a/tutoraspects/templates/openedx-assets/assets/datasets/fact_transcript_usage.yaml
+++ b/tutoraspects/templates/openedx-assets/assets/datasets/fact_transcript_usage.yaml
@@ -92,8 +92,8 @@ metrics:
   warning_text: null
 offset: 0
 params: null
-schema: {{ DBT_PROFILE_TARGET_DATABASE }}
-sql: null
+schema: null
+sql: "{% include 'openedx-assets/queries/fact_transcript_usage.sql' %}"
 table_name: fact_transcript_usage
 template_params: {}
 uuid: a96a4b13-a429-442d-83ca-5d6f94010909

--- a/tutoraspects/templates/openedx-assets/assets/datasets/fact_transcript_usage.yaml
+++ b/tutoraspects/templates/openedx-assets/assets/datasets/fact_transcript_usage.yaml
@@ -26,6 +26,18 @@ columns:
   type: String
   verbose_name: null
 - advanced_data_type: null
+  column_name: course_key
+  description: null
+  expression: null
+  extra: null
+  filterable: true
+  groupby: true
+  is_active: true
+  is_dttm: false
+  python_date_format: null
+  type: String
+  verbose_name: null
+- advanced_data_type: null
   column_name: course_name
   description: null
   expression: null

--- a/tutoraspects/templates/openedx-assets/assets/datasets/fact_video_plays.yaml
+++ b/tutoraspects/templates/openedx-assets/assets/datasets/fact_video_plays.yaml
@@ -26,6 +26,18 @@ columns:
   type: String
   verbose_name: null
 - advanced_data_type: null
+  column_name: course_key
+  description: null
+  expression: null
+  extra: null
+  filterable: true
+  groupby: true
+  is_active: true
+  is_dttm: false
+  python_date_format: null
+  type: String
+  verbose_name: null
+- advanced_data_type: null
   column_name: course_name
   description: null
   expression: null

--- a/tutoraspects/templates/openedx-assets/assets/datasets/fact_video_plays.yaml
+++ b/tutoraspects/templates/openedx-assets/assets/datasets/fact_video_plays.yaml
@@ -92,8 +92,8 @@ metrics:
   warning_text: null
 offset: 0
 params: null
-schema: {{ DBT_PROFILE_TARGET_DATABASE }}
-sql: null
+schema: null
+sql: "{% include 'openedx-assets/queries/fact_video_plays.sql' %}"
 table_name: fact_video_plays
 template_params: {}
 uuid: 6ec360a5-e247-42e7-b301-fa8275fc93f9

--- a/tutoraspects/templates/openedx-assets/assets/datasets/fact_watched_video_segments.yaml
+++ b/tutoraspects/templates/openedx-assets/assets/datasets/fact_watched_video_segments.yaml
@@ -38,6 +38,18 @@ columns:
   type: String
   verbose_name: null
 - advanced_data_type: null
+  column_name: course_key
+  description: null
+  expression: null
+  extra: null
+  filterable: true
+  groupby: true
+  is_active: true
+  is_dttm: false
+  python_date_format: null
+  type: String
+  verbose_name: null
+- advanced_data_type: null
   column_name: course_name
   description: null
   expression: null

--- a/tutoraspects/templates/openedx-assets/assets/datasets/hints_per_success.yaml
+++ b/tutoraspects/templates/openedx-assets/assets/datasets/hints_per_success.yaml
@@ -38,6 +38,18 @@ columns:
   type: String
   verbose_name: null
 - advanced_data_type: null
+  column_name: course_key
+  description: null
+  expression: null
+  extra: null
+  filterable: true
+  groupby: true
+  is_active: true
+  is_dttm: false
+  python_date_format: null
+  type: String
+  verbose_name: null
+- advanced_data_type: null
   column_name: course_name
   description: null
   expression: null

--- a/tutoraspects/templates/openedx-assets/queries/common_filters.sql
+++ b/tutoraspects/templates/openedx-assets/queries/common_filters.sql
@@ -1,0 +1,13 @@
+{% raw -%}
+{% if filter_values('org') != [] %}
+and org in {{ filter_values('org') | where_in }}
+{% endif %}
+
+{% if filter_values('course_name') != [] %}
+and course_key in (
+    select course_key
+    from {% endraw -%}{{ ASPECTS_EVENT_SINK_DATABASE }}.course_names{%- raw %}
+    where course_name in {{ filter_values('course_name') | where_in }}
+)
+{% endif %}
+{%- endraw %}

--- a/tutoraspects/templates/openedx-assets/queries/fact_enrollments.sql
+++ b/tutoraspects/templates/openedx-assets/queries/fact_enrollments.sql
@@ -9,6 +9,7 @@ where
 select
     emission_time,
     org,
+    course_key,
     course_name,
     course_run,
     actor_id,

--- a/tutoraspects/templates/openedx-assets/queries/fact_enrollments.sql
+++ b/tutoraspects/templates/openedx-assets/queries/fact_enrollments.sql
@@ -1,0 +1,17 @@
+with enrollments as (
+select *
+from {{ DBT_PROFILE_TARGET_DATABASE }}.fact_enrollments
+where
+    1=1
+    {% include 'openedx-assets/queries/common_filters.sql' %}
+)
+
+select
+    emission_time,
+    org,
+    course_name,
+    course_run,
+    actor_id,
+    enrollment_mode,
+    enrollment_status
+from enrollments

--- a/tutoraspects/templates/openedx-assets/queries/fact_enrollments_by_day.sql
+++ b/tutoraspects/templates/openedx-assets/queries/fact_enrollments_by_day.sql
@@ -4,6 +4,7 @@ with enrollments as (
   select
     emission_time,
     org,
+    course_key,
     course_name,
     course_run,
     actor_id,
@@ -15,6 +16,7 @@ with enrollments as (
 ), enrollment_windows as (
   select
     org,
+    course_key,
     course_name,
     course_run,
     actor_id,
@@ -29,6 +31,7 @@ with enrollments as (
 ), enrollment_window_dates as (
     select
         org,
+        course_key,
         course_name,
         course_run,
         actor_id,
@@ -49,6 +52,7 @@ select
         )
     )) as enrollment_status_date,
     org,
+    course_key,
     course_name,
     course_run,
     actor_id,

--- a/tutoraspects/templates/openedx-assets/queries/fact_enrollments_by_day.sql
+++ b/tutoraspects/templates/openedx-assets/queries/fact_enrollments_by_day.sql
@@ -1,4 +1,6 @@
-with enrollments_ranked as (
+with enrollments as (
+    {% include 'openedx-assets/queries/fact_enrollments.sql' %}
+), enrollments_ranked as (
   select
     emission_time,
     org,
@@ -9,13 +11,7 @@ with enrollments_ranked as (
     enrollment_status,
     rank() over (partition by date(emission_time), org, course_name, course_run, actor_id order by emission_time desc) as event_rank
   from
-    {{ DBT_PROFILE_TARGET_DATABASE }}.fact_enrollments
-  {% raw -%}
-  {% if filter_values('org') != [] %}
-    where
-      org in {{ filter_values('org') | where_in }}
-  {% endif %}
-  {%- endraw %}
+    enrollments
 ), enrollment_windows as (
   select
     org,

--- a/tutoraspects/templates/openedx-assets/queries/fact_learner_problem_summary.sql
+++ b/tutoraspects/templates/openedx-assets/queries/fact_learner_problem_summary.sql
@@ -1,0 +1,118 @@
+WITH problem_responses AS (
+        {% include 'openedx-assets/queries/fact_problem_responses.sql' %}
+), outcomes AS (
+    SELECT
+        emission_time,
+        org,
+        course_key,
+        problem_id,
+        actor_id,
+        success,
+        first_value(success) OVER (PARTITION BY course_key, problem_id, actor_id ORDER BY success DESC) AS was_successful
+    FROM problem_responses
+), successful_responses AS (
+    SELECT
+        org,
+        course_key,
+        problem_id,
+        actor_id,
+        min(emission_time) AS first_success_at
+    FROM outcomes
+    WHERE was_successful = true and success = true
+    GROUP BY
+        org,
+        course_key,
+        problem_id,
+        actor_id
+), unsuccessful_responses AS (
+    SELECT
+        org,
+        course_key,
+        problem_id,
+        actor_id,
+        max(emission_time) AS last_response_at
+    FROM outcomes
+    WHERE was_successful = false
+    GROUP BY
+        org,
+        course_key,
+        problem_id,
+        actor_id
+), final_responses AS (
+    SELECT
+        org,
+        course_key,
+        problem_id,
+        actor_id,
+        first_success_at AS emission_time
+    FROM successful_responses
+    UNION ALL
+    SELECT
+        org,
+        course_key,
+        problem_id,
+        actor_id,
+        last_response_at AS emission_time
+    FROM unsuccessful_responses
+), int_problem_results AS (
+    SELECT
+        emission_time,
+        org,
+        course_key,
+        course_name,
+        course_run,
+        problem_id,
+        problem_name,
+        actor_id,
+        responses,
+        success,
+        attempts
+    FROM problem_responses
+    INNER JOIN final_responses USING (org, course_key, problem_id, actor_id, emission_time)
+), summary AS (
+    SELECT
+        org,
+        course_key,
+        course_name,
+        course_run,
+        problem_name,
+        actor_id,
+        success,
+        attempts,
+        0 AS num_hints_displayed,
+        0 AS num_answers_displayed
+    FROM int_problem_results
+    UNION ALL
+    SELECT
+        org,
+        course_key,
+        course_name,
+        course_run,
+        problem_name,
+        actor_id,
+        NULL AS success,
+        NULL AS attempts,
+        caseWithExpression(help_type, 'hint', 1, 0) AS num_hints_displayed,
+        caseWithExpression(help_type, 'answer', 1, 0) AS num_answers_displayed
+    FROM {{ DBT_PROFILE_TARGET_DATABASE }}.int_problem_hints
+    WHERE 1=1
+    {% include 'openedx-assets/queries/common_filters.sql' %}
+)
+
+SELECT
+    org,
+    course_name,
+    course_run,
+    problem_name,
+    actor_id,
+    coalesce(any(success), false) AS success,
+    coalesce(any(attempts), 0) AS attempts,
+    sum(num_hints_displayed) AS num_hints_displayed,
+    sum(num_answers_displayed) AS num_answers_displayed
+FROM summary
+GROUP BY
+    org,
+    course_name,
+    course_run,
+    problem_name,
+    actor_id

--- a/tutoraspects/templates/openedx-assets/queries/fact_learner_problem_summary.sql
+++ b/tutoraspects/templates/openedx-assets/queries/fact_learner_problem_summary.sql
@@ -101,6 +101,7 @@ WITH problem_responses AS (
 
 SELECT
     org,
+    course_key,
     course_name,
     course_run,
     problem_name,
@@ -112,6 +113,7 @@ SELECT
 FROM summary
 GROUP BY
     org,
+    course_key,
     course_name,
     course_run,
     problem_name,

--- a/tutoraspects/templates/openedx-assets/queries/fact_problem_responses.sql
+++ b/tutoraspects/templates/openedx-assets/queries/fact_problem_responses.sql
@@ -1,0 +1,22 @@
+with problem_responses as (
+select *
+from {{ DBT_PROFILE_TARGET_DATABASE }}.fact_problem_responses
+where
+    1=1
+    {% include 'openedx-assets/queries/common_filters.sql' %}
+)
+
+select
+    emission_time,
+    org,
+    course_key,
+    course_name,
+    course_run,
+    problem_id,
+    problem_name,
+    actor_id,
+    attempts,
+    success,
+    responses
+from
+    problem_responses

--- a/tutoraspects/templates/openedx-assets/queries/fact_transcript_usage.sql
+++ b/tutoraspects/templates/openedx-assets/queries/fact_transcript_usage.sql
@@ -1,0 +1,16 @@
+with transcripts as (
+select *
+from {{ DBT_PROFILE_TARGET_DATABASE }}.fact_transcript_usage
+where
+    1=1
+    {% include 'openedx-assets/queries/common_filters.sql' %}
+)
+
+select
+    emission_time,
+    org,
+    course_name,
+    course_run,
+    video_name,
+    actor_id
+from transcripts

--- a/tutoraspects/templates/openedx-assets/queries/fact_transcript_usage.sql
+++ b/tutoraspects/templates/openedx-assets/queries/fact_transcript_usage.sql
@@ -9,6 +9,7 @@ where
 select
     emission_time,
     org,
+    course_key,
     course_name,
     course_run,
     video_name,

--- a/tutoraspects/templates/openedx-assets/queries/fact_video_plays.sql
+++ b/tutoraspects/templates/openedx-assets/queries/fact_video_plays.sql
@@ -1,0 +1,16 @@
+with plays as (
+select *
+from {{ DBT_PROFILE_TARGET_DATABASE }}.fact_video_plays
+where
+    1=1
+    {% include 'openedx-assets/queries/common_filters.sql' %}
+)
+
+select
+    emission_time,
+    org,
+    course_name,
+    course_run,
+    video_name,
+    actor_id
+from plays

--- a/tutoraspects/templates/openedx-assets/queries/fact_video_plays.sql
+++ b/tutoraspects/templates/openedx-assets/queries/fact_video_plays.sql
@@ -9,6 +9,7 @@ where
 select
     emission_time,
     org,
+    course_key,
     course_name,
     course_run,
     video_name,

--- a/tutoraspects/templates/openedx-assets/queries/fact_watched_video_segments.sql
+++ b/tutoraspects/templates/openedx-assets/queries/fact_watched_video_segments.sql
@@ -10,11 +10,7 @@ with starts as (
     from {{ ASPECTS_XAPI_DATABASE }}.{{ ASPECTS_VIDEO_PLAYBACK_EVENTS_TABLE }}
     where
         verb_id = 'https://w3id.org/xapi/video/verbs/played'
-        {% raw -%}
-        {% if filter_values('org') != [] %}
-        and org in {{ filter_values('org') | where_in }}
-        {% endif %}
-        {%- endraw %}
+        {% include 'openedx-assets/queries/common_filters.sql' %}
 ), ends as (
     select
         emission_time,
@@ -32,11 +28,7 @@ with starts as (
             'https://w3id.org/xapi/video/verbs/paused',
             'http://adlnet.gov/expapi/verbs/terminated'
         )
-        {% raw -%}
-        {% if filter_values('org') != [] %}
-        and org in {{ filter_values('org') | where_in }}
-        {% endif %}
-        {%- endraw %}
+        {% include 'openedx-assets/queries/common_filters.sql' %}
 ), segments as(
     select
         starts.org as org,

--- a/tutoraspects/templates/openedx-assets/queries/fact_watched_video_segments.sql
+++ b/tutoraspects/templates/openedx-assets/queries/fact_watched_video_segments.sql
@@ -51,6 +51,7 @@ with starts as (
 ), enriched_segments as (
     select
         segments.org as org,
+        courses.course_key as course_key,
         courses.course_name as course_name,
         courses.course_run as course_run,
         blocks.block_name as video_name,
@@ -68,6 +69,7 @@ with starts as (
 
 select
     org,
+    course_key,
     course_name,
     course_run,
     video_name,

--- a/tutoraspects/templates/openedx-assets/queries/hints_per_success.sql
+++ b/tutoraspects/templates/openedx-assets/queries/hints_per_success.sql
@@ -1,3 +1,7 @@
+with summary as (
+    {% include 'openedx-assets/queries/fact_learner_problem_summary.sql' %}
+)
+
 select
     org,
     course_name,
@@ -6,7 +10,7 @@ select
     actor_id,
     sum(num_hints_displayed) + sum(num_answers_displayed) as total_hints
 from
-    {{ DBT_PROFILE_TARGET_DATABASE }}.fact_learner_problem_summary
+    summary
 where success = 1
 group by
     org,

--- a/tutoraspects/templates/openedx-assets/queries/hints_per_success.sql
+++ b/tutoraspects/templates/openedx-assets/queries/hints_per_success.sql
@@ -4,6 +4,7 @@ with summary as (
 
 select
     org,
+    course_key,
     course_name,
     course_run,
     problem_name,
@@ -14,6 +15,7 @@ from
 where success = 1
 group by
     org,
+    course_key,
     course_name,
     course_run,
     problem_name,


### PR DESCRIPTION
This change brings back virtual datasets so that we can use the course name dashboard filter to leverage the index on `course_key` in ClickHouse. There doesn't appear to be a straightforward way to allow users to pick from course names in the dashboard while using the course key in our queries, so virtual datasets are the only way for us to leverage the `course_key` index.

I've run this locally and confirmed that the dashboard results are the same as using the dbt models directly.