### PR TITLE
feat: add RLS filters for dbt models (FC-0033)

### DIFF
--- a/tutoraspects/patches/superset-row-level-security
+++ b/tutoraspects/patches/superset-row-level-security
@@ -6,3 +6,67 @@
     "clause": {% raw %}'{{can_view_courses(current_username(), "splitByChar(\'/\', course_id)[-1]")}}',{% endraw %}
     "filter_type": "Regular",
 },
+{
+  "schema": None,
+  "table_name": "fact_enrollments_by_day",
+  "role_name": "{{SUPERSET_ROLES_MAPPING.instructor}}",
+  "group_key": "{{SUPERSET_ROW_LEVEL_SECURITY_XAPI_GROUP_KEY}}",
+  "clause": {% raw %}'{{can_view_courses(current_username(), "course_key")}}',{% endraw %}
+  "filter_type": "Regular"
+},
+{
+  "schema": None,
+  "table_name": "fact_enrollments",
+  "role_name": "{{SUPERSET_ROLES_MAPPING.instructor}}",
+  "group_key": "{{SUPERSET_ROW_LEVEL_SECURITY_XAPI_GROUP_KEY}}",
+  "clause": {% raw %}'{{can_view_courses(current_username(), "course_key")}}',{% endraw %}
+  "filter_type": "Regular"
+},
+{
+  "schema": None,
+  "table_name": "fact_learner_problem_summary",
+  "role_name": "{{SUPERSET_ROLES_MAPPING.instructor}}",
+  "group_key": "{{SUPERSET_ROW_LEVEL_SECURITY_XAPI_GROUP_KEY}}",
+  "clause": {% raw %}'{{can_view_courses(current_username(), "course_key")}}',{% endraw %}
+  "filter_type": "Regular"
+},
+{
+  "schema": None,
+  "table_name": "fact_problem_responses",
+  "role_name": "{{SUPERSET_ROLES_MAPPING.instructor}}",
+  "group_key": "{{SUPERSET_ROW_LEVEL_SECURITY_XAPI_GROUP_KEY}}",
+  "clause": {% raw %}'{{can_view_courses(current_username(), "course_key")}}',{% endraw %}
+  "filter_type": "Regular"
+},
+{
+  "schema": None,
+  "table_name": "fact_transcript_usage",
+  "role_name": "{{SUPERSET_ROLES_MAPPING.instructor}}",
+  "group_key": "{{SUPERSET_ROW_LEVEL_SECURITY_XAPI_GROUP_KEY}}",
+  "clause": {% raw %}'{{can_view_courses(current_username(), "course_key")}}',{% endraw %}
+  "filter_type": "Regular"
+},
+{
+  "schema": None,
+  "table_name": "fact_video_plays",
+  "role_name": "{{SUPERSET_ROLES_MAPPING.instructor}}",
+  "group_key": "{{SUPERSET_ROW_LEVEL_SECURITY_XAPI_GROUP_KEY}}",
+  "clause": {% raw %}'{{can_view_courses(current_username(), "course_key")}}',{% endraw %}
+  "filter_type": "Regular"
+},
+{
+  "schema": None,
+  "table_name": "fact_watched_video_segments",
+  "role_name": "{{SUPERSET_ROLES_MAPPING.instructor}}",
+  "group_key": "{{SUPERSET_ROW_LEVEL_SECURITY_XAPI_GROUP_KEY}}",
+  "clause": {% raw %}'{{can_view_courses(current_username(), "course_key")}}',{% endraw %}
+  "filter_type": "Regular"
+},
+{
+  "schema": None,
+  "table_name": "hints_per_success",
+  "role_name": "{{SUPERSET_ROLES_MAPPING.instructor}}",
+  "group_key": "{{SUPERSET_ROW_LEVEL_SECURITY_XAPI_GROUP_KEY}}",
+  "clause": {% raw %}'{{can_view_courses(current_username(), "course_key")}}',{% endraw %}
+  "filter_type": "Regular"
+},

--- a/tutoraspects/patches/superset-row-level-security
+++ b/tutoraspects/patches/superset-row-level-security
@@ -70,3 +70,27 @@
   "clause": {% raw %}'{{can_view_courses(current_username(), "course_key")}}',{% endraw %}
   "filter_type": "Regular"
 },
+{
+  "schema": "{{ASPECTS_EVENT_SINK_DATABASE}}",
+  "table_name": "course_names",
+  "role_name": "{{SUPERSET_ROLES_MAPPING.instructor}}",
+  "group_key": "{{SUPERSET_ROW_LEVEL_SECURITY_XAPI_GROUP_KEY}}",
+  "clause": {% raw %}'{{can_view_courses(current_username(), "course_key")}}',{% endraw %}
+  "filter_type": "Regular"
+},
+{
+  "schema": "{{ASPECTS_EVENT_SINK_DATABASE}}",
+  "table_name": "course_overviews",
+  "role_name": "{{SUPERSET_ROLES_MAPPING.instructor}}",
+  "group_key": "{{SUPERSET_ROW_LEVEL_SECURITY_XAPI_GROUP_KEY}}",
+  "clause": {% raw %}'{{can_view_courses(current_username(), "course_key")}}',{% endraw %}
+  "filter_type": "Regular"
+},
+{
+  "schema": "{{ASPECTS_EVENT_SINK_DATABASE}}",
+  "table_name": "course_blocks",
+  "role_name": "{{SUPERSET_ROLES_MAPPING.instructor}}",
+  "group_key": "{{SUPERSET_ROW_LEVEL_SECURITY_XAPI_GROUP_KEY}}",
+  "clause": {% raw %}'{{can_view_courses(current_username(), "course_key")}}',{% endraw %}
+  "filter_type": "Regular"
+},


### PR DESCRIPTION
This adds row-level security filters for datasets created from dbt models by applying the existing `can_view_course` macro. The schema is listed as `None` as that is what appears for the schema attribute when working with the Superset library. I've tested that these policies are created as expected but I am still working on confirming that they are applied when a user has neither the `Admin` nor `Alpha` roles.