### PR TITLE
feat: display multiple-choice answers separately (FC-0033)

### DIFF
--- a/tutoraspects/plugin.py
+++ b/tutoraspects/plugin.py
@@ -319,7 +319,7 @@ hooks.Filters.CONFIG_DEFAULTS.add_items(
         # For now we are pulling this from github, which should allow maximum
         # flexibility for forking, running branches, specific versions, etc.
         ("DBT_REPOSITORY", "https://github.com/openedx/aspects-dbt"),
-        ("DBT_BRANCH", "v2.6"),
+        ("DBT_BRANCH", "v2.7"),
         # Path to the dbt project inside the repository
         ("DBT_REPOSITORY_PATH", "aspects-dbt"),
         # This is a pip compliant list of Python packages to install to run dbt

--- a/tutoraspects/templates/openedx-assets/queries/fact_learner_problem_summary.sql
+++ b/tutoraspects/templates/openedx-assets/queries/fact_learner_problem_summary.sql
@@ -8,7 +8,7 @@ WITH problem_responses AS (
         problem_id,
         actor_id,
         success,
-        first_value(success) OVER (PARTITION BY course_key, problem_id, actor_id ORDER BY success DESC) AS was_successful
+        first_value(success) OVER (PARTITION BY course_key, problem_id, actor_id ORDER BY success ASC) AS was_successful
     FROM problem_responses
 ), successful_responses AS (
     SELECT

--- a/tutoraspects/templates/openedx-assets/queries/fact_problem_responses.sql
+++ b/tutoraspects/templates/openedx-assets/queries/fact_problem_responses.sql
@@ -14,7 +14,12 @@ select
     actor_id,
     attempts,
     success,
-    responses
+    arrayJoin(
+        if(
+            startsWith(responses, '['),
+            cast(responses as Array(String)),
+            [responses]
+    )) as responses
 from
     problem_responses
 where


### PR DESCRIPTION
Addresses #479 

This change updates the "Distribution of Responses" chart to show each choice individually for multiple-choice problems. This also fixes a bug with the problem-level learner summary model exposed by accommodating problems with multiple parts.

Here is a screenshot of the chart with the new query:
![Screenshot from 2023-10-19 12-48-19](https://github.com/openedx/tutor-contrib-aspects/assets/2566242/e2490f9d-a595-4405-994a-5326307ce99e)
