### PR TITLE
feat: add top-level MV for grading events (FC-0033)

### DIFF
--- a/tutoraspects/plugin.py
+++ b/tutoraspects/plugin.py
@@ -64,6 +64,8 @@ hooks.Filters.CONFIG_DEFAULTS.add_items(
         ("ASPECTS_PROBLEM_EVENTS_TABLE", "problem_events"),
         ("ASPECTS_NAVIGATION_TRANSFORM_MV", "navigation_events_mv"),
         ("ASPECTS_NAVIGATION_EVENTS_TABLE", "navigation_events"),
+        ("ASPECTS_GRADING_TRANSFORM_MV", "grading_events_mv"),
+        ("ASPECTS_GRADING_EVENTS_TABLE", "grading_events"),
         # ClickHouse event sink settings
         ("ASPECTS_EVENT_SINK_DATABASE", "event_sink"),
         ("ASPECTS_EVENT_SINK_NODES_TABLE", "course_blocks"),

--- a/tutoraspects/templates/aspects/apps/aspects/migrations/alembic/versions/0018_grading_events_mv.py
+++ b/tutoraspects/templates/aspects/apps/aspects/migrations/alembic/versions/0018_grading_events_mv.py
@@ -1,0 +1,61 @@
+"""
+create a top-level materialized view for grading events
+"""
+from alembic import op
+
+
+revision = "0018"
+down_revision = "0017"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.execute(
+        """
+        CREATE TABLE IF NOT EXISTS {{ ASPECTS_XAPI_DATABASE }}.{{ ASPECTS_GRADING_EVENTS_TABLE }} (
+            `event_id` UUID NOT NULL,
+            `emission_time` DateTime64 NOT NULL,
+            `actor_id` String NOT NULL,
+            `object_id` String NOT NULL,
+            `course_key` String NOT NULL,
+            `org` String NOT NULL,
+            `verb_id` LowCardinality(String) NOT NULL,
+            `scaled_score` String
+        ) ENGINE = ReplacingMergeTree
+        PRIMARY KEY (org, course_key, verb_id)
+        ORDER BY (org, course_key, verb_id, emission_time, actor_id, object_id, scaled_score, event_id);
+        """
+    )
+
+    op.execute(
+        """
+        CREATE MATERIALIZED VIEW IF NOT EXISTS {{ ASPECTS_XAPI_DATABASE }}.{{ ASPECTS_GRADING_TRANSFORM_MV }}
+        TO {{ ASPECTS_XAPI_DATABASE }}.{{ ASPECTS_GRADING_EVENTS_TABLE }} AS
+        SELECT
+            event_id,
+            cast(emission_time as DateTime) as emission_time,
+            actor_id,
+            object_id,
+            splitByString('/', course_id)[-1] AS course_key,
+            org,
+            verb_id,
+            JSON_VALUE(event_str, '$.result.score.scaled') as scaled_score
+        FROM
+            {{ ASPECTS_XAPI_DATABASE }}.{{ ASPECTS_XAPI_TABLE }}
+        WHERE
+            verb_id in (
+                'http://id.tincanapi.com/verb/earned',
+                'https://w3id.org/xapi/acrossx/verbs/evaluated'
+            );
+        """
+    )
+
+
+def downgrade():
+    op.execute(
+        "DROP TABLE IF EXISTS {{ ASPECTS_XAPI_DATABASE }}.{{ ASPECTS_GRADING_EVENTS_TABLE }}"
+    )
+    op.execute(
+        "DROP VIEW IF EXISTS {{ ASPECTS_XAPI_DATABASE }}.{{ ASPECTS_GRADING_TRANSFORM_MV }}"
+    )


### PR DESCRIPTION
This adds a top-level materialized view for grading events. This includes course, subsection, and problem grades. Please note that the problem grading events are also included in the `problem_events` materialized view. However, it feels more appropriate to create a new MV and duplicate these events than to try and fit the grading events into the problem interaction MV or include the problem interaction models whenever we want to do analyses on grades.