### PR TITLE
fix: update ralph clickhouse database name in k8s

### DIFF
--- a/tutoraspects/patches/k8s-deployments
+++ b/tutoraspects/patches/k8s-deployments
@@ -92,7 +92,7 @@ spec:
               value: "clickhouse"
             - name: RALPH_BACKENDS__DATABASE__CLICKHOUSE__USERNAME
               value: "{{CLICKHOUSE_ADMIN_USER}}"
-            - name: RALPH_BACKENDS__DATABASE__CLICKHOUSE__XAPI_DATABASE
+            - name: RALPH_BACKENDS__DATABASE__CLICKHOUSE__DATABASE
               value: "{{ASPECTS_XAPI_DATABASE}}"
             - name: RALPH_RUNSERVER_BACKEND
               value: "clickhouse"

--- a/tutoraspects/patches/k8s-jobs
+++ b/tutoraspects/patches/k8s-jobs
@@ -118,7 +118,7 @@ spec:
               value: "clickhouse"
             - name: RALPH_BACKENDS__DATABASE__CLICKHOUSE__USERNAME
               value: "{{CLICKHOUSE_ADMIN_USER}}"
-            - name: RALPH_BACKENDS__DATABASE__CLICKHOUSE__XAPI_DATABASE
+            - name: RALPH_BACKENDS__DATABASE__CLICKHOUSE__DATABASE
               value: "{{ASPECTS_XAPI_DATABASE}}"
             - name: RALPH_RUNSERVER_BACKEND
               value: "clickhouse"


### PR DESCRIPTION
### Description

This PR fixes an error in which Ralph was receiving the wrong variable name for the Clickhouse database.

Extracted from here: https://github.com/openfun/ralph/blob/a42dbae8c4fd856aca6ac1cd555d381712ed80f6/tests/test_cli.py#L918