### PR TITLE
fix: Change translations source path

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -120,7 +120,7 @@ Contributing Charts and Dashboards to Aspects
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 The Superset assets provided by Aspects can be found in the templated
-`tutoraspects/templates/openedx-assets/assets` directory. For the most part,
+`tutoraspects/templates/aspects/build/aspects-superset/openedx-assets/assets/` directory. For the most part,
 these files are what Superset exports, but with some crucial differences
 which make these assets usable across all Tutor deployments.
 

--- a/scripts/translate_utils.py
+++ b/scripts/translate_utils.py
@@ -11,7 +11,11 @@ ASSET_FOLDER_MAPPING = {
 
 def get_text_for_translations(root_path):
     assets_path = (
-        os.path.join(root_path, "tutoraspects/templates/openedx-assets/assets/")
+        os.path.join(
+            root_path,
+            "tutoraspects/templates/aspects/build/aspects-superset/"
+            "openedx-assets/assets/"
+        )
     )
 
     print(f"Assets path: {assets_path}")


### PR DESCRIPTION
This path change got missed in the assets refactor, causing source strings to be deleted in Transifex.