### PR TITLE
fix: Enable Superset proxy fix when Caddy is on

### DIFF
--- a/tutoraspects/plugin.py
+++ b/tutoraspects/plugin.py
@@ -290,6 +290,11 @@ hooks.Filters.CONFIG_DEFAULTS.add_items(
         ),
         ("SUPERSET_EXTRA_JINJA_FILTERS", {}),
         ("SUPERSET_BLOCK_STUDENT_ACCESS", True),
+        # This setting allows Superset to run behind a reverse proxy in HTTPS and
+        # redirect to the correct http/s based on the headers sent from the proxy.
+        # By default it is on if Caddy is enabled, but it can be set separately in
+        # case you are running a different proxy or otherwise have different needs.
+        ("SUPERSET_ENABLE_PROXY_FIX", "{{ENABLE_WEB_PROXY}}"),
         ######################
         # dbt Settings
         # For the most part you shouldn't have to touch these

--- a/tutoraspects/templates/aspects/apps/superset/pythonpath/superset_config_docker.py
+++ b/tutoraspects/templates/aspects/apps/superset/pythonpath/superset_config_docker.py
@@ -91,14 +91,14 @@ def can_view_courses_wrapper(*args, **kwargs):
     from superset.extensions import cache_manager
 
     return memoized_func(key="{username}", cache=cache_manager.cache)(can_view_courses)(*args, **kwargs)
-    
+
 
 JINJA_CONTEXT_ADDONS = {
     'can_view_courses': can_view_courses_wrapper,
     {% for filter in SUPERSET_EXTRA_JINJA_FILTERS %}'{{ filter }}': {{filter}},{% endfor %}
 }
 
-{% if not ENABLE_WEB_PROXY %}
+{% if ENABLE_WEB_PROXY %}
 # Caddy is running behind a proxy: Superset needs to handle x-forwarded-* headers
 # https://flask.palletsprojects.com/en/latest/deploying/proxy_fix/
 ENABLE_PROXY_FIX = True

--- a/tutoraspects/templates/aspects/apps/superset/pythonpath/superset_config_docker.py
+++ b/tutoraspects/templates/aspects/apps/superset/pythonpath/superset_config_docker.py
@@ -98,7 +98,7 @@ JINJA_CONTEXT_ADDONS = {
     {% for filter in SUPERSET_EXTRA_JINJA_FILTERS %}'{{ filter }}': {{filter}},{% endfor %}
 }
 
-{% if ENABLE_WEB_PROXY %}
+{% if SUPERSET_ENABLE_PROXY_FIX %}
 # Caddy is running behind a proxy: Superset needs to handle x-forwarded-* headers
 # https://flask.palletsprojects.com/en/latest/deploying/proxy_fix/
 ENABLE_PROXY_FIX = True


### PR DESCRIPTION
Closes #353 

This setting seems to have been reversed from what we want. It was causing Superset SSO to fail in tutor local HTTPS environments due to Superset not knowing it was proxied behind HTTPS and sending an incorrect "http://" redirect instead of "https://".