### PR TITLE
fix: use local volume instead of emtpy dir for vector data

### DIFF
--- a/tutoraspects/patches/k8s-deployments
+++ b/tutoraspects/patches/k8s-deployments
@@ -505,15 +505,6 @@ spec:
               name: config
               subPath: k8s.toml
               readOnly: true
-            - mountPath: /var/lib
-              name: var-lib
-              readOnly: true
-            - mountPath: /host/proc
-              name: procfs
-              readOnly: true
-            - mountPath: /host/sys
-              name: sysfs
-              readOnly: true
           securityContext:
             allowPrivilegeEscalation: false
       terminationGracePeriodSeconds: 60
@@ -525,16 +516,7 @@ spec:
         - name: data
           hostPath:
             path: /var/lib/vector
-        - hostPath:
+        - name: var-log
+          hostPath:
             path: /var/log/
-          name: var-log
-        - hostPath:
-            path: /var/lib/
-          name: var-lib
-        - hostPath:
-            path: /proc
-          name: procfs
-        - hostPath:
-            path: /sys
-          name: sysfs
 {% endif %}

--- a/tutoraspects/patches/k8s-deployments
+++ b/tutoraspects/patches/k8s-deployments
@@ -408,7 +408,7 @@ spec:
 ---
 # log collection
 # https://vector.dev/docs/setup/installation/platforms/kubernetes/
-# https://github.com/timberio/vector/blob/master/distribution/kubernetes/vector-agent/resources.yaml
+# https://github.com/timberio/vector/blob/master/distribution/kubernetes/vector-agent/
 ---
 apiVersion: v1
 kind: ServiceAccount
@@ -464,13 +464,16 @@ metadata:
 spec:
   selector:
     matchLabels:
-      name: vector
+      app.kubernetes.io/name: vector
+  minReadySeconds: 0
   template:
     metadata:
       labels:
-        name: vector
+        app.kubernetes.io/name: vector
+        vector.dev/exclude: "true"
     spec:
       serviceAccountName: vector
+      dnsPolicy: ClusterFirst
       containers:
         - name: vector
           image: {{ DOCKER_IMAGE_VECTOR }}
@@ -492,27 +495,46 @@ spec:
             - name: SYSFS_ROOT
               value: /host/sys
             - name: VECTOR_LOG
-              value: warn
+              value: info
           volumeMounts:
             - name: data
               mountPath: /vector-data-dir
             - name: var-log
               mountPath: /var/log/
-              readOnly: true
             - mountPath: /etc/vector/vector.toml
               name: config
               subPath: k8s.toml
               readOnly: true
+            - mountPath: /var/lib
+              name: var-lib
+              readOnly: true
+            - mountPath: /host/proc
+              name: procfs
+              readOnly: true
+            - mountPath: /host/sys
+              name: sysfs
+              readOnly: true
           securityContext:
             allowPrivilegeEscalation: false
+      terminationGracePeriodSeconds: 60
       priorityClassName: vector-priority
       volumes:
-        - name: data
-          emptyDir: {}
-        - name: var-log
-          hostPath:
-            path: /var/log/
         - name: config
           configMap:
             name: vector-config
+        - name: data
+          hostPath:
+            path: /var/lib/vector
+        - hostPath:
+            path: /var/log/
+          name: var-log
+        - hostPath:
+            path: /var/lib/
+          name: var-lib
+        - hostPath:
+            path: /proc
+          name: procfs
+        - hostPath:
+            path: /sys
+          name: sysfs
 {% endif %}

--- a/tutoraspects/patches/k8s-volumes
+++ b/tutoraspects/patches/k8s-volumes
@@ -30,22 +30,6 @@ spec:
     requests:
       storage: 5Mi
 {% endif %}
-{% if RUN_VECTOR %}
----
-apiVersion: v1
-kind: PersistentVolumeClaim
-metadata:
-  name: vector
-  labels:
-    app.kubernetes.io/component: volume
-    app.kubernetes.io/name: vector
-spec:
-  accessModes:
-    - ReadWriteOnce
-  resources:
-    requests:
-      storage: 2Gi
-{% endif %}
 ---
 apiVersion: v1
 kind: PersistentVolumeClaim


### PR DESCRIPTION
### Description

This PR uses a local volume for the Vector DaemonSet instead of a emptyDir volume