### PR TITLE
feat: include language code in translated asset name (FC-0033)

### DIFF
--- a/tutoraspects/templates/aspects/apps/superset/pythonpath/create_assets.py
+++ b/tutoraspects/templates/aspects/apps/superset/pythonpath/create_assets.py
@@ -249,10 +249,11 @@ def update_dashboard_roles(roles):
 
 def get_translation(text, language):
     """Get a translation for a text in a language"""
+    default_text = f"{text} - {language}"
     LANGUAGE = ASSETS_TRANSLATIONS.get(language, {})
     if not LANGUAGE:
-        return text
-    return ASSETS_TRANSLATIONS.get(language, {}).get(text) or text
+        return default_text
+    return ASSETS_TRANSLATIONS.get(language, {}).get(text) or default_text
 
 
 if __name__ == "__main__":

--- a/tutoraspects/templates/openedx-assets/assets/dashboards/Instructor_dashboard.yaml
+++ b/tutoraspects/templates/openedx-assets/assets/dashboards/Instructor_dashboard.yaml
@@ -1,6 +1,4 @@
 _file_name: Instructor_dashboard.yaml
-_roles:
-  - {{ SUPERSET_ROLES_MAPPING.instructor }}
 css: ''
 dashboard_title: Instructor dashboard
 description: null
@@ -185,8 +183,8 @@ metadata:
     - 46
     - 47
     controlValues:
-      defaultToFirstItem: true
-      enableEmptyFilter: true
+      defaultToFirstItem: false
+      enableEmptyFilter: false
       inverseSelection: false
       multiSelect: false
       searchAllOptions: false
@@ -198,7 +196,6 @@ metadata:
     filterType: filter_select
     id: NATIVE_FILTER-6xfFY5VGz
     name: Problem name
-    requiredFirst: true
     scope:
       excluded: []
       rootPath:
@@ -216,8 +213,8 @@ metadata:
     - NATIVE_FILTER-E6-vOpjZv
     chartsInScope: []
     controlValues:
-      defaultToFirstItem: true
-      enableEmptyFilter: true
+      defaultToFirstItem: false
+      enableEmptyFilter: false
       inverseSelection: false
       multiSelect: false
       searchAllOptions: false
@@ -229,7 +226,6 @@ metadata:
     filterType: filter_select
     id: NATIVE_FILTER-V77Ybaw2w
     name: Video name
-    requiredFirst: true
     scope:
       excluded: []
       rootPath:

--- a/tutoraspects/templates/openedx-assets/assets/dashboards/Instructor_dashboard.yaml
+++ b/tutoraspects/templates/openedx-assets/assets/dashboards/Instructor_dashboard.yaml
@@ -1,4 +1,6 @@
 _file_name: Instructor_dashboard.yaml
+_roles:
+  - {{ SUPERSET_ROLES_MAPPING.instructor }}
 css: ''
 dashboard_title: Instructor dashboard
 description: null
@@ -183,8 +185,8 @@ metadata:
     - 46
     - 47
     controlValues:
-      defaultToFirstItem: false
-      enableEmptyFilter: false
+      defaultToFirstItem: true
+      enableEmptyFilter: true
       inverseSelection: false
       multiSelect: false
       searchAllOptions: false
@@ -196,6 +198,7 @@ metadata:
     filterType: filter_select
     id: NATIVE_FILTER-6xfFY5VGz
     name: Problem name
+    requiredFirst: true
     scope:
       excluded: []
       rootPath:
@@ -213,8 +216,8 @@ metadata:
     - NATIVE_FILTER-E6-vOpjZv
     chartsInScope: []
     controlValues:
-      defaultToFirstItem: false
-      enableEmptyFilter: false
+      defaultToFirstItem: true
+      enableEmptyFilter: true
       inverseSelection: false
       multiSelect: false
       searchAllOptions: false
@@ -226,6 +229,7 @@ metadata:
     filterType: filter_select
     id: NATIVE_FILTER-V77Ybaw2w
     name: Video name
+    requiredFirst: true
     scope:
       excluded: []
       rootPath:


### PR DESCRIPTION
This change includes the language code in the default text of a translated asset. This would make it easier to identify the canonical version of assets, such as the instructor dashboard, that should be modified and exported when making changes.