### PR TITLE
feat: add materialized view for forum events (FC-0033)

### DIFF
--- a/tutoraspects/plugin.py
+++ b/tutoraspects/plugin.py
@@ -66,6 +66,8 @@ hooks.Filters.CONFIG_DEFAULTS.add_items(
         ("ASPECTS_NAVIGATION_EVENTS_TABLE", "navigation_events"),
         ("ASPECTS_GRADING_TRANSFORM_MV", "grading_events_mv"),
         ("ASPECTS_GRADING_EVENTS_TABLE", "grading_events"),
+        ("ASPECTS_FORUM_TRANSFORM_MV", "forum_events_mv"),
+        ("ASPECTS_FORUM_EVENTS_TABLE", "forum_events"),
         # ClickHouse event sink settings
         ("ASPECTS_EVENT_SINK_DATABASE", "event_sink"),
         ("ASPECTS_EVENT_SINK_NODES_TABLE", "course_blocks"),

--- a/tutoraspects/templates/aspects/apps/aspects/migrations/alembic/versions/0019_forum_events_mv.py
+++ b/tutoraspects/templates/aspects/apps/aspects/migrations/alembic/versions/0019_forum_events_mv.py
@@ -42,15 +42,7 @@ def upgrade():
         FROM
             {{ ASPECTS_XAPI_DATABASE }}.{{ ASPECTS_XAPI_TABLE }}
         WHERE
-            verb_id in (
-                'https://w3id.org/xapi/acrossx/verbs/posted',
-                'https://w3id.org/xapi/acrossx/verbs/edited',
-                'https://w3id.org/xapi/dod-isd/verbs/deleted',
-                'http://id.tincanapi.com/verb/viewed',
-                'https://w3id.org/xapi/openedx/verb/voted',
-                'https://w3id.org/xapi/acrossx/verbs/reported',
-                'https://w3id.org/xapi/openedx/verb/unreported'
-            );
+            JSON_VALUE(event_str, '$.object.definition.type') = 'http://id.tincanapi.com/activitytype/discussion'
         """
     )
 

--- a/tutoraspects/templates/aspects/apps/aspects/migrations/alembic/versions/0019_forum_events_mv.py
+++ b/tutoraspects/templates/aspects/apps/aspects/migrations/alembic/versions/0019_forum_events_mv.py
@@ -1,0 +1,64 @@
+"""
+create a top-level materialized view for forum events
+"""
+from alembic import op
+
+
+revision = "0019"
+down_revision = "0018"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.execute(
+        """
+        CREATE TABLE IF NOT EXISTS {{ ASPECTS_XAPI_DATABASE }}.{{ ASPECTS_FORUM_EVENTS_TABLE }} (
+            `event_id` UUID NOT NULL,
+            `emission_time` DateTime64 NOT NULL,
+            `org` String NOT NULL,
+            `course_key` String NOT NULL,
+            `object_id` String NOT NULL,
+            `actor_id` String NOT NULL,
+            `verb_id` LowCardinality(String) NOT NULL
+        ) ENGINE = ReplacingMergeTree
+        PRIMARY KEY (org, course_key, verb_id)
+        ORDER BY (org, course_key, verb_id, emission_time, actor_id, object_id, event_id);
+        """
+    )
+
+    op.execute(
+        """
+        CREATE MATERIALIZED VIEW IF NOT EXISTS {{ ASPECTS_XAPI_DATABASE }}.{{ ASPECTS_FORUM_TRANSFORM_MV }}
+        TO {{ ASPECTS_XAPI_DATABASE }}.{{ ASPECTS_FORUM_EVENTS_TABLE }} AS
+        SELECT
+            event_id,
+            cast(emission_time as DateTime) as emission_time,
+            org,
+            splitByString('/', course_id)[-1] AS course_key,
+            object_id,
+            actor_id,
+            verb_id
+        FROM
+            {{ ASPECTS_XAPI_DATABASE }}.{{ ASPECTS_XAPI_TABLE }}
+        WHERE
+            verb_id in (
+                'https://w3id.org/xapi/acrossx/verbs/posted',
+                'https://w3id.org/xapi/acrossx/verbs/edited',
+                'https://w3id.org/xapi/dod-isd/verbs/deleted',
+                'http://id.tincanapi.com/verb/viewed',
+                'https://w3id.org/xapi/openedx/verb/voted',
+                'https://w3id.org/xapi/acrossx/verbs/reported',
+                'https://w3id.org/xapi/openedx/verb/unreported'
+            );
+        """
+    )
+
+
+def downgrade():
+    op.execute(
+        "DROP TABLE IF EXISTS {{ ASPECTS_XAPI_DATABASE }}.{{ ASPECTS_FORUM_EVENTS_TABLE }}"
+    )
+    op.execute(
+        "DROP VIEW IF EXISTS {{ ASPECTS_XAPI_DATABASE }}.{{ ASPECTS_FORUM_TRANSFORM_MV }}"
+    )


### PR DESCRIPTION
This adds a new top-level materialized view for forum events. This set of fields should cover our existing use cases so I didn't want to add anything else until we had a better idea of the requirements, but please let me know if there's anything else that could be included at this point.