### PR TITLE
feat: upgrade event-routing-backends to 5.6.0

### DIFF
--- a/tutoraspects/plugin.py
+++ b/tutoraspects/plugin.py
@@ -46,7 +46,7 @@ hooks.Filters.CONFIG_DEFAULTS.add_items(
             "OPENEDX_EXTRA_PIP_REQUIREMENTS",
             [
                 "openedx-event-sink-clickhouse==0.1.1",
-                "edx-event-routing-backends==5.5.5",
+                "edx-event-routing-backends==5.6.0",
             ],
         ),
         # ClickHouse xAPI settings


### PR DESCRIPTION
This PR upgrades `event-routing-backends` to 5.6.0