### PR TITLE
fix: remove unused dbt overrides

### DIFF
--- a/tutoraspects/plugin.py
+++ b/tutoraspects/plugin.py
@@ -259,7 +259,6 @@ hooks.Filters.CONFIG_DEFAULTS.add_items(
         ("DBT_PROFILE_SYNC_REQUEST_TIMEOUT", "5"),
         # Compression block size if compression is enabled, this is the default value
         ("DBT_PROFILE_COMPRESS_BLOCK_SIZE", "1048576"),
-        ("DBT_ENABLE_OVERRIDE", False),
     ]
 )
 

--- a/tutoraspects/templates/aspects/apps/aspects/scripts/dbt.sh
+++ b/tutoraspects/templates/aspects/apps/aspects/scripts/dbt.sh
@@ -15,16 +15,12 @@ git clone -b {{ DBT_BRANCH }} {{ DBT_REPOSITORY }}
 
 cd {{ DBT_REPOSITORY_PATH }} || exit
 
-{% if DBT_ENABLE_OVERRIDE %}
-cat /app/aspects/dbt/packages.yml > packages.yml
-cat /app/aspects/dbt/dbt_project.yml > dbt_project.yml
-{% endif %}
+export ASPECTS_EVENT_SINK_DATABASE={{ASPECTS_EVENT_SINK_DATABASE}}
 
 echo "Installing dbt dependencies"
 dbt deps --profiles-dir /app/aspects/dbt/
 
 echo "Running dbt $*"
-export ASPECTS_EVENT_SINK_DATABASE={{ASPECTS_EVENT_SINK_DATABASE}}
 dbt "$@" --profiles-dir /app/aspects/dbt/
 
 rm -rf {{ DBT_REPOSITORY_PATH }}

--- a/tutoraspects/templates/aspects/jobs/init/aspects/init-aspects.sh
+++ b/tutoraspects/templates/aspects/jobs/init/aspects/init-aspects.sh
@@ -16,17 +16,13 @@ echo "Installing dbt packages..."
 
 pip install -r /app/aspects/dbt/requirements.txt
 
-rm -rf aspects-dbt
+rm -rf {{ DBT_REPOSITORY_PATH }}
 
 echo "Installing aspects-dbt"
+echo "git clone -b {{ DBT_BRANCH }} {{ DBT_REPOSITORY }}"
 git clone -b {{ DBT_BRANCH }} {{ DBT_REPOSITORY }}
 
 cd {{ DBT_REPOSITORY_PATH }} || exit
-
-{% if DBT_ENABLE_OVERRIDE %}
-cat /app/aspects/dbt/packages.yml > packages.yml
-cat /app/aspects/dbt/dbt_project.yml > dbt_project.yml
-{% endif %}
 
 export ASPECTS_EVENT_SINK_DATABASE={{ASPECTS_EVENT_SINK_DATABASE}}
 


### PR DESCRIPTION
## Description

This PR removes the current implementation of dbt overrides in favor of patterns like the one implemented in the following PR: https://github.com/eduNEXT/dbt-aspects-unidigital/pull/1

This is a pattern that is more maintainable in the long run. An example of this implementation can be found here: https://github.com/eduNEXT/tutor-contrib-aspects-unidigital/pull/5
