### PR TITLE
feat: limit data returned when filters are absent (FC-0033)

### DIFF
--- a/tutoraspects/templates/openedx-assets/assets/charts/Grade_distribution_courses.yaml
+++ b/tutoraspects/templates/openedx-assets/assets/charts/Grade_distribution_courses.yaml
@@ -24,7 +24,7 @@ params:
     - null
     - null
   y_axis_format: SMART_NUMBER
-slice_name: Grade distribution - courses
+slice_name: Grade distribution - course
 uuid: f9adbc85-1f50-4c04-ace3-31ba7390de5e
 version: 1.0.0
 viz_type: dist_bar

--- a/tutoraspects/templates/openedx-assets/assets/charts/Grade_distribution_problems.yaml
+++ b/tutoraspects/templates/openedx-assets/assets/charts/Grade_distribution_problems.yaml
@@ -24,7 +24,7 @@ params:
     - null
     - null
   y_axis_format: SMART_NUMBER
-slice_name: Grade distribution - problems
+slice_name: Grade distribution - problem
 uuid: 4f7e3606-f5de-4643-97c0-bbb6340a3df2
 version: 1.0.0
 viz_type: dist_bar

--- a/tutoraspects/templates/openedx-assets/assets/charts/Problem_submission_counts.yaml
+++ b/tutoraspects/templates/openedx-assets/assets/charts/Problem_submission_counts.yaml
@@ -1,6 +1,6 @@
 _file_name: Problem_submission_counts.yaml
 cache_timeout: null
-dataset_uuid: 9362354c-1541-43c2-b769-da9818236298
+dataset_uuid: 981f30d9-b2f0-4a0b-9e95-0ee0e06db806
 params:
   adhoc_filters: []
   bar_stacked: true
@@ -8,7 +8,7 @@ params:
   color_scheme: supersetColors
   columns:
   - success
-  datasource: 43__table
+  datasource: 56__table
   extra_form_data: {}
   groupby:
   - problem_name
@@ -41,7 +41,7 @@ params:
   rich_tooltip: true
   row_limit: 10000
   show_legend: true
-  slice_id: '38'
+  slice_id: 48
   time_range: No filter
   viz_type: dist_bar
   x_ticks_layout: auto
@@ -50,6 +50,6 @@ params:
   - null
   y_axis_format: SMART_NUMBER
 slice_name: Problem submission counts
-uuid: 3dc6a642-a71d-4c8c-ab98-14f54852b40f
+uuid: a3e79162-4ace-4349-ab34-89aa60ae75ed
 version: 1.0.0
 viz_type: dist_bar

--- a/tutoraspects/templates/openedx-assets/assets/dashboards/Instructor_dashboard.yaml
+++ b/tutoraspects/templates/openedx-assets/assets/dashboards/Instructor_dashboard.yaml
@@ -247,7 +247,6 @@ metadata:
     type: NATIVE_FILTER
   refresh_frequency: 0
   shared_label_colors:
-    'True': '#1FA8C9'
     audit: '#1FA8C9'
     registered: '#1FA8C9'
   show_native_filters: true
@@ -313,6 +312,21 @@ position:
     - TAB-CLiLC4zxo
     - ROW-lN_IXnlUhL
     type: CHART
+  CHART-RTO33WE9FH:
+    children: []
+    id: CHART-RTO33WE9FH
+    meta:
+      chartId: 894
+      height: 50
+      sliceName: Problem submission counts
+      uuid: a3e79162-4ace-4349-ab34-89aa60ae75ed
+      width: 12
+    parents:
+    - ROOT_ID
+    - TABS-SNeKAJcjhd
+    - TAB-NR4UTAs9K
+    - ROW-87X0ypdHH_
+    type: CHART
   CHART-Tej2oLPBAl:
     children: []
     id: CHART-Tej2oLPBAl
@@ -364,7 +378,7 @@ position:
     meta:
       chartId: 865
       height: 50
-      sliceName: Grade distribution - problems
+      sliceName: Grade distribution - problem
       uuid: 4f7e3606-f5de-4643-97c0-bbb6340a3df2
       width: 6
     parents:
@@ -388,21 +402,6 @@ position:
     - TAB-8BxDuJd9Jb
     - ROW-K8s_8uq9IP
     type: CHART
-  CHART-s8sC81tP9u:
-    children: []
-    id: CHART-s8sC81tP9u
-    meta:
-      chartId: 48
-      height: 48
-      sliceName: Problem submission counts
-      uuid: 3dc6a642-a71d-4c8c-ab98-14f54852b40f
-      width: 12
-    parents:
-    - ROOT_ID
-    - TABS-SNeKAJcjhd
-    - TAB-NR4UTAs9K
-    - ROW-_qzhG9fM3z
-    type: CHART
   CHART-tWnaoVNNTH:
     children: []
     id: CHART-tWnaoVNNTH
@@ -424,7 +423,7 @@ position:
     meta:
       chartId: 879
       height: 50
-      sliceName: Grade distribution - courses
+      sliceName: Grade distribution - course
       uuid: f9adbc85-1f50-4c04-ace3-31ba7390de5e
       width: 12
     parents:
@@ -471,6 +470,17 @@ position:
     - TABS-SNeKAJcjhd
     id: ROOT_ID
     type: ROOT
+  ROW-87X0ypdHH_:
+    children:
+    - CHART-RTO33WE9FH
+    id: ROW-87X0ypdHH_
+    meta:
+      background: BACKGROUND_TRANSPARENT
+    parents:
+    - ROOT_ID
+    - TABS-SNeKAJcjhd
+    - TAB-NR4UTAs9K
+    type: ROW
   ROW-AG2xAOM044:
     children:
     - CHART-w-k4N2T_L8
@@ -516,17 +526,6 @@ position:
     - ROOT_ID
     - TABS-SNeKAJcjhd
     - TAB-8BxDuJd9Jb
-    type: ROW
-  ROW-_qzhG9fM3z:
-    children:
-    - CHART-s8sC81tP9u
-    id: ROW-_qzhG9fM3z
-    meta:
-      background: BACKGROUND_TRANSPARENT
-    parents:
-    - ROOT_ID
-    - TABS-SNeKAJcjhd
-    - TAB-NR4UTAs9K
     type: ROW
   ROW-je_Wqya3Ga:
     children:
@@ -603,7 +602,7 @@ position:
   TAB-NR4UTAs9K:
     children:
     - HEADER-v9QDHi2Dxm
-    - ROW-_qzhG9fM3z
+    - ROW-87X0ypdHH_
     - ROW-AG2xAOM044
     - DIVIDER-G6rO0La8YT
     id: TAB-NR4UTAs9K

--- a/tutoraspects/templates/openedx-assets/assets/dashboards/Instructor_dashboard.yaml
+++ b/tutoraspects/templates/openedx-assets/assets/dashboards/Instructor_dashboard.yaml
@@ -25,6 +25,8 @@ metadata:
     - 47
     - 48
     - 52
+    - 865
+    - 879
     controlValues:
       enableEmptyFilter: false
     defaultDataMask:
@@ -186,9 +188,10 @@ metadata:
     - 45
     - 46
     - 47
+    - 865
     controlValues:
-      defaultToFirstItem: true
-      enableEmptyFilter: true
+      defaultToFirstItem: false
+      enableEmptyFilter: false
       inverseSelection: false
       multiSelect: false
       searchAllOptions: false
@@ -200,7 +203,6 @@ metadata:
     filterType: filter_select
     id: NATIVE_FILTER-6xfFY5VGz
     name: Problem name
-    requiredFirst: true
     scope:
       excluded: []
       rootPath:
@@ -216,10 +218,11 @@ metadata:
     - NATIVE_FILTER-Vx7HxG8_7
     - NATIVE_FILTER-XPuiTOej4
     - NATIVE_FILTER-E6-vOpjZv
-    chartsInScope: []
+    chartsInScope:
+    - 52
     controlValues:
-      defaultToFirstItem: true
-      enableEmptyFilter: true
+      defaultToFirstItem: false
+      enableEmptyFilter: false
       inverseSelection: false
       multiSelect: false
       searchAllOptions: false
@@ -231,12 +234,12 @@ metadata:
     filterType: filter_select
     id: NATIVE_FILTER-V77Ybaw2w
     name: Video name
-    requiredFirst: true
     scope:
       excluded: []
       rootPath:
       - TAB-CLiLC4zxo
-    tabsInScope: []
+    tabsInScope:
+    - TAB-CLiLC4zxo
     targets:
     - column:
         name: video_name

--- a/tutoraspects/templates/openedx-assets/assets/datasets/fact_learner_problem_course_summary.yaml
+++ b/tutoraspects/templates/openedx-assets/assets/datasets/fact_learner_problem_course_summary.yaml
@@ -1,0 +1,147 @@
+_file_name: fact_learner_problem_course_summary.yaml
+cache_timeout: null
+columns:
+  - advanced_data_type: null
+    column_name: attempts
+    description: null
+    expression: null
+    extra: null
+    filterable: true
+    groupby: true
+    is_active: true
+    is_dttm: false
+    python_date_format: null
+    type: Int16
+    verbose_name: null
+  - advanced_data_type: null
+    column_name: num_answers_displayed
+    description: null
+    expression: null
+    extra: null
+    filterable: true
+    groupby: true
+    is_active: true
+    is_dttm: false
+    python_date_format: null
+    type: UInt64
+    verbose_name: null
+  - advanced_data_type: null
+    column_name: num_hints_displayed
+    description: null
+    expression: null
+    extra: null
+    filterable: true
+    groupby: true
+    is_active: true
+    is_dttm: false
+    python_date_format: null
+    type: UInt64
+    verbose_name: null
+  - advanced_data_type: null
+    column_name: success
+    description: null
+    expression: null
+    extra: null
+    filterable: true
+    groupby: true
+    is_active: true
+    is_dttm: false
+    python_date_format: null
+    type: Bool
+    verbose_name: null
+  - advanced_data_type: null
+    column_name: problem_name
+    description: null
+    expression: null
+    extra: null
+    filterable: true
+    groupby: true
+    is_active: true
+    is_dttm: false
+    python_date_format: null
+    type: String
+    verbose_name: null
+  - advanced_data_type: null
+    column_name: actor_id
+    description: null
+    expression: null
+    extra: null
+    filterable: true
+    groupby: true
+    is_active: true
+    is_dttm: false
+    python_date_format: null
+    type: String
+    verbose_name: null
+  - advanced_data_type: null
+    column_name: course_name
+    description: null
+    expression: null
+    extra: null
+    filterable: true
+    groupby: true
+    is_active: true
+    is_dttm: false
+    python_date_format: null
+    type: String
+    verbose_name: null
+  - advanced_data_type: null
+    column_name: course_key
+    description: null
+    expression: null
+    extra: null
+    filterable: true
+    groupby: true
+    is_active: true
+    is_dttm: false
+    python_date_format: null
+    type: String
+    verbose_name: null
+  - advanced_data_type: null
+    column_name: course_run
+    description: null
+    expression: null
+    extra: null
+    filterable: true
+    groupby: true
+    is_active: true
+    is_dttm: false
+    python_date_format: null
+    type: String
+    verbose_name: null
+  - advanced_data_type: null
+    column_name: org
+    description: null
+    expression: null
+    extra: null
+    filterable: true
+    groupby: true
+    is_active: true
+    is_dttm: false
+    python_date_format: null
+    type: String
+    verbose_name: null
+database_uuid: 21174b6c-4d40-4958-8161-d6c3cf5e77b6
+default_endpoint: null
+description: null
+extra: null
+fetch_values_predicate: null
+filter_select_enabled: false
+main_dttm_col: null
+metrics:
+  - d3format: null
+    description: null
+    expression: count(*)
+    extra: null
+    metric_name: count
+    metric_type: null
+    verbose_name: null
+    warning_text: null
+offset: 0
+params: null
+schema: null
+sql: "{% include 'openedx-assets/queries/fact_learner_problem_course_summary.sql' %}"
+table_name: fact_learner_problem_course_summary
+template_params: null
+uuid: 981f30d9-b2f0-4a0b-9e95-0ee0e06db806
+version: 1.0.0

--- a/tutoraspects/templates/openedx-assets/queries/fact_course_grades.sql
+++ b/tutoraspects/templates/openedx-assets/queries/fact_course_grades.sql
@@ -2,6 +2,13 @@ with grades as (
     select *
     from {{ DBT_PROFILE_TARGET_DATABASE }}.fact_grades
     where grade_type = 'course'
+    {% raw %}
+    {% if filter_values('course_name') != [] %}
+    and entity_name in {{ filter_values('course_name', remove_filter=True) | where_in }}
+    {% else %}
+    and 0=1
+    {% endif %}
+    {% endraw %}
     {% include 'openedx-assets/queries/common_filters.sql' %}
 ),
 most_recent_grades as (
@@ -35,11 +42,3 @@ from
     grades
     join most_recent_grades
         using (org, course_key, entity_id, actor_id, emission_time)
-where
-    {% raw %}
-    {% if filter_values('course_name') != [] %}
-    entity_name in {{ filter_values('course_name', remove_filter=True) | where_in }}
-    {% else %}
-    entity_name in ('')
-    {% endif %}
-    {% endraw %}

--- a/tutoraspects/templates/openedx-assets/queries/fact_learner_problem_course_summary.sql
+++ b/tutoraspects/templates/openedx-assets/queries/fact_learner_problem_course_summary.sql
@@ -95,8 +95,7 @@ WITH problem_responses AS (
         caseWithExpression(help_type, 'hint', 1, 0) AS num_hints_displayed,
         caseWithExpression(help_type, 'answer', 1, 0) AS num_answers_displayed
     FROM {{ DBT_PROFILE_TARGET_DATABASE }}.int_problem_hints
-    WHERE
-    1=1
+    WHERE 1=1
     {% include 'openedx-assets/queries/common_filters.sql' %}
 )
 
@@ -112,10 +111,10 @@ SELECT
     sum(num_hints_displayed) AS num_hints_displayed,
     sum(num_answers_displayed) AS num_answers_displayed
 FROM summary
-where
+WHERE
     {% raw %}
-    {% if filter_values('problem_name') != [] %}
-    problem_name in {{ filter_values('problem_name') | where_in }}
+    {% if filter_values('course_name') != [] %}
+    course_name in {{ filter_values('course_name') | where_in }}
     {% else %}
     1=0
     {% endif %}

--- a/tutoraspects/templates/openedx-assets/queries/fact_learner_problem_summary.sql
+++ b/tutoraspects/templates/openedx-assets/queries/fact_learner_problem_summary.sql
@@ -95,7 +95,14 @@ WITH problem_responses AS (
         caseWithExpression(help_type, 'hint', 1, 0) AS num_hints_displayed,
         caseWithExpression(help_type, 'answer', 1, 0) AS num_answers_displayed
     FROM {{ DBT_PROFILE_TARGET_DATABASE }}.int_problem_hints
-    WHERE 1=1
+    WHERE
+    {% raw %}
+    {% if filter_values('problem_name') != [] %}
+    problem_name in {{ filter_values('problem_name') | where_in }}
+    {% else %}
+    1=0
+    {% endif %}
+    {% endraw %}
     {% include 'openedx-assets/queries/common_filters.sql' %}
 )
 

--- a/tutoraspects/templates/openedx-assets/queries/fact_problem_responses.sql
+++ b/tutoraspects/templates/openedx-assets/queries/fact_problem_responses.sql
@@ -1,15 +1,5 @@
 with problem_responses as (
-select *
-from {{ DBT_PROFILE_TARGET_DATABASE }}.fact_problem_responses
-where
-    {% raw %}
-    {% if filter_values('problem_name') != [] %}
-    problem_name in {{ filter_values('problem_name') | where_in }}
-    {% else %}
-    1=0
-    {% endif %}
-    {% endraw %}
-    {% include 'openedx-assets/queries/common_filters.sql' %}
+    {% include 'openedx-assets/queries/int_problem_responses.sql' %}
 )
 
 select
@@ -26,3 +16,11 @@ select
     responses
 from
     problem_responses
+where
+    {% raw %}
+    {% if filter_values('problem_name') != [] %}
+    problem_name in {{ filter_values('problem_name') | where_in }}
+    {% else %}
+    1=0
+    {% endif %}
+    {% endraw %}

--- a/tutoraspects/templates/openedx-assets/queries/fact_problem_responses.sql
+++ b/tutoraspects/templates/openedx-assets/queries/fact_problem_responses.sql
@@ -2,7 +2,13 @@ with problem_responses as (
 select *
 from {{ DBT_PROFILE_TARGET_DATABASE }}.fact_problem_responses
 where
-    1=1
+    {% raw %}
+    {% if filter_values('problem_name') != [] %}
+    problem_name in {{ filter_values('problem_name') | where_in }}
+    {% else %}
+    1=0
+    {% endif %}
+    {% endraw %}
     {% include 'openedx-assets/queries/common_filters.sql' %}
 )
 

--- a/tutoraspects/templates/openedx-assets/queries/fact_transcript_usage.sql
+++ b/tutoraspects/templates/openedx-assets/queries/fact_transcript_usage.sql
@@ -3,8 +3,8 @@ select *
 from {{ DBT_PROFILE_TARGET_DATABASE }}.fact_transcript_usage
 where
     {% raw %}
-    {% if filter_values('video_name') != [] %}
-    video_name in {{ filter_values('video_name', remove_filter=True) | where_in }}
+    {% if filter_values('course_name') != [] %}
+    course_name in {{ filter_values('course_name') | where_in }}
     {% else %}
     0=1
     {% endif %}

--- a/tutoraspects/templates/openedx-assets/queries/fact_transcript_usage.sql
+++ b/tutoraspects/templates/openedx-assets/queries/fact_transcript_usage.sql
@@ -2,7 +2,13 @@ with transcripts as (
 select *
 from {{ DBT_PROFILE_TARGET_DATABASE }}.fact_transcript_usage
 where
-    1=1
+    {% raw %}
+    {% if filter_values('video_name') != [] %}
+    video_name in {{ filter_values('video_name', remove_filter=True) | where_in }}
+    {% else %}
+    0=1
+    {% endif %}
+    {% endraw %}
     {% include 'openedx-assets/queries/common_filters.sql' %}
 )
 

--- a/tutoraspects/templates/openedx-assets/queries/fact_video_plays.sql
+++ b/tutoraspects/templates/openedx-assets/queries/fact_video_plays.sql
@@ -3,8 +3,8 @@ select *
 from {{ DBT_PROFILE_TARGET_DATABASE }}.fact_video_plays
 where
     {% raw %}
-    {% if filter_values('video_name') != [] %}
-    video_name in {{ filter_values('video_name') | where_in }}
+    {% if filter_values('course_name') != [] %}
+    course_name in {{ filter_values('course_name') | where_in }}
     {% else %}
     1=0
     {% endif %}

--- a/tutoraspects/templates/openedx-assets/queries/fact_video_plays.sql
+++ b/tutoraspects/templates/openedx-assets/queries/fact_video_plays.sql
@@ -2,7 +2,13 @@ with plays as (
 select *
 from {{ DBT_PROFILE_TARGET_DATABASE }}.fact_video_plays
 where
-    1=1
+    {% raw %}
+    {% if filter_values('video_name') != [] %}
+    video_name in {{ filter_values('video_name') | where_in }}
+    {% else %}
+    1=0
+    {% endif %}
+    {% endraw %}
     {% include 'openedx-assets/queries/common_filters.sql' %}
 )
 

--- a/tutoraspects/templates/openedx-assets/queries/fact_watched_video_segments.sql
+++ b/tutoraspects/templates/openedx-assets/queries/fact_watched_video_segments.sql
@@ -1,5 +1,6 @@
 with video_events as (
-    emission_time,
+    select
+        emission_time,
         org,
         course_key,
         splitByString('/xblock/', object_id)[-1] as video_id,

--- a/tutoraspects/templates/openedx-assets/queries/int_problem_responses.sql
+++ b/tutoraspects/templates/openedx-assets/queries/int_problem_responses.sql
@@ -1,0 +1,21 @@
+with problem_responses as (
+select *
+from {{ DBT_PROFILE_TARGET_DATABASE }}.fact_problem_responses
+where 1=1
+    {% include 'openedx-assets/queries/common_filters.sql' %}
+)
+
+select
+    emission_time,
+    org,
+    course_key,
+    course_name,
+    course_run,
+    problem_id,
+    problem_name,
+    actor_id,
+    attempts,
+    success,
+    responses
+from
+    problem_responses


### PR DESCRIPTION
For course- and component-scoped datasets, limit the results of a query when filter values are absent. This will prevent returning a lot of data in a way that could be confusing for users.

Here are two screenshots of the problem performance tab that shows the default view and the view when a specific problem is selected:
![Screenshot from 2023-09-12 16-32-30](https://github.com/openedx/tutor-contrib-aspects/assets/2566242/66b9c26d-1416-4e30-a34d-11842e7cc963)
![Screenshot from 2023-09-12 16-32-41](https://github.com/openedx/tutor-contrib-aspects/assets/2566242/f4a5b4cd-bef3-4ef7-8976-4b8348e48d71)
