### PR TITLE
feat: add tutor patches for superset config

### DIFF
--- a/tutoraspects/templates/aspects/apps/superset/pythonpath/superset_config.py
+++ b/tutoraspects/templates/aspects/apps/superset/pythonpath/superset_config.py
@@ -161,6 +161,8 @@ TALISMAN_CONFIG = {{SUPERSET_TALISMAN_CONFIG}}
 
 BABEL_DEFAULT_LOCALE = "{{ SUPERSET_DEFAULT_LOCALE }}"
 
+{{ patch('superset-config')}}
+
 # Optionally import superset_config_docker.py (which will have been included on
 # the PYTHONPATH) in order to allow for local settings to be overridden
 #

--- a/tutoraspects/templates/aspects/apps/superset/pythonpath/superset_config_docker.py
+++ b/tutoraspects/templates/aspects/apps/superset/pythonpath/superset_config_docker.py
@@ -107,3 +107,6 @@ JINJA_CONTEXT_ADDONS = {
 # https://flask.palletsprojects.com/en/latest/deploying/proxy_fix/
 ENABLE_PROXY_FIX = True
 {% endif %}
+
+
+{{ patch('superset-config-docker')}}


### PR DESCRIPTION
### Description

This PR implements add two new patches:
- `superset-config`: Allow to add/override Superset production config
- `superset-config-docker`: Allow to add/override Superset docker config