### PR TITLE
fix: add option to deduplicate tables after backfill

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -70,9 +70,17 @@ Usage
 
 #. (Optional) Sink Historical event data to ClickHouse::
 
-    tutor [dev|local] run lms ./manage.py lms transform_tracking_logs --source_provider LOCAL --source_config '{"key": "/openedx/data", "container": "logs", "prefix": "tracking.log"}' --transformer_type xapi
+    tutor [dev|local] do transform_tracking_logs \
+      --source_provider LOCAL --source_config '{"key": "/openedx/data", "container": "logs", "prefix": "tracking.log"}' \
+      --transformer_type xapi
+
     # Note that this will work only for default tutor installation. If you store your tracking logs any other way, you need to change the source_config option accordingly.
     # See https://event-routing-backends.readthedocs.io/en/latest/howto/how_to_bulk_transform.html#sources-and-destinations for details on how to change the source_config option.
+
+#. (Optional) Run deduplicate data. This is useful for cases in which you are already have pre-existing data and you want to backfill tracking logs,
+   which can lead to duplicated data. This can take a long time to run::
+
+    tutor [dev|local] do transform_tracking_logs ... --deduplicate
 
 Superset Assets
 ---------------

--- a/tutoraspects/templates/aspects/jobs/init/clickhouse/deduplicate.sh
+++ b/tutoraspects/templates/aspects/jobs/init/clickhouse/deduplicate.sh
@@ -1,0 +1,28 @@
+echo "Initialising Clickhouse..."
+ch_connection_max_attempts=10
+ch_connection_attempt=0
+until clickhouse client --user {{ CLICKHOUSE_ADMIN_USER }} --password="{{ CLICKHOUSE_ADMIN_PASSWORD }}" --host "{{ CLICKHOUSE_HOST }}" {% if CLICKHOUSE_SECURE_CONNECTION %} --secure {% else %} --port {{ CLICKHOUSE_CLIENT_PORT }}{% endif %} -q 'exit'
+do
+    ch_connection_attempt=$(expr $ch_connection_attempt + 1)
+    echo "    [$ch_connection_attempt/$ch_connection_max_attempts] Waiting for Clickhouse service (this may take a while)..."
+    if [ $ch_connection_attempt -eq $ch_connection_max_attempts ]
+    then
+      echo "Clickhouse initialisation error" 1>&2
+      exit 1
+    fi
+    sleep 10
+done
+echo "Clickhouse is up and running"
+
+echo "Running deduplication script..."
+
+clickhouse client --user "{{ CLICKHOUSE_ADMIN_USER }}" --password="{{ CLICKHOUSE_ADMIN_PASSWORD }}" --host "{{ CLICKHOUSE_HOST }}" {% if CLICKHOUSE_SECURE_CONNECTION %} --secure {% else %} --port {{ CLICKHOUSE_CLIENT_PORT }}{% endif %} --multiquery <<'EOF'
+-- Optimize final
+OPTIMIZE TABLE {{ASPECTS_XAPI_DATABASE}}.{{ASPECTS_RAW_XAPI_TABLE}} FINAL;
+OPTIMIZE TABLE {{ASPECTS_XAPI_DATABASE}}.{{ASPECTS_ENROLLMENT_EVENTS_TABLE}} FINAL;
+OPTIMIZE TABLE {{ASPECTS_XAPI_DATABASE}}.{{ASPECTS_XAPI_TABLE}} FINAL;
+OPTIMIZE TABLE {{ASPECTS_XAPI_DATABASE}}.{{ASPECTS_NAVIGATION_EVENTS_TABLE}} FINAL;
+OPTIMIZE TABLE {{ASPECTS_XAPI_DATABASE}}.{{ASPECTS_PROBLEM_EVENTS_TABLE}} FINAL;
+OPTIMIZE TABLE {{ASPECTS_XAPI_DATABASE}}.{{ASPECTS_VIDEO_PLAYBACK_EVENTS_TABLE}} FINAL;
+
+EOF


### PR DESCRIPTION
## Description

This PR adds a `deduplicate` option for the `transform_tracking_log` command that will run the `OPTIMIZE table FINAL` for every table that needs it.

Fixes #300 