### PR TITLE
chore: update dashboard yaml to new version

### DIFF
--- a/tutoraspects/templates/openedx-assets/assets/charts/Active_Users_Per_Organization.yaml
+++ b/tutoraspects/templates/openedx-assets/assets/charts/Active_Users_Per_Organization.yaml
@@ -1,6 +1,9 @@
 _file_name: Active_Users_Per_Organization.yaml
 cache_timeout: null
+certification_details: null
+certified_by: null
 dataset_uuid: 2a2498dc-03ce-41a0-b798-d84f808f7da6
+description: null
 params:
   adhoc_filters: []
   color_scheme: supersetColors
@@ -49,6 +52,7 @@ params:
   sort_by_metric: true
   time_range: No filter
   viz_type: pie
+query_context: null
 slice_name: Active Users Per Organization
 uuid: 09a8a31c-c65f-452a-951f-dce6f0f03292
 version: 1.0.0

--- a/tutoraspects/templates/openedx-assets/assets/charts/Actor_IDs_over_time.yaml
+++ b/tutoraspects/templates/openedx-assets/assets/charts/Actor_IDs_over_time.yaml
@@ -1,6 +1,9 @@
 _file_name: Actor_IDs_over_time.yaml
 cache_timeout: null
+certification_details: null
+certified_by: null
 dataset_uuid: 2a2498dc-03ce-41a0-b798-d84f808f7da6
+description: null
 params:
   adhoc_filters: []
   color_picker:
@@ -46,6 +49,7 @@ params:
   time_range: No filter
   viz_type: big_number
   y_axis_format: SMART_NUMBER
+query_context: null
 slice_name: Actor IDs over time
 uuid: 6a8ded91-f9a6-45c2-9f9f-f85dc1ff7ed6
 version: 1.0.0

--- a/tutoraspects/templates/openedx-assets/assets/charts/Course_Grade_Distribution.yaml
+++ b/tutoraspects/templates/openedx-assets/assets/charts/Course_Grade_Distribution.yaml
@@ -34,6 +34,7 @@ params:
   - null
   y_axis_format: SMART_NUMBER
   y_axis_label: Number Of Students
+query_context: null
 slice_name: Course Grade Distribution
 uuid: f9adbc85-1f50-4c04-ace3-31ba7390de5e
 version: 1.0.0

--- a/tutoraspects/templates/openedx-assets/assets/charts/Course_Registrations_Over_Time.yaml
+++ b/tutoraspects/templates/openedx-assets/assets/charts/Course_Registrations_Over_Time.yaml
@@ -1,6 +1,9 @@
 _file_name: Course_Registrations_Over_Time.yaml
 cache_timeout: null
+certification_details: null
+certified_by: null
 dataset_uuid: 352311fe-12f0-470c-8b8c-d4f6a3936b3d
+description: null
 params:
   adhoc_filters:
   - clause: WHERE
@@ -71,6 +74,7 @@ params:
   y_axis_title: Registrations
   y_axis_title_margin: 15
   y_axis_title_position: Left
+query_context: null
 slice_name: Course Registrations Over Time
 uuid: bf4f4671-c276-4185-9b9a-b10864efea6c
 version: 1.0.0

--- a/tutoraspects/templates/openedx-assets/assets/charts/Courses.yaml
+++ b/tutoraspects/templates/openedx-assets/assets/charts/Courses.yaml
@@ -1,6 +1,9 @@
 _file_name: Courses.yaml
 cache_timeout: null
+certification_details: null
+certified_by: null
 dataset_uuid: 2a2498dc-03ce-41a0-b798-d84f808f7da6
+description: null
 params:
   adhoc_filters: []
   datasource: 4__table
@@ -38,6 +41,7 @@ params:
   time_range: No filter
   viz_type: big_number_total
   y_axis_format: SMART_NUMBER
+query_context: null
 slice_name: Courses
 uuid: 63f86926-3325-43cf-b075-ef37f5f60413
 version: 1.0.0

--- a/tutoraspects/templates/openedx-assets/assets/charts/Courses_Per_Organization.yaml
+++ b/tutoraspects/templates/openedx-assets/assets/charts/Courses_Per_Organization.yaml
@@ -1,6 +1,9 @@
 _file_name: Courses_Per_Organization.yaml
 cache_timeout: null
+certification_details: null
+certified_by: null
 dataset_uuid: 46183302-6fa6-41a3-b6a7-79ff6c1c8402
+description: null
 params:
   adhoc_filters: []
   color_scheme: supersetColors
@@ -49,6 +52,7 @@ params:
   sort_by_metric: true
   time_range: No filter
   viz_type: pie
+query_context: null
 slice_name: Courses Per Organization
 uuid: 7901d6ae-dea8-4d2c-9232-35c22571cfb7
 version: 1.0.0

--- a/tutoraspects/templates/openedx-assets/assets/charts/Currently_Enrolled_Learners_Per_Day.yaml
+++ b/tutoraspects/templates/openedx-assets/assets/charts/Currently_Enrolled_Learners_Per_Day.yaml
@@ -38,6 +38,7 @@ params:
   time_range: No filter
   viz_type: big_number
   y_axis_format: SMART_NUMBER
+query_context: null
 slice_name: Currently Enrolled Learners Per Day
 uuid: ed2fe731-6544-422f-bc55-42f399f48b2c
 version: 1.0.0

--- a/tutoraspects/templates/openedx-assets/assets/charts/Distribution_Of_Attempts.yaml
+++ b/tutoraspects/templates/openedx-assets/assets/charts/Distribution_Of_Attempts.yaml
@@ -44,6 +44,7 @@ params:
   - null
   y_axis_format: SMART_NUMBER
   y_axis_label: Students
+query_context: null
 slice_name: Distribution Of Attempts
 uuid: db90930f-f16e-4c32-8050-0e4abae28f4c
 version: 1.0.0

--- a/tutoraspects/templates/openedx-assets/assets/charts/Distribution_Of_Hints_Per_Correct_Answer.yaml
+++ b/tutoraspects/templates/openedx-assets/assets/charts/Distribution_Of_Hints_Per_Correct_Answer.yaml
@@ -34,6 +34,7 @@ params:
   - null
   y_axis_format: SMART_NUMBER
   y_axis_label: Students
+query_context: null
 slice_name: Distribution Of Hints Per Correct Answer
 uuid: ee94be4c-6fdd-4295-b43c-40890d6c549d
 version: 1.0.0

--- a/tutoraspects/templates/openedx-assets/assets/charts/Distribution_Of_Problem_Grades.yaml
+++ b/tutoraspects/templates/openedx-assets/assets/charts/Distribution_Of_Problem_Grades.yaml
@@ -35,6 +35,7 @@ params:
   - null
   y_axis_format: SMART_NUMBER
   y_axis_label: Students
+query_context: null
 slice_name: Distribution Of Problem Grades
 uuid: 4f7e3606-f5de-4643-97c0-bbb6340a3df2
 version: 1.0.0

--- a/tutoraspects/templates/openedx-assets/assets/charts/Distribution_Of_Responses.yaml
+++ b/tutoraspects/templates/openedx-assets/assets/charts/Distribution_Of_Responses.yaml
@@ -34,6 +34,7 @@ params:
   - null
   y_axis_format: SMART_NUMBER
   y_axis_label: Responses
+query_context: null
 slice_name: Distribution Of Responses
 uuid: f1651c44-a8f4-4b44-ad49-962823009319
 version: 1.0.0

--- a/tutoraspects/templates/openedx-assets/assets/charts/Enrollment_Events_Per_Day.yaml
+++ b/tutoraspects/templates/openedx-assets/assets/charts/Enrollment_Events_Per_Day.yaml
@@ -49,6 +49,7 @@ params:
   y_axis_title: Number Of Events
   y_axis_title_margin: 15
   y_axis_title_position: Left
+query_context: null
 slice_name: Enrollment Events Per Day
 uuid: bb1147cc-b7bc-44b7-b06a-79b0db6626aa
 version: 1.0.0

--- a/tutoraspects/templates/openedx-assets/assets/charts/Enrollments_By_Enrollment_Mode.yaml
+++ b/tutoraspects/templates/openedx-assets/assets/charts/Enrollments_By_Enrollment_Mode.yaml
@@ -43,6 +43,7 @@ params:
   sort_by_metric: true
   time_range: 'DATEADD(DATETIME("now"), -1, month) : DATEADD(DATETIME("now"), 1, day)'
   viz_type: pie
+query_context: null
 slice_name: Enrollments By Enrollment Mode
 uuid: 05ed7102-5464-4e2f-86ae-31700b787cc3
 version: 1.0.0

--- a/tutoraspects/templates/openedx-assets/assets/charts/Enrollments_By_Type.yaml
+++ b/tutoraspects/templates/openedx-assets/assets/charts/Enrollments_By_Type.yaml
@@ -1,6 +1,9 @@
 _file_name: Enrollments_By_Type.yaml
 cache_timeout: null
+certification_details: null
+certified_by: null
 dataset_uuid: 352311fe-12f0-470c-8b8c-d4f6a3936b3d
+description: null
 params:
   adhoc_filters:
   - clause: WHERE
@@ -44,6 +47,7 @@ params:
   sort_by_metric: true
   time_range: No filter
   viz_type: pie
+query_context: null
 slice_name: Enrollments By Type
 uuid: 6c473b09-6a1a-4531-b71d-ab82e09721ef
 version: 1.0.0

--- a/tutoraspects/templates/openedx-assets/assets/charts/Event_type.yaml
+++ b/tutoraspects/templates/openedx-assets/assets/charts/Event_type.yaml
@@ -1,6 +1,9 @@
 _file_name: Event_type.yaml
 cache_timeout: null
+certification_details: null
+certified_by: null
 dataset_uuid: 2a2498dc-03ce-41a0-b798-d84f808f7da6
+description: null
 params:
   adhoc_filters: []
   color_scheme: supersetColors
@@ -25,6 +28,7 @@ params:
   sort_by_metric: true
   time_range: No filter
   viz_type: pie
+query_context: null
 slice_name: Event type
 uuid: b4a9a10d-0e82-43e7-a619-3ef3f6bf57a5
 version: 1.0.0

--- a/tutoraspects/templates/openedx-assets/assets/charts/Events_per_course.yaml
+++ b/tutoraspects/templates/openedx-assets/assets/charts/Events_per_course.yaml
@@ -1,6 +1,9 @@
 _file_name: Events_per_course.yaml
 cache_timeout: null
+certification_details: null
+certified_by: null
 dataset_uuid: 2a2498dc-03ce-41a0-b798-d84f808f7da6
+description: null
 params:
   adhoc_filters: []
   color_scheme: supersetColors
@@ -26,6 +29,7 @@ params:
   sort_by_metric: true
   time_range: No filter
   viz_type: pie
+query_context: null
 slice_name: Events per course
 uuid: a445d9e5-ac98-411e-9a47-eda10081bd5b
 version: 1.0.0

--- a/tutoraspects/templates/openedx-assets/assets/charts/Last_Received_Event.yaml
+++ b/tutoraspects/templates/openedx-assets/assets/charts/Last_Received_Event.yaml
@@ -1,6 +1,9 @@
 _file_name: Last_Received_Event.yaml
 cache_timeout: null
+certification_details: null
+certified_by: null
 dataset_uuid: 2a2498dc-03ce-41a0-b798-d84f808f7da6
+description: null
 params:
   adhoc_filters: []
   datasource: 6__table
@@ -23,6 +26,7 @@ params:
   time_range: No filter
   viz_type: big_number_total
   y_axis_format: ~g
+query_context: null
 slice_name: Last Received Event
 uuid: ffdaabc5-8d01-47d7-8f29-66efa643befb
 version: 1.0.0

--- a/tutoraspects/templates/openedx-assets/assets/charts/Last_course_syncronized.yaml
+++ b/tutoraspects/templates/openedx-assets/assets/charts/Last_course_syncronized.yaml
@@ -1,6 +1,9 @@
 _file_name: Last_course_syncronized.yaml
 cache_timeout: null
+certification_details: null
+certified_by: null
 dataset_uuid: 46183302-6fa6-41a3-b6a7-79ff6c1c8402
+description: null
 params:
   adhoc_filters: []
   datasource: 2__table
@@ -37,6 +40,7 @@ params:
   time_range: No filter
   viz_type: big_number_total
   y_axis_format: SMART_NUMBER
+query_context: null
 slice_name: Last course syncronized
 uuid: ca93f427-d021-476e-9a36-6ea0d99d30ea
 version: 1.0.0

--- a/tutoraspects/templates/openedx-assets/assets/charts/Most_Active_Courses_Per_Day.yaml
+++ b/tutoraspects/templates/openedx-assets/assets/charts/Most_Active_Courses_Per_Day.yaml
@@ -1,6 +1,9 @@
 _file_name: Most_Active_Courses_Per_Day.yaml
 cache_timeout: null
+certification_details: null
+certified_by: null
 dataset_uuid: 2a2498dc-03ce-41a0-b798-d84f808f7da6
+description: null
 params:
   adhoc_filters: []
   annotation_layers: []
@@ -61,6 +64,7 @@ params:
   y_axis_format: SMART_NUMBER
   y_axis_title_margin: 15
   y_axis_title_position: Left
+query_context: null
 slice_name: Most Active Courses Per Day
 uuid: a19a7c6a-e2c9-4033-86b3-b2e5878b5b69
 version: 1.0.0

--- a/tutoraspects/templates/openedx-assets/assets/charts/Responses_Per_Problem.yaml
+++ b/tutoraspects/templates/openedx-assets/assets/charts/Responses_Per_Problem.yaml
@@ -60,6 +60,7 @@ params:
   - null
   y_axis_format: SMART_NUMBER
   y_axis_label: Number Of Students
+query_context: null
 slice_name: Responses Per Problem
 uuid: a3e79162-4ace-4349-ab34-89aa60ae75ed
 version: 1.0.0

--- a/tutoraspects/templates/openedx-assets/assets/charts/Total_Organizations.yaml
+++ b/tutoraspects/templates/openedx-assets/assets/charts/Total_Organizations.yaml
@@ -1,6 +1,9 @@
 _file_name: Total_Organizations.yaml
 cache_timeout: null
+certification_details: null
+certified_by: null
 dataset_uuid: 2a2498dc-03ce-41a0-b798-d84f808f7da6
+description: null
 params:
   adhoc_filters: []
   datasource: 6__table
@@ -39,6 +42,7 @@ params:
   time_range: No filter
   viz_type: big_number_total
   y_axis_format: SMART_NUMBER
+query_context: null
 slice_name: Total Organizations
 uuid: e66b1cdb-6974-4fa2-a769-4908665118f6
 version: 1.0.0

--- a/tutoraspects/templates/openedx-assets/assets/charts/Transcripts_Captions_Per_Video.yaml
+++ b/tutoraspects/templates/openedx-assets/assets/charts/Transcripts_Captions_Per_Video.yaml
@@ -58,6 +58,7 @@ params:
   - null
   y_axis_format: SMART_NUMBER
   y_axis_label: Number of Users / Uses
+query_context: null
 slice_name: Transcripts / Captions Per Video
 uuid: 6b830def-f3ca-4b4c-9455-7a7b7354bce8
 version: 1.0.0

--- a/tutoraspects/templates/openedx-assets/assets/charts/Unique_actors.yaml
+++ b/tutoraspects/templates/openedx-assets/assets/charts/Unique_actors.yaml
@@ -1,6 +1,9 @@
 _file_name: Unique_actors.yaml
 cache_timeout: null
+certification_details: null
+certified_by: null
 dataset_uuid: 2a2498dc-03ce-41a0-b798-d84f808f7da6
+description: null
 params:
   adhoc_filters: []
   datasource: 4__table
@@ -40,6 +43,7 @@ params:
   time_range: No filter
   viz_type: big_number_total
   y_axis_format: SMART_NUMBER
+query_context: null
 slice_name: Unique actors
 uuid: 071bf3d5-8b9d-4e26-83fb-7836db5a7ab6
 version: 1.0.0

--- a/tutoraspects/templates/openedx-assets/assets/charts/Watched_Video_Segments.yaml
+++ b/tutoraspects/templates/openedx-assets/assets/charts/Watched_Video_Segments.yaml
@@ -36,6 +36,7 @@ params:
   - null
   y_axis_format: SMART_NUMBER
   y_axis_label: Number Of Viewers / Views
+query_context: null
 slice_name: Watched Video Segments
 uuid: 2985a9db-c338-4008-af52-2930b81ee2e5
 version: 1.0.0

--- a/tutoraspects/templates/openedx-assets/assets/charts/Watches_Per_Video.yaml
+++ b/tutoraspects/templates/openedx-assets/assets/charts/Watches_Per_Video.yaml
@@ -58,6 +58,7 @@ params:
   - null
   y_axis_format: SMART_NUMBER
   y_axis_label: Number of Views / Viewers
+query_context: null
 slice_name: Watches Per Video
 uuid: 829c1d5b-2844-4115-876a-34ad3b3cad64
 version: 1.0.0

--- a/tutoraspects/templates/openedx-assets/assets/charts/xAPI_Events_Over_Time.yaml
+++ b/tutoraspects/templates/openedx-assets/assets/charts/xAPI_Events_Over_Time.yaml
@@ -1,6 +1,9 @@
 _file_name: xAPI_Events_Over_Time.yaml
 cache_timeout: null
+certification_details: null
+certified_by: null
 dataset_uuid: 2a2498dc-03ce-41a0-b798-d84f808f7da6
+description: null
 params:
   adhoc_filters: []
   color_picker:
@@ -24,6 +27,7 @@ params:
   time_range: No filter
   viz_type: big_number
   y_axis_format: SMART_NUMBER
+query_context: null
 slice_name: xAPI Events Over Time
 uuid: e6a30923-6382-413e-a1c7-2ac223fa5c5c
 version: 1.0.0

--- a/tutoraspects/templates/openedx-assets/assets/dashboards/Instructor_Dashboard.yaml
+++ b/tutoraspects/templates/openedx-assets/assets/dashboards/Instructor_Dashboard.yaml
@@ -1,4 +1,6 @@
 _file_name: Instructor_Dashboard.yaml
+_roles:
+- {{ SUPERSET_ROLES_MAPPING.instructor }}
 css: ''
 dashboard_title: Instructor Dashboard
 description: null

--- a/tutoraspects/templates/openedx-assets/assets/dashboards/Instructor_Dashboard.yaml
+++ b/tutoraspects/templates/openedx-assets/assets/dashboards/Instructor_Dashboard.yaml
@@ -1,6 +1,4 @@
 _file_name: Instructor_Dashboard.yaml
-_roles:
-  - {{ SUPERSET_ROLES_MAPPING.instructor }}
 css: ''
 dashboard_title: Instructor Dashboard
 description: null
@@ -250,14 +248,13 @@ metadata:
   refresh_frequency: 0
   shared_label_colors:
     audit: '#1FA8C9'
-  show_native_filters: true
   timed_refresh_immune_slices: []
 position:
   CHART-AZZnl_lpMv:
     children: []
     id: CHART-AZZnl_lpMv
     meta:
-      chartId: 25
+      chartId: 297
       height: 50
       sliceName: Watches Per Video
       uuid: 829c1d5b-2844-4115-876a-34ad3b3cad64
@@ -272,7 +269,7 @@ position:
     children: []
     id: CHART-GFCO8s2cxv
     meta:
-      chartId: 314
+      chartId: 7
       height: 50
       sliceName: Distribution Of Responses
       uuid: f1651c44-a8f4-4b44-ad49-962823009319
@@ -287,7 +284,7 @@ position:
     children: []
     id: CHART-Jr-gNVms2Q
     meta:
-      chartId: 111
+      chartId: 101
       height: 50
       sliceName: Enrollment Events Per Day
       uuid: bb1147cc-b7bc-44b7-b06a-79b0db6626aa
@@ -302,7 +299,7 @@ position:
     children: []
     id: CHART-OMy4wjRBWt
     meta:
-      chartId: 204
+      chartId: 3
       height: 50
       sliceName: Watched Video Segments
       uuid: 2985a9db-c338-4008-af52-2930b81ee2e5
@@ -317,7 +314,7 @@ position:
     children: []
     id: CHART-RTO33WE9FH
     meta:
-      chartId: 367
+      chartId: 366
       height: 50
       sliceName: Responses Per Problem
       uuid: a3e79162-4ace-4349-ab34-89aa60ae75ed
@@ -332,7 +329,7 @@ position:
     children: []
     id: CHART-Tej2oLPBAl
     meta:
-      chartId: 47
+      chartId: 27
       height: 50
       sliceName: Transcripts / Captions Per Video
       uuid: 6b830def-f3ca-4b4c-9455-7a7b7354bce8
@@ -347,7 +344,7 @@ position:
     children: []
     id: CHART-evjVO-ZSSd
     meta:
-      chartId: 40
+      chartId: 8
       height: 50
       sliceName: Enrollments By Enrollment Mode
       uuid: 05ed7102-5464-4e2f-86ae-31700b787cc3
@@ -362,7 +359,7 @@ position:
     children: []
     id: CHART-lTr8DL3XuI
     meta:
-      chartId: 166
+      chartId: 183
       height: 50
       sliceName: Distribution Of Hints Per Correct Answer
       uuid: ee94be4c-6fdd-4295-b43c-40890d6c549d
@@ -377,7 +374,7 @@ position:
     children: []
     id: CHART-o56v9yEe2I
     meta:
-      chartId: 345
+      chartId: 353
       height: 50
       sliceName: Distribution Of Problem Grades
       uuid: 4f7e3606-f5de-4643-97c0-bbb6340a3df2
@@ -392,7 +389,7 @@ position:
     children: []
     id: CHART-rnb6PSwCOS
     meta:
-      chartId: 87
+      chartId: 49
       height: 50
       sliceName: Currently Enrolled Learners Per Day
       uuid: ed2fe731-6544-422f-bc55-42f399f48b2c
@@ -407,7 +404,7 @@ position:
     children: []
     id: CHART-tWnaoVNNTH
     meta:
-      chartId: 30
+      chartId: 233
       height: 50
       sliceName: Distribution Of Attempts
       uuid: db90930f-f16e-4c32-8050-0e4abae28f4c
@@ -422,7 +419,7 @@ position:
     children: []
     id: CHART-w-k4N2T_L8
     meta:
-      chartId: 352
+      chartId: 376
       height: 50
       sliceName: Course Grade Distribution
       uuid: f9adbc85-1f50-4c04-ace3-31ba7390de5e

--- a/tutoraspects/templates/openedx-assets/assets/dashboards/Operator_Dashboard.yaml
+++ b/tutoraspects/templates/openedx-assets/assets/dashboards/Operator_Dashboard.yaml
@@ -1,4 +1,6 @@
 _file_name: Operator_Dashboard.yaml
+_roles:
+- {{ SUPERSET_ROLES_MAPPING.operator }}
 css: ''
 dashboard_title: Operator Dashboard
 description: null
@@ -431,10 +433,31 @@ position:
     children: []
     id: MARKDOWN-EZXXAbo-Tg
     meta:
-      code: '# Instance information
+      code: "# Instance information Aspects: {{ ASPECTS_VERSION }}
 
-
-        Aspects Version'
+        {% if RUN_VECTOR %}
+        - **Vector Version**: {{ DOCKER_IMAGE_VECTOR }} \n 
+        {% endif %}
+        {% if RUN_CLICKHOUSE %}
+        - **Clickhouse Version**: {{ DOCKER_IMAGE_CLICKHOUSE }} \n
+        {% endif %}
+        {% if RUN_RALPH %}
+        - **Ralph Version**: {{ DOCKER_IMAGE_RALPH }} \n
+        {% endif %}
+        {% if RUN_SUPERSET %}
+        - **Superset Version**: {{ DOCKER_IMAGE_SUPERSET }} \n
+        {% endif %}
+        \n
+        
+        ## Dependencies: 
+        {% for requirement in OPENEDX_EXTRA_PIP_REQUIREMENTS %}
+         {% if 'openedx-event-sink-clickhouse' in requirement %}
+        - **Clickhouse Event Sink Version**: {{ requirement.split('==')[1] }} \n 
+         {% elif 'event-routing-backends' in requirement %}
+        - **Event Routing Backends Version**: {{ requirement.split('==')[1] }} \n
+         {% endif %}
+        {% endfor %}
+        "
       height: 50
       width: 4
     parents:

--- a/tutoraspects/templates/openedx-assets/assets/dashboards/Operator_Dashboard.yaml
+++ b/tutoraspects/templates/openedx-assets/assets/dashboards/Operator_Dashboard.yaml
@@ -1,12 +1,12 @@
 _file_name: Operator_Dashboard.yaml
-_roles:
-- {{ SUPERSET_ROLES_MAPPING.operator }}
 css: ''
 dashboard_title: Operator Dashboard
 description: null
 metadata:
   chart_configuration: {}
   color_scheme: ''
+  color_scheme_domain: []
+  cross_filters_enabled: false
   default_filters: '{}'
   expanded_slices: {}
   label_colors: {}
@@ -96,10 +96,10 @@ metadata:
     name: Course Key
     scope:
       excluded:
-      - 418
-      - 451
-      - 452
-      - 453
+      - 116
+      - 124
+      - 180
+      - 13
       rootPath:
       - ROOT_ID
     tabsInScope:
@@ -111,15 +111,18 @@ metadata:
       datasetUuid: 2a2498dc-03ce-41a0-b798-d84f808f7da6
     type: NATIVE_FILTER
   refresh_frequency: 0
-  shared_label_colors: {}
-  show_native_filters: true
+  shared_label_colors:
+    attempted: '#5AC189'
+    earned: '#1FA8C9'
+    evaluated: '#454E7C'
+    registered: '#FF7F44'
   timed_refresh_immune_slices: []
 position:
   CHART-8rDUkRBgv9:
     children: []
     id: CHART-8rDUkRBgv9
     meta:
-      chartId: 452
+      chartId: 180
       height: 50
       sliceName: Enrollments By Type
       uuid: 6c473b09-6a1a-4531-b71d-ab82e09721ef
@@ -135,7 +138,7 @@ position:
     children: []
     id: CHART-H4NTUWfMqH
     meta:
-      chartId: 451
+      chartId: 124
       height: 50
       sliceName: Course Registrations Over Time
       uuid: bf4f4671-c276-4185-9b9a-b10864efea6c
@@ -151,7 +154,7 @@ position:
     children: []
     id: CHART-QN5x3ibIzS
     meta:
-      chartId: 455
+      chartId: 313
       height: 50
       sliceName: Active Users Per Organization
       uuid: 09a8a31c-c65f-452a-951f-dce6f0f03292
@@ -167,7 +170,7 @@ position:
     children: []
     id: CHART-explore-15-1
     meta:
-      chartId: 430
+      chartId: 284
       height: 50
       sliceName: xAPI Events Over Time
       uuid: e6a30923-6382-413e-a1c7-2ac223fa5c5c
@@ -183,7 +186,7 @@ position:
     children: []
     id: CHART-explore-17-1
     meta:
-      chartId: 450
+      chartId: 12
       height: 16
       sliceName: Last Received Event
       uuid: ffdaabc5-8d01-47d7-8f29-66efa643befb
@@ -200,7 +203,7 @@ position:
     children: []
     id: CHART-explore-19-1
     meta:
-      chartId: 418
+      chartId: 116
       height: 16
       sliceName: Last course syncronized
       uuid: ca93f427-d021-476e-9a36-6ea0d99d30ea
@@ -217,7 +220,7 @@ position:
     children: []
     id: CHART-explore-20-1
     meta:
-      chartId: 445
+      chartId: 176
       height: 14
       sliceName: Total Organizations
       uuid: e66b1cdb-6974-4fa2-a769-4908665118f6
@@ -234,7 +237,7 @@ position:
     children: []
     id: CHART-explore-21-1
     meta:
-      chartId: 411
+      chartId: 316
       height: 16
       sliceName: Unique actors
       uuid: 071bf3d5-8b9d-4e26-83fb-7836db5a7ab6
@@ -251,7 +254,7 @@ position:
     children: []
     id: CHART-explore-22-1
     meta:
-      chartId: 413
+      chartId: 264
       height: 15
       sliceName: Courses
       uuid: 63f86926-3325-43cf-b075-ef37f5f60413
@@ -268,7 +271,7 @@ position:
     children: []
     id: CHART-explore-25-1
     meta:
-      chartId: 437
+      chartId: 162
       height: 50
       sliceName: Event type
       uuid: b4a9a10d-0e82-43e7-a619-3ef3f6bf57a5
@@ -284,7 +287,7 @@ position:
     children: []
     id: CHART-explore-26-1
     meta:
-      chartId: 438
+      chartId: 41
       height: 50
       sliceName: Events per course
       uuid: a445d9e5-ac98-411e-9a47-eda10081bd5b
@@ -300,7 +303,7 @@ position:
     children: []
     id: CHART-explore-27-1
     meta:
-      chartId: 427
+      chartId: 262
       height: 50
       sliceName: Actor IDs over time
       sliceNameOverride: Active Users Over Time
@@ -317,7 +320,7 @@ position:
     children: []
     id: CHART-o87Pu6wg5_
     meta:
-      chartId: 454
+      chartId: 22
       height: 50
       sliceName: Most Active Courses Per Day
       uuid: a19a7c6a-e2c9-4033-86b3-b2e5878b5b69
@@ -333,7 +336,7 @@ position:
     children: []
     id: CHART-wz1Y-JkV9-
     meta:
-      chartId: 453
+      chartId: 13
       height: 50
       sliceName: Courses Per Organization
       uuid: 7901d6ae-dea8-4d2c-9232-35c22571cfb7
@@ -424,6 +427,23 @@ position:
     meta:
       text: Operator Dashboard
     type: HEADER
+  MARKDOWN-EZXXAbo-Tg:
+    children: []
+    id: MARKDOWN-EZXXAbo-Tg
+    meta:
+      code: '# Instance information
+
+
+        Aspects Version'
+      height: 50
+      width: 4
+    parents:
+    - ROOT_ID
+    - GRID_ID
+    - TABS-7nA6MwltSD
+    - TAB-DE73B5pXm
+    - ROW-fgCiGD7i8F
+    type: MARKDOWN
   ROOT_ID:
     children:
     - GRID_ID
@@ -481,6 +501,18 @@ position:
     - TABS-7nA6MwltSD
     - TAB-6Mdnw3FZh
     type: ROW
+  ROW-fgCiGD7i8F:
+    children:
+    - MARKDOWN-EZXXAbo-Tg
+    id: ROW-fgCiGD7i8F
+    meta:
+      background: BACKGROUND_TRANSPARENT
+    parents:
+    - ROOT_ID
+    - GRID_ID
+    - TABS-7nA6MwltSD
+    - TAB-DE73B5pXm
+    type: ROW
   ROW-mPSz65tZ7E:
     children:
     - CHART-explore-25-1
@@ -525,6 +557,7 @@ position:
     children:
     - ROW-7gxdpYV-y
     - ROW-mPSz65tZ7E
+    - ROW-fgCiGD7i8F
     id: TAB-DE73B5pXm
     meta:
       defaultText: Tab title

--- a/tutoraspects/templates/openedx-assets/assets/datasets/course_names.yaml
+++ b/tutoraspects/templates/openedx-assets/assets/datasets/course_names.yaml
@@ -57,7 +57,8 @@ fetch_values_predicate: null
 filter_select_enabled: false
 main_dttm_col: null
 metrics:
-- d3format: null
+- currency: null
+  d3format: null
   description: null
   expression: COUNT(*)
   extra: null
@@ -65,6 +66,7 @@ metrics:
   metric_type: count
   verbose_name: COUNT(*)
   warning_text: null
+normalize_columns: true
 offset: 0
 params: null
 schema: {{ ASPECTS_EVENT_SINK_DATABASE }}

--- a/tutoraspects/templates/openedx-assets/assets/datasets/course_overviews.yaml
+++ b/tutoraspects/templates/openedx-assets/assets/datasets/course_overviews.yaml
@@ -165,7 +165,8 @@ fetch_values_predicate: null
 filter_select_enabled: false
 main_dttm_col: null
 metrics:
-- d3format: null
+- currency: null
+  d3format: null
   description: null
   expression: COUNT(*)
   extra: null
@@ -173,6 +174,7 @@ metrics:
   metric_type: count
   verbose_name: COUNT(*)
   warning_text: null
+normalize_columns: true
 offset: 0
 params: null
 schema: {{ ASPECTS_EVENT_SINK_DATABASE }}

--- a/tutoraspects/templates/openedx-assets/assets/datasets/dim_course_problems.yaml
+++ b/tutoraspects/templates/openedx-assets/assets/datasets/dim_course_problems.yaml
@@ -26,18 +26,6 @@ columns:
   type: String
   verbose_name: null
 - advanced_data_type: null
-  column_name: course_run
-  description: null
-  expression: null
-  extra: null
-  filterable: true
-  groupby: true
-  is_active: true
-  is_dttm: false
-  python_date_format: null
-  type: String
-  verbose_name: null
-- advanced_data_type: null
   column_name: problem_id
   description: null
   expression: null
@@ -51,6 +39,18 @@ columns:
   verbose_name: null
 - advanced_data_type: null
   column_name: course_key
+  description: null
+  expression: null
+  extra: null
+  filterable: true
+  groupby: true
+  is_active: true
+  is_dttm: false
+  python_date_format: null
+  type: String
+  verbose_name: null
+- advanced_data_type: null
+  column_name: course_run
   description: null
   expression: null
   extra: null
@@ -81,7 +81,8 @@ fetch_values_predicate: null
 filter_select_enabled: false
 main_dttm_col: null
 metrics:
-- d3format: null
+- currency: null
+  d3format: null
   description: null
   expression: count(*)
   extra: null
@@ -89,9 +90,10 @@ metrics:
   metric_type: null
   verbose_name: null
   warning_text: null
+normalize_columns: true
 offset: 0
 params: null
-schema: null
+schema: main
 sql: "{% include 'openedx-assets/queries/dim_course_problems.sql' %}"
 table_name: dim_course_problems
 template_params: {}

--- a/tutoraspects/templates/openedx-assets/assets/datasets/dim_course_videos.yaml
+++ b/tutoraspects/templates/openedx-assets/assets/datasets/dim_course_videos.yaml
@@ -26,7 +26,7 @@ columns:
   type: String
   verbose_name: null
 - advanced_data_type: null
-  column_name: course_run
+  column_name: course_key
   description: null
   expression: null
   extra: null
@@ -38,7 +38,7 @@ columns:
   type: String
   verbose_name: null
 - advanced_data_type: null
-  column_name: course_key
+  column_name: course_run
   description: null
   expression: null
   extra: null
@@ -81,7 +81,8 @@ fetch_values_predicate: null
 filter_select_enabled: false
 main_dttm_col: null
 metrics:
-- d3format: null
+- currency: null
+  d3format: null
   description: null
   expression: count(*)
   extra: null
@@ -89,9 +90,10 @@ metrics:
   metric_type: null
   verbose_name: null
   warning_text: null
+normalize_columns: true
 offset: 0
 params: null
-schema: null
+schema: main
 sql: "{% include 'openedx-assets/queries/dim_course_videos.sql' %}"
 table_name: dim_course_videos
 template_params: {}

--- a/tutoraspects/templates/openedx-assets/assets/datasets/fact_course_grades.yaml
+++ b/tutoraspects/templates/openedx-assets/assets/datasets/fact_course_grades.yaml
@@ -1,126 +1,126 @@
 _file_name: fact_course_grades.yaml
 cache_timeout: null
 columns:
-  - advanced_data_type: null
-    column_name: emission_time
-    description: null
-    expression: null
-    extra: null
-    filterable: true
-    groupby: true
-    is_active: true
-    is_dttm: true
-    python_date_format: null
-    type: DateTime
-    verbose_name: null
-  - advanced_data_type: null
-    column_name: scaled_score
-    description: null
-    expression: null
-    extra: null
-    filterable: true
-    groupby: true
-    is_active: true
-    is_dttm: false
-    python_date_format: null
-    type: Float
-    verbose_name: null
-  - advanced_data_type: null
-    column_name: grade_bucket
-    description: null
-    expression: null
-    extra: null
-    filterable: true
-    groupby: true
-    is_active: true
-    is_dttm: false
-    python_date_format: null
-    type: String
-    verbose_name: null
-  - advanced_data_type: null
-    column_name: actor_id
-    description: null
-    expression: null
-    extra: null
-    filterable: true
-    groupby: true
-    is_active: true
-    is_dttm: false
-    python_date_format: null
-    type: String
-    verbose_name: null
-  - advanced_data_type: null
-    column_name: course_name
-    description: null
-    expression: null
-    extra: null
-    filterable: true
-    groupby: true
-    is_active: true
-    is_dttm: false
-    python_date_format: null
-    type: String
-    verbose_name: null
-  - advanced_data_type: null
-    column_name: grade_type
-    description: null
-    expression: null
-    extra: null
-    filterable: true
-    groupby: true
-    is_active: true
-    is_dttm: false
-    python_date_format: null
-    type: String
-    verbose_name: null
-  - advanced_data_type: null
-    column_name: entity_name
-    description: null
-    expression: null
-    extra: null
-    filterable: true
-    groupby: true
-    is_active: true
-    is_dttm: false
-    python_date_format: null
-    type: String
-    verbose_name: null
-  - advanced_data_type: null
-    column_name: course_key
-    description: null
-    expression: null
-    extra: null
-    filterable: true
-    groupby: true
-    is_active: true
-    is_dttm: false
-    python_date_format: null
-    type: String
-    verbose_name: null
-  - advanced_data_type: null
-    column_name: course_run
-    description: null
-    expression: null
-    extra: null
-    filterable: true
-    groupby: true
-    is_active: true
-    is_dttm: false
-    python_date_format: null
-    type: String
-    verbose_name: null
-  - advanced_data_type: null
-    column_name: org
-    description: null
-    expression: null
-    extra: null
-    filterable: true
-    groupby: true
-    is_active: true
-    is_dttm: false
-    python_date_format: null
-    type: String
-    verbose_name: null
+- advanced_data_type: null
+  column_name: emission_time
+  description: null
+  expression: null
+  extra: null
+  filterable: true
+  groupby: true
+  is_active: true
+  is_dttm: true
+  python_date_format: null
+  type: DateTime
+  verbose_name: null
+- advanced_data_type: null
+  column_name: scaled_score
+  description: null
+  expression: null
+  extra: null
+  filterable: true
+  groupby: true
+  is_active: true
+  is_dttm: false
+  python_date_format: null
+  type: Float
+  verbose_name: null
+- advanced_data_type: null
+  column_name: grade_bucket
+  description: null
+  expression: null
+  extra: null
+  filterable: true
+  groupby: true
+  is_active: true
+  is_dttm: false
+  python_date_format: null
+  type: String
+  verbose_name: null
+- advanced_data_type: null
+  column_name: actor_id
+  description: null
+  expression: null
+  extra: null
+  filterable: true
+  groupby: true
+  is_active: true
+  is_dttm: false
+  python_date_format: null
+  type: String
+  verbose_name: null
+- advanced_data_type: null
+  column_name: course_name
+  description: null
+  expression: null
+  extra: null
+  filterable: true
+  groupby: true
+  is_active: true
+  is_dttm: false
+  python_date_format: null
+  type: String
+  verbose_name: null
+- advanced_data_type: null
+  column_name: grade_type
+  description: null
+  expression: null
+  extra: null
+  filterable: true
+  groupby: true
+  is_active: true
+  is_dttm: false
+  python_date_format: null
+  type: String
+  verbose_name: null
+- advanced_data_type: null
+  column_name: entity_name
+  description: null
+  expression: null
+  extra: null
+  filterable: true
+  groupby: true
+  is_active: true
+  is_dttm: false
+  python_date_format: null
+  type: String
+  verbose_name: null
+- advanced_data_type: null
+  column_name: course_key
+  description: null
+  expression: null
+  extra: null
+  filterable: true
+  groupby: true
+  is_active: true
+  is_dttm: false
+  python_date_format: null
+  type: String
+  verbose_name: null
+- advanced_data_type: null
+  column_name: course_run
+  description: null
+  expression: null
+  extra: null
+  filterable: true
+  groupby: true
+  is_active: true
+  is_dttm: false
+  python_date_format: null
+  type: String
+  verbose_name: null
+- advanced_data_type: null
+  column_name: org
+  description: null
+  expression: null
+  extra: null
+  filterable: true
+  groupby: true
+  is_active: true
+  is_dttm: false
+  python_date_format: null
+  type: String
+  verbose_name: null
 database_uuid: 21174b6c-4d40-4958-8161-d6c3cf5e77b6
 default_endpoint: null
 description: null
@@ -129,17 +129,19 @@ fetch_values_predicate: null
 filter_select_enabled: false
 main_dttm_col: null
 metrics:
-  - d3format: null
-    description: null
-    expression: count(*)
-    extra: null
-    metric_name: count
-    metric_type: null
-    verbose_name: null
-    warning_text: null
+- currency: null
+  d3format: null
+  description: null
+  expression: count(*)
+  extra: null
+  metric_name: count
+  metric_type: null
+  verbose_name: null
+  warning_text: null
+normalize_columns: true
 offset: 0
 params: null
-schema: null
+schema: main
 sql: "{% include 'openedx-assets/queries/fact_course_grades.sql' %}"
 table_name: fact_course_grades
 template_params: {}

--- a/tutoraspects/templates/openedx-assets/assets/datasets/fact_enrollments.yaml
+++ b/tutoraspects/templates/openedx-assets/assets/datasets/fact_enrollments.yaml
@@ -38,18 +38,6 @@ columns:
   type: String
   verbose_name: null
 - advanced_data_type: null
-  column_name: course_key
-  description: null
-  expression: null
-  extra: null
-  filterable: true
-  groupby: true
-  is_active: true
-  is_dttm: false
-  python_date_format: null
-  type: String
-  verbose_name: null
-- advanced_data_type: null
   column_name: course_name
   description: null
   expression: null
@@ -63,6 +51,18 @@ columns:
   verbose_name: null
 - advanced_data_type: null
   column_name: enrollment_status
+  description: null
+  expression: null
+  extra: null
+  filterable: true
+  groupby: true
+  is_active: true
+  is_dttm: false
+  python_date_format: null
+  type: String
+  verbose_name: null
+- advanced_data_type: null
+  column_name: course_key
   description: null
   expression: null
   extra: null
@@ -105,7 +105,8 @@ fetch_values_predicate: null
 filter_select_enabled: false
 main_dttm_col: null
 metrics:
-- d3format: null
+- currency: null
+  d3format: null
   description: null
   expression: count(*)
   extra: null
@@ -113,9 +114,10 @@ metrics:
   metric_type: null
   verbose_name: null
   warning_text: null
+normalize_columns: true
 offset: 0
 params: null
-schema: null
+schema: main
 sql: "{% include 'openedx-assets/queries/fact_enrollments.sql' %}"
 table_name: fact_enrollments
 template_params: {}

--- a/tutoraspects/templates/openedx-assets/assets/datasets/fact_enrollments_by_day.yaml
+++ b/tutoraspects/templates/openedx-assets/assets/datasets/fact_enrollments_by_day.yaml
@@ -38,18 +38,6 @@ columns:
   type: String
   verbose_name: null
 - advanced_data_type: null
-  column_name: course_key
-  description: null
-  expression: null
-  extra: null
-  filterable: true
-  groupby: true
-  is_active: true
-  is_dttm: false
-  python_date_format: null
-  type: String
-  verbose_name: null
-- advanced_data_type: null
   column_name: course_name
   description: null
   expression: null
@@ -63,6 +51,18 @@ columns:
   verbose_name: null
 - advanced_data_type: null
   column_name: enrollment_status
+  description: null
+  expression: null
+  extra: null
+  filterable: true
+  groupby: true
+  is_active: true
+  is_dttm: false
+  python_date_format: null
+  type: String
+  verbose_name: null
+- advanced_data_type: null
+  column_name: course_key
   description: null
   expression: null
   extra: null
@@ -105,7 +105,8 @@ fetch_values_predicate: null
 filter_select_enabled: false
 main_dttm_col: null
 metrics:
-- d3format: null
+- currency: null
+  d3format: null
   description: null
   expression: count(*)
   extra: null
@@ -113,9 +114,10 @@ metrics:
   metric_type: null
   verbose_name: null
   warning_text: null
+normalize_columns: true
 offset: 0
 params: null
-schema: null
+schema: main
 sql: "{% include 'openedx-assets/queries/fact_enrollments_by_day.sql' %}"
 table_name: fact_enrollments_by_day
 template_params: {}

--- a/tutoraspects/templates/openedx-assets/assets/datasets/fact_learner_problem_course_summary.yaml
+++ b/tutoraspects/templates/openedx-assets/assets/datasets/fact_learner_problem_course_summary.yaml
@@ -1,126 +1,126 @@
 _file_name: fact_learner_problem_course_summary.yaml
 cache_timeout: null
 columns:
-  - advanced_data_type: null
-    column_name: attempts
-    description: null
-    expression: null
-    extra: null
-    filterable: true
-    groupby: true
-    is_active: true
-    is_dttm: false
-    python_date_format: null
-    type: Int16
-    verbose_name: null
-  - advanced_data_type: null
-    column_name: num_answers_displayed
-    description: null
-    expression: null
-    extra: null
-    filterable: true
-    groupby: true
-    is_active: true
-    is_dttm: false
-    python_date_format: null
-    type: UInt64
-    verbose_name: null
-  - advanced_data_type: null
-    column_name: num_hints_displayed
-    description: null
-    expression: null
-    extra: null
-    filterable: true
-    groupby: true
-    is_active: true
-    is_dttm: false
-    python_date_format: null
-    type: UInt64
-    verbose_name: null
-  - advanced_data_type: null
-    column_name: success
-    description: null
-    expression: null
-    extra: null
-    filterable: true
-    groupby: true
-    is_active: true
-    is_dttm: false
-    python_date_format: null
-    type: Bool
-    verbose_name: null
-  - advanced_data_type: null
-    column_name: problem_name
-    description: null
-    expression: null
-    extra: null
-    filterable: true
-    groupby: true
-    is_active: true
-    is_dttm: false
-    python_date_format: null
-    type: String
-    verbose_name: null
-  - advanced_data_type: null
-    column_name: actor_id
-    description: null
-    expression: null
-    extra: null
-    filterable: true
-    groupby: true
-    is_active: true
-    is_dttm: false
-    python_date_format: null
-    type: String
-    verbose_name: null
-  - advanced_data_type: null
-    column_name: course_name
-    description: null
-    expression: null
-    extra: null
-    filterable: true
-    groupby: true
-    is_active: true
-    is_dttm: false
-    python_date_format: null
-    type: String
-    verbose_name: null
-  - advanced_data_type: null
-    column_name: course_key
-    description: null
-    expression: null
-    extra: null
-    filterable: true
-    groupby: true
-    is_active: true
-    is_dttm: false
-    python_date_format: null
-    type: String
-    verbose_name: null
-  - advanced_data_type: null
-    column_name: course_run
-    description: null
-    expression: null
-    extra: null
-    filterable: true
-    groupby: true
-    is_active: true
-    is_dttm: false
-    python_date_format: null
-    type: String
-    verbose_name: null
-  - advanced_data_type: null
-    column_name: org
-    description: null
-    expression: null
-    extra: null
-    filterable: true
-    groupby: true
-    is_active: true
-    is_dttm: false
-    python_date_format: null
-    type: String
-    verbose_name: null
+- advanced_data_type: null
+  column_name: attempts
+  description: null
+  expression: null
+  extra: null
+  filterable: true
+  groupby: true
+  is_active: true
+  is_dttm: false
+  python_date_format: null
+  type: Int16
+  verbose_name: null
+- advanced_data_type: null
+  column_name: num_answers_displayed
+  description: null
+  expression: null
+  extra: null
+  filterable: true
+  groupby: true
+  is_active: true
+  is_dttm: false
+  python_date_format: null
+  type: UInt64
+  verbose_name: null
+- advanced_data_type: null
+  column_name: num_hints_displayed
+  description: null
+  expression: null
+  extra: null
+  filterable: true
+  groupby: true
+  is_active: true
+  is_dttm: false
+  python_date_format: null
+  type: UInt64
+  verbose_name: null
+- advanced_data_type: null
+  column_name: success
+  description: null
+  expression: null
+  extra: null
+  filterable: true
+  groupby: true
+  is_active: true
+  is_dttm: false
+  python_date_format: null
+  type: Bool
+  verbose_name: null
+- advanced_data_type: null
+  column_name: problem_name
+  description: null
+  expression: null
+  extra: null
+  filterable: true
+  groupby: true
+  is_active: true
+  is_dttm: false
+  python_date_format: null
+  type: String
+  verbose_name: null
+- advanced_data_type: null
+  column_name: actor_id
+  description: null
+  expression: null
+  extra: null
+  filterable: true
+  groupby: true
+  is_active: true
+  is_dttm: false
+  python_date_format: null
+  type: String
+  verbose_name: null
+- advanced_data_type: null
+  column_name: course_name
+  description: null
+  expression: null
+  extra: null
+  filterable: true
+  groupby: true
+  is_active: true
+  is_dttm: false
+  python_date_format: null
+  type: String
+  verbose_name: null
+- advanced_data_type: null
+  column_name: course_key
+  description: null
+  expression: null
+  extra: null
+  filterable: true
+  groupby: true
+  is_active: true
+  is_dttm: false
+  python_date_format: null
+  type: String
+  verbose_name: null
+- advanced_data_type: null
+  column_name: course_run
+  description: null
+  expression: null
+  extra: null
+  filterable: true
+  groupby: true
+  is_active: true
+  is_dttm: false
+  python_date_format: null
+  type: String
+  verbose_name: null
+- advanced_data_type: null
+  column_name: org
+  description: null
+  expression: null
+  extra: null
+  filterable: true
+  groupby: true
+  is_active: true
+  is_dttm: false
+  python_date_format: null
+  type: String
+  verbose_name: null
 database_uuid: 21174b6c-4d40-4958-8161-d6c3cf5e77b6
 default_endpoint: null
 description: null
@@ -129,17 +129,19 @@ fetch_values_predicate: null
 filter_select_enabled: false
 main_dttm_col: null
 metrics:
-  - d3format: null
-    description: null
-    expression: count(*)
-    extra: null
-    metric_name: count
-    metric_type: null
-    verbose_name: null
-    warning_text: null
+- currency: null
+  d3format: null
+  description: null
+  expression: count(*)
+  extra: null
+  metric_name: count
+  metric_type: null
+  verbose_name: null
+  warning_text: null
+normalize_columns: true
 offset: 0
 params: null
-schema: null
+schema: main
 sql: "{% include 'openedx-assets/queries/fact_learner_problem_course_summary.sql' %}"
 table_name: fact_learner_problem_course_summary
 template_params: null

--- a/tutoraspects/templates/openedx-assets/assets/datasets/fact_learner_problem_summary.yaml
+++ b/tutoraspects/templates/openedx-assets/assets/datasets/fact_learner_problem_summary.yaml
@@ -74,7 +74,7 @@ columns:
   type: String
   verbose_name: null
 - advanced_data_type: null
-  column_name: course_key
+  column_name: course_name
   description: null
   expression: null
   extra: null
@@ -86,7 +86,7 @@ columns:
   type: String
   verbose_name: null
 - advanced_data_type: null
-  column_name: course_name
+  column_name: course_key
   description: null
   expression: null
   extra: null
@@ -129,7 +129,8 @@ fetch_values_predicate: null
 filter_select_enabled: false
 main_dttm_col: null
 metrics:
-- d3format: null
+- currency: null
+  d3format: null
   description: null
   expression: count(*)
   extra: null
@@ -137,9 +138,10 @@ metrics:
   metric_type: null
   verbose_name: null
   warning_text: null
+normalize_columns: true
 offset: 0
 params: null
-schema: null
+schema: main
 sql: "{% include 'openedx-assets/queries/fact_learner_problem_summary.sql' %}"
 table_name: fact_learner_problem_summary
 template_params: null

--- a/tutoraspects/templates/openedx-assets/assets/datasets/fact_problem_grades.yaml
+++ b/tutoraspects/templates/openedx-assets/assets/datasets/fact_problem_grades.yaml
@@ -1,126 +1,126 @@
 _file_name: fact_problem_grades.yaml
 cache_timeout: null
 columns:
-  - advanced_data_type: null
-    column_name: emission_time
-    description: null
-    expression: null
-    extra: null
-    filterable: true
-    groupby: true
-    is_active: true
-    is_dttm: true
-    python_date_format: null
-    type: DateTime
-    verbose_name: null
-  - advanced_data_type: null
-    column_name: scaled_score
-    description: null
-    expression: null
-    extra: null
-    filterable: true
-    groupby: true
-    is_active: true
-    is_dttm: false
-    python_date_format: null
-    type: Float
-    verbose_name: null
-  - advanced_data_type: null
-    column_name: grade_bucket
-    description: null
-    expression: null
-    extra: null
-    filterable: true
-    groupby: true
-    is_active: true
-    is_dttm: false
-    python_date_format: null
-    type: String
-    verbose_name: null
-  - advanced_data_type: null
-    column_name: actor_id
-    description: null
-    expression: null
-    extra: null
-    filterable: true
-    groupby: true
-    is_active: true
-    is_dttm: false
-    python_date_format: null
-    type: String
-    verbose_name: null
-  - advanced_data_type: null
-    column_name: course_name
-    description: null
-    expression: null
-    extra: null
-    filterable: true
-    groupby: true
-    is_active: true
-    is_dttm: false
-    python_date_format: null
-    type: String
-    verbose_name: null
-  - advanced_data_type: null
-    column_name: grade_type
-    description: null
-    expression: null
-    extra: null
-    filterable: true
-    groupby: true
-    is_active: true
-    is_dttm: false
-    python_date_format: null
-    type: String
-    verbose_name: null
-  - advanced_data_type: null
-    column_name: entity_name
-    description: null
-    expression: null
-    extra: null
-    filterable: true
-    groupby: true
-    is_active: true
-    is_dttm: false
-    python_date_format: null
-    type: String
-    verbose_name: null
-  - advanced_data_type: null
-    column_name: course_key
-    description: null
-    expression: null
-    extra: null
-    filterable: true
-    groupby: true
-    is_active: true
-    is_dttm: false
-    python_date_format: null
-    type: String
-    verbose_name: null
-  - advanced_data_type: null
-    column_name: course_run
-    description: null
-    expression: null
-    extra: null
-    filterable: true
-    groupby: true
-    is_active: true
-    is_dttm: false
-    python_date_format: null
-    type: String
-    verbose_name: null
-  - advanced_data_type: null
-    column_name: org
-    description: null
-    expression: null
-    extra: null
-    filterable: true
-    groupby: true
-    is_active: true
-    is_dttm: false
-    python_date_format: null
-    type: String
-    verbose_name: null
+- advanced_data_type: null
+  column_name: emission_time
+  description: null
+  expression: null
+  extra: null
+  filterable: true
+  groupby: true
+  is_active: true
+  is_dttm: true
+  python_date_format: null
+  type: DateTime
+  verbose_name: null
+- advanced_data_type: null
+  column_name: scaled_score
+  description: null
+  expression: null
+  extra: null
+  filterable: true
+  groupby: true
+  is_active: true
+  is_dttm: false
+  python_date_format: null
+  type: Float
+  verbose_name: null
+- advanced_data_type: null
+  column_name: grade_bucket
+  description: null
+  expression: null
+  extra: null
+  filterable: true
+  groupby: true
+  is_active: true
+  is_dttm: false
+  python_date_format: null
+  type: String
+  verbose_name: null
+- advanced_data_type: null
+  column_name: actor_id
+  description: null
+  expression: null
+  extra: null
+  filterable: true
+  groupby: true
+  is_active: true
+  is_dttm: false
+  python_date_format: null
+  type: String
+  verbose_name: null
+- advanced_data_type: null
+  column_name: course_name
+  description: null
+  expression: null
+  extra: null
+  filterable: true
+  groupby: true
+  is_active: true
+  is_dttm: false
+  python_date_format: null
+  type: String
+  verbose_name: null
+- advanced_data_type: null
+  column_name: grade_type
+  description: null
+  expression: null
+  extra: null
+  filterable: true
+  groupby: true
+  is_active: true
+  is_dttm: false
+  python_date_format: null
+  type: String
+  verbose_name: null
+- advanced_data_type: null
+  column_name: entity_name
+  description: null
+  expression: null
+  extra: null
+  filterable: true
+  groupby: true
+  is_active: true
+  is_dttm: false
+  python_date_format: null
+  type: String
+  verbose_name: null
+- advanced_data_type: null
+  column_name: course_key
+  description: null
+  expression: null
+  extra: null
+  filterable: true
+  groupby: true
+  is_active: true
+  is_dttm: false
+  python_date_format: null
+  type: String
+  verbose_name: null
+- advanced_data_type: null
+  column_name: course_run
+  description: null
+  expression: null
+  extra: null
+  filterable: true
+  groupby: true
+  is_active: true
+  is_dttm: false
+  python_date_format: null
+  type: String
+  verbose_name: null
+- advanced_data_type: null
+  column_name: org
+  description: null
+  expression: null
+  extra: null
+  filterable: true
+  groupby: true
+  is_active: true
+  is_dttm: false
+  python_date_format: null
+  type: String
+  verbose_name: null
 database_uuid: 21174b6c-4d40-4958-8161-d6c3cf5e77b6
 default_endpoint: null
 description: null
@@ -129,17 +129,19 @@ fetch_values_predicate: null
 filter_select_enabled: false
 main_dttm_col: null
 metrics:
-  - d3format: null
-    description: null
-    expression: count(*)
-    extra: null
-    metric_name: count
-    metric_type: null
-    verbose_name: null
-    warning_text: null
+- currency: null
+  d3format: null
+  description: null
+  expression: count(*)
+  extra: null
+  metric_name: count
+  metric_type: null
+  verbose_name: null
+  warning_text: null
+normalize_columns: true
 offset: 0
 params: null
-schema: null
+schema: main
 sql: "{% include 'openedx-assets/queries/fact_problem_grades.sql' %}"
 table_name: fact_problem_grades
 template_params: {}

--- a/tutoraspects/templates/openedx-assets/assets/datasets/fact_problem_responses.yaml
+++ b/tutoraspects/templates/openedx-assets/assets/datasets/fact_problem_responses.yaml
@@ -117,7 +117,8 @@ fetch_values_predicate: null
 filter_select_enabled: false
 main_dttm_col: null
 metrics:
-- d3format: null
+- currency: null
+  d3format: null
   description: null
   expression: count(*)
   extra: null
@@ -125,9 +126,10 @@ metrics:
   metric_type: null
   verbose_name: null
   warning_text: null
+normalize_columns: true
 offset: 0
 params: null
-schema: null
+schema: main
 sql: "{% include 'openedx-assets/queries/fact_problem_responses.sql' %}"
 table_name: fact_problem_responses
 template_params: null

--- a/tutoraspects/templates/openedx-assets/assets/datasets/fact_transcript_usage.yaml
+++ b/tutoraspects/templates/openedx-assets/assets/datasets/fact_transcript_usage.yaml
@@ -26,18 +26,6 @@ columns:
   type: String
   verbose_name: null
 - advanced_data_type: null
-  column_name: course_key
-  description: null
-  expression: null
-  extra: null
-  filterable: true
-  groupby: true
-  is_active: true
-  is_dttm: false
-  python_date_format: null
-  type: String
-  verbose_name: null
-- advanced_data_type: null
   column_name: course_name
   description: null
   expression: null
@@ -85,6 +73,18 @@ columns:
   python_date_format: null
   type: String
   verbose_name: null
+- advanced_data_type: null
+  column_name: course_key
+  description: null
+  expression: null
+  extra: null
+  filterable: true
+  groupby: true
+  is_active: true
+  is_dttm: false
+  python_date_format: null
+  type: String
+  verbose_name: null
 database_uuid: 21174b6c-4d40-4958-8161-d6c3cf5e77b6
 default_endpoint: null
 description: null
@@ -93,7 +93,8 @@ fetch_values_predicate: null
 filter_select_enabled: false
 main_dttm_col: null
 metrics:
-- d3format: null
+- currency: null
+  d3format: null
   description: null
   expression: count(*)
   extra:
@@ -102,9 +103,10 @@ metrics:
   metric_type: null
   verbose_name: Total transcript usage
   warning_text: null
+normalize_columns: true
 offset: 0
 params: null
-schema: null
+schema: main
 sql: "{% include 'openedx-assets/queries/fact_transcript_usage.sql' %}"
 table_name: fact_transcript_usage
 template_params: {}

--- a/tutoraspects/templates/openedx-assets/assets/datasets/fact_video_plays.yaml
+++ b/tutoraspects/templates/openedx-assets/assets/datasets/fact_video_plays.yaml
@@ -26,18 +26,6 @@ columns:
   type: String
   verbose_name: null
 - advanced_data_type: null
-  column_name: course_key
-  description: null
-  expression: null
-  extra: null
-  filterable: true
-  groupby: true
-  is_active: true
-  is_dttm: false
-  python_date_format: null
-  type: String
-  verbose_name: null
-- advanced_data_type: null
   column_name: course_name
   description: null
   expression: null
@@ -85,6 +73,18 @@ columns:
   python_date_format: null
   type: String
   verbose_name: null
+- advanced_data_type: null
+  column_name: course_key
+  description: null
+  expression: null
+  extra: null
+  filterable: true
+  groupby: true
+  is_active: true
+  is_dttm: false
+  python_date_format: null
+  type: String
+  verbose_name: null
 database_uuid: 21174b6c-4d40-4958-8161-d6c3cf5e77b6
 default_endpoint: null
 description: null
@@ -93,7 +93,8 @@ fetch_values_predicate: null
 filter_select_enabled: false
 main_dttm_col: null
 metrics:
-- d3format: null
+- currency: null
+  d3format: null
   description: null
   expression: count(*)
   extra:
@@ -102,9 +103,10 @@ metrics:
   metric_type: null
   verbose_name: Total plays
   warning_text: null
+normalize_columns: true
 offset: 0
 params: null
-schema: null
+schema: main
 sql: "{% include 'openedx-assets/queries/fact_video_plays.sql' %}"
 table_name: fact_video_plays
 template_params: {}

--- a/tutoraspects/templates/openedx-assets/assets/datasets/fact_watched_video_segments.yaml
+++ b/tutoraspects/templates/openedx-assets/assets/datasets/fact_watched_video_segments.yaml
@@ -38,18 +38,6 @@ columns:
   type: String
   verbose_name: null
 - advanced_data_type: null
-  column_name: course_key
-  description: null
-  expression: null
-  extra: null
-  filterable: true
-  groupby: true
-  is_active: true
-  is_dttm: false
-  python_date_format: null
-  type: String
-  verbose_name: null
-- advanced_data_type: null
   column_name: course_name
   description: null
   expression: null
@@ -97,6 +85,18 @@ columns:
   python_date_format: null
   type: String
   verbose_name: null
+- advanced_data_type: null
+  column_name: course_key
+  description: null
+  expression: null
+  extra: null
+  filterable: true
+  groupby: true
+  is_active: true
+  is_dttm: false
+  python_date_format: null
+  type: String
+  verbose_name: null
 database_uuid: 21174b6c-4d40-4958-8161-d6c3cf5e77b6
 default_endpoint: null
 description: null
@@ -105,7 +105,8 @@ fetch_values_predicate: null
 filter_select_enabled: false
 main_dttm_col: null
 metrics:
-- d3format: null
+- currency: null
+  d3format: null
   description: null
   expression: count(*) - count(distinct actor_id)
   extra: {}
@@ -113,7 +114,8 @@ metrics:
   metric_type: null
   verbose_name: Repeat views
   warning_text: null
-- d3format: null
+- currency: null
+  d3format: null
   description: null
   expression: count(*)
   extra:
@@ -122,7 +124,8 @@ metrics:
   metric_type: null
   verbose_name: Total views
   warning_text: null
-- d3format: null
+- currency: null
+  d3format: null
   description: null
   expression: count(distinct actor_id)
   extra: {}
@@ -130,9 +133,10 @@ metrics:
   metric_type: null
   verbose_name: Unique viewers
   warning_text: null
+normalize_columns: true
 offset: 0
 params: null
-schema: null
+schema: main
 sql: "{% include 'openedx-assets/queries/fact_watched_video_segments.sql' %}"
 table_name: fact_watched_video_segments
 template_params: null

--- a/tutoraspects/templates/openedx-assets/assets/datasets/hints_per_success.yaml
+++ b/tutoraspects/templates/openedx-assets/assets/datasets/hints_per_success.yaml
@@ -38,7 +38,7 @@ columns:
   type: String
   verbose_name: null
 - advanced_data_type: null
-  column_name: course_key
+  column_name: course_name
   description: null
   expression: null
   extra: null
@@ -50,7 +50,7 @@ columns:
   type: String
   verbose_name: null
 - advanced_data_type: null
-  column_name: course_name
+  column_name: course_key
   description: null
   expression: null
   extra: null
@@ -93,7 +93,8 @@ fetch_values_predicate: null
 filter_select_enabled: false
 main_dttm_col: null
 metrics:
-- d3format: null
+- currency: null
+  d3format: null
   description: null
   expression: count(*)
   extra: null
@@ -101,9 +102,10 @@ metrics:
   metric_type: null
   verbose_name: null
   warning_text: null
+normalize_columns: true
 offset: 0
 params: null
-schema: null
+schema: main
 sql: "{% include 'openedx-assets/queries/hints_per_success.sql' %}"
 table_name: hints_per_success
 template_params: null

--- a/tutoraspects/templates/openedx-assets/assets/datasets/xapi_events_all_parsed.yaml
+++ b/tutoraspects/templates/openedx-assets/assets/datasets/xapi_events_all_parsed.yaml
@@ -153,7 +153,8 @@ fetch_values_predicate: null
 filter_select_enabled: false
 main_dttm_col: emission_time
 metrics:
-- d3format: null
+- currency: null
+  d3format: null
   description: null
   expression: COUNT(*)
   extra:
@@ -162,6 +163,7 @@ metrics:
   metric_type: count
   verbose_name: COUNT(*)
   warning_text: null
+normalize_columns: true
 offset: 0
 params: null
 schema: {{ASPECTS_XAPI_DATABASE}}


### PR DESCRIPTION
## Description:

This PR updates the YAML definition of the assets to the new Superset version. It also adds a version card to the operator dashboard:

![image](https://github.com/openedx/tutor-contrib-aspects/assets/33465240/43a6c1b6-1cfb-4a76-9d35-929b318d99a8)


Fixes: #359 

