### PR TITLE
fix: consistently apply datetime filter on problem engagement tab (FC-0033)

### DIFF
--- a/tutoraspects/templates/openedx-assets/queries/fact_learner_problem_course_summary.sql
+++ b/tutoraspects/templates/openedx-assets/queries/fact_learner_problem_course_summary.sql
@@ -82,6 +82,15 @@ WITH problem_responses AS (
         0 AS num_hints_displayed,
         0 AS num_answers_displayed
     FROM int_problem_results
+    WHERE 1=1
+    {% raw %}
+    {% if from_dttm is not none %}
+    and emission_time > '{{ from_dttm }}'
+    {% endif %}
+    {% if to_dttm is not none %}
+    and emission_time < '{{ to_dttm }}'
+    {% endif %}
+    {% endraw %}
     UNION ALL
     SELECT
         org,
@@ -96,6 +105,14 @@ WITH problem_responses AS (
         caseWithExpression(help_type, 'answer', 1, 0) AS num_answers_displayed
     FROM {{ DBT_PROFILE_TARGET_DATABASE }}.int_problem_hints
     WHERE 1=1
+    {% raw %}
+    {% if from_dttm is not none %}
+    and emission_time > '{{ from_dttm }}'
+    {% endif %}
+    {% if to_dttm is not none %}
+    and emission_time < '{{ to_dttm }}'
+    {% endif %}
+    {% endraw %}
     {% include 'openedx-assets/queries/common_filters.sql' %}
 )
 


### PR DESCRIPTION
The "Responses Per Problem" chart on the problem engagement tab does not respond to the datetime filters. This PR adds those filters to the templated query powering the chart so that it may accurately reflect the chosen filters.