### PR TITLE
feat: upgrade event-routing-backends to 6.2.0

### DIFF
--- a/tutoraspects/plugin.py
+++ b/tutoraspects/plugin.py
@@ -46,7 +46,7 @@ hooks.Filters.CONFIG_DEFAULTS.add_items(
             "OPENEDX_EXTRA_PIP_REQUIREMENTS",
             [
                 "openedx-event-sink-clickhouse==0.2.2",
-                "edx-event-routing-backends==5.6.0",
+                "edx-event-routing-backends==6.2.0",
             ],
         ),
         ("EVENT_SINK_CLICKHOUSE_MODELS", ["course_overviews", "user_profile"]),


### PR DESCRIPTION
### Description

This PR upgrades event-routing-backends to 6.2.0.

Full changelog: https://github.com/openedx/event-routing-backends/compare/v5.6.0...v6.2.0