### PR TITLE
fix: update the get org from url function to include other chars

### DIFF
--- a/tutoraspects/templates/aspects/apps/aspects/migrations/alembic/versions/0020_get_org_from_course_url.py
+++ b/tutoraspects/templates/aspects/apps/aspects/migrations/alembic/versions/0020_get_org_from_course_url.py
@@ -1,0 +1,31 @@
+"""Update the get org function to include other characters"""
+from alembic import op
+import sqlalchemy as sa
+
+revision = "0020"
+down_revision = "0019"
+branch_labels = None
+depends_on = None
+on_cluster = " ON CLUSTER '{{CLICKHOUSE_CLUSTER_NAME}}' " if "{{CLICKHOUSE_CLUSTER_NAME}}" else ""
+
+
+def upgrade():
+    op.execute(
+        f"""
+        CREATE OR REPLACE FUNCTION get_org_from_course_url {on_cluster}
+        AS (
+        course_url) ->
+        nullIf(EXTRACT(course_url, 'course-v1:([a-zA-Z0-9\w\-~.:%]*)'), '');
+        """
+    )
+
+
+def downgrade():
+    op.execute(
+        f"""
+        CREATE OR REPLACE FUNCTION get_org_from_course_url {on_cluster}
+        AS (
+        course_url) ->
+        nullIf(EXTRACT(course_url, 'course-v1:([a-zA-Z0-9]*)'), '');
+        """
+    )


### PR DESCRIPTION
### Description

The old get_org_from_course_url function was not working correctly as it was omitting text that included some of the following chars: `-~.:%`

We are using the deprecated version as it's a superset of the actual version and it will allow us to support very old courses

This was extracted from: https://github.com/openedx/opaque-keys/blob/e0ee525df4395f3795501fdc3a75a7ecdbedcb1f/opaque_keys/edx/locator.py#L46-L47