### PR TITLE
fix: Move superset-pythonpath ConfigMap to PVC

### DIFF
--- a/tutoraspects/patches/k8s-deployments
+++ b/tutoraspects/patches/k8s-deployments
@@ -218,8 +218,8 @@ spec:
           configMap:
             name: superset-docker
         - name: pythonpath
-          persistentVolumeClaim:
-            claimName: superset-pythonpath
+          hostPath:
+            path: aspects/apps/superset/pythonpath
         - name: security
           configMap:
             name: superset-security
@@ -307,8 +307,8 @@ spec:
           configMap:
             name: superset-docker
         - name: pythonpath
-          persistentVolumeClaim:
-            claimName: superset-pythonpath
+          hostPath:
+            path: aspects/apps/superset/pythonpath
         - name: security
           configMap:
             name: superset-security
@@ -396,8 +396,8 @@ spec:
           configMap:
             name: superset-docker
         - name: pythonpath
-          persistentVolumeClaim:
-            claimName: superset-pythonpath
+          hostPath:
+            path: aspects/apps/superset/pythonpath
         - name: security
           configMap:
             name: superset-security

--- a/tutoraspects/patches/k8s-deployments
+++ b/tutoraspects/patches/k8s-deployments
@@ -218,8 +218,8 @@ spec:
           configMap:
             name: superset-docker
         - name: pythonpath
-          configMap:
-            name: superset-pythonpath
+          persistentVolumeClaim:
+            claimName: superset-pythonpath
         - name: security
           configMap:
             name: superset-security
@@ -307,8 +307,8 @@ spec:
           configMap:
             name: superset-docker
         - name: pythonpath
-          configMap:
-            name: superset-pythonpath
+          persistentVolumeClaim:
+            claimName: superset-pythonpath
         - name: security
           configMap:
             name: superset-security
@@ -396,8 +396,8 @@ spec:
           configMap:
             name: superset-docker
         - name: pythonpath
-          configMap:
-            name: superset-pythonpath
+          persistentVolumeClaim:
+            claimName: superset-pythonpath
         - name: security
           configMap:
             name: superset-security

--- a/tutoraspects/patches/k8s-jobs
+++ b/tutoraspects/patches/k8s-jobs
@@ -219,15 +219,15 @@ spec:
         - name: docker
           configMap:
             name: superset-docker
-        - name: pythonpath
-          configMap:
-            name: superset-pythonpath
         - name: security
           configMap:
             name: superset-security
         - name: assets
           persistentVolumeClaim:
             claimName: superset-assets
+        - name: pythonpath
+          persistentVolumeClaim:
+            claimName: superset-pythonpath
 
 ---
 apiVersion: batch/v1
@@ -299,13 +299,13 @@ spec:
         - name: docker
           configMap:
             name: superset-docker
-        - name: pythonpath
-          configMap:
-            name: superset-pythonpath
         - name: security
           configMap:
             name: superset-security
         - name: assets
           persistentVolumeClaim:
             claimName: superset-assets
+        - name: pythonpath
+          persistentVolumeClaim:
+            claimName: superset-pythonpath
 {% endif %}

--- a/tutoraspects/patches/k8s-jobs
+++ b/tutoraspects/patches/k8s-jobs
@@ -226,8 +226,8 @@ spec:
           persistentVolumeClaim:
             claimName: superset-assets
         - name: pythonpath
-          persistentVolumeClaim:
-            claimName: superset-pythonpath
+          hostPath:
+            path: aspects/apps/superset/pythonpath
 
 ---
 apiVersion: batch/v1
@@ -306,6 +306,6 @@ spec:
           persistentVolumeClaim:
             claimName: superset-assets
         - name: pythonpath
-          persistentVolumeClaim:
-            claimName: superset-pythonpath
+          hostPath:
+            path: aspects/apps/superset/pythonpath
 {% endif %}

--- a/tutoraspects/patches/k8s-volumes
+++ b/tutoraspects/patches/k8s-volumes
@@ -29,6 +29,20 @@ spec:
   resources:
     requests:
       storage: 5Mi
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: superset-pythonpath
+  labels:
+    app.kubernetes.io/component: volume
+    app.kubernetes.io/name: superset
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 10Mi
 {% endif %}
 {% if RUN_VECTOR %}
 ---

--- a/tutoraspects/patches/k8s-volumes
+++ b/tutoraspects/patches/k8s-volumes
@@ -33,22 +33,6 @@ spec:
 apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
-  name: superset-pythonpath
-  labels:
-    app.kubernetes.io/component: volume
-    app.kubernetes.io/name: superset
-spec:
-  accessModes:
-    - ReadWriteOnce
-  resources:
-    requests:
-      storage: 10Mi
-{% endif %}
-{% if RUN_VECTOR %}
----
-apiVersion: v1
-kind: PersistentVolumeClaim
-metadata:
   name: vector
   labels:
     app.kubernetes.io/component: volume


### PR DESCRIPTION
ConfigMap is too small to hold all of our files, moving to a persistent volume instead.