### PR TITLE
fix: set security context for superset job

### DIFF
--- a/tutoraspects/patches/k8s-jobs
+++ b/tutoraspects/patches/k8s-jobs
@@ -159,6 +159,11 @@ metadata:
 spec:
   template:
     spec:
+      securityContext:
+        runAsUser: 1000
+        runAsGroup: 1000
+        fsGroup: 1000
+        fsGroupChangePolicy: "OnRootMismatch"
       restartPolicy: Never
       containers:
       - name: superset

--- a/tutoraspects/templates/aspects/jobs/init/superset/init-superset.sh
+++ b/tutoraspects/templates/aspects/jobs/init/superset/init-superset.sh
@@ -67,9 +67,9 @@ echo_step "3" "Complete" "Setting up roles and perms"
 echo_step "4" "Starting" "Importing assets"
 
 cd /app/assets/
-rm -rf /app/assets/superset
+rm -rf superset
 
-mkdir /app/assets/superset -p
+mkdir superset
 
 date=$(date -u +"%Y-%m-%dT%H:%M:%S.%6N+00:00") 
 echo "version: 1.0.0


### PR DESCRIPTION
This PR fixes an issue in the superset job that makes the init script unable to create folders