### PR TITLE
fix: remove cache for get_courses

### DIFF
--- a/tutoraspects/templates/aspects/apps/superset/pythonpath/openedx_sso_security_manager.py
+++ b/tutoraspects/templates/aspects/apps/superset/pythonpath/openedx_sso_security_manager.py
@@ -190,7 +190,6 @@ class OpenEdxSsoSecurityManager(SupersetSecurityManager):
         {{patch("superset-sso-assignment-rules") | indent(8)}}
         return None
 
-    @lru_cache(maxsize=LRU_CACHE_MAX_SIZE)
     def get_courses(self, username, permission="staff", next_url=None):
         """
         Returns the list of courses the current user has access to.


### PR DESCRIPTION
This fixes an issue in small installations where if the permissions were granted after the user login to Superset, superset will cache forever the missing permissions and the server needs to be restarted

Fixes: https://github.com/openedx/tutor-contrib-aspects/issues/406