### PR TITLE
refactor: replaces dashboard tab docs with link to openedx-aspects docs

### DIFF
--- a/tutoraspects/plugin.py
+++ b/tutoraspects/plugin.py
@@ -50,7 +50,14 @@ hooks.Filters.CONFIG_DEFAULTS.add_items(
         # in the ClickHouse database. Make sure that you understand the legal
         # consequences of data storage and privacy before turning this on!
         ("ASPECTS_ENABLE_PII", False),
-        ("ASPECTS_DOCS_ROOT_URL", "https://docs.openedx.org/projects/openedx-aspects/en/latest/"),
+
+        # Set this to empty string/False to omit Help tabs from the dashboard.
+        # Newlines and double-quotes must be escaped.
+        ("ASPECTS_HELP_MARKDOWN",
+         "## Help\\n"
+         "* [Aspects Documentation](https://docs.openedx.org/projects/openedx-aspects/)\\n"
+         "* [Superset Resources](https://github.com/apache/superset#resources)\\n"
+        ),
         # ClickHouse xAPI settings
         ("ASPECTS_XAPI_DATABASE", "xapi"),
         ("ASPECTS_RAW_XAPI_TABLE", "xapi_events_all"),

--- a/tutoraspects/plugin.py
+++ b/tutoraspects/plugin.py
@@ -50,6 +50,7 @@ hooks.Filters.CONFIG_DEFAULTS.add_items(
         # in the ClickHouse database. Make sure that you understand the legal
         # consequences of data storage and privacy before turning this on!
         ("ASPECTS_ENABLE_PII", False),
+        ("ASPECTS_DOCS_ROOT_URL", "https://docs.openedx.org/projects/openedx-aspects/en/latest/"),
         # ClickHouse xAPI settings
         ("ASPECTS_XAPI_DATABASE", "xapi"),
         ("ASPECTS_RAW_XAPI_TABLE", "xapi_events_all"),

--- a/tutoraspects/plugin.py
+++ b/tutoraspects/plugin.py
@@ -56,15 +56,15 @@ hooks.Filters.CONFIG_DEFAULTS.add_items(
         (
             "ASPECTS_INSTRUCTOR_HELP_MARKDOWN",
             "## Help\\n"
-            "* [Aspects Reference]"
-            "(https://docs.openedx.org/projects/openedx-aspects/page/reference/instructor_reports.html)\\n"
+            "* [Aspects Reference](https://docs.openedx.org/projects/openedx-aspects/page/"
+            "reference/instructor_reports.html)\\n"
             "* [Superset Resources](https://github.com/apache/superset#resources)\\n",
         ),
         (
             "ASPECTS_OPERATOR_HELP_MARKDOWN",
             "## Help\\n"
-            "* [Aspects Reference]"
-            "(https://docs.openedx.org/projects/openedx-aspects/page/reference/operator_reports.html)\\n"
+            "* [Aspects Reference](https://docs.openedx.org/projects/openedx-aspects/page/"
+            "reference/operator_reports.html)\\n"
             "* [Superset Resources](https://github.com/apache/superset#resources)\\n",
         ),
         # ClickHouse xAPI settings

--- a/tutoraspects/plugin.py
+++ b/tutoraspects/plugin.py
@@ -50,13 +50,13 @@ hooks.Filters.CONFIG_DEFAULTS.add_items(
         # in the ClickHouse database. Make sure that you understand the legal
         # consequences of data storage and privacy before turning this on!
         ("ASPECTS_ENABLE_PII", False),
-
         # Set this to empty string/False to omit Help tabs from the dashboard.
         # Newlines and double-quotes must be escaped.
-        ("ASPECTS_HELP_MARKDOWN",
-         "## Help\\n"
-         "* [Aspects Documentation](https://docs.openedx.org/projects/openedx-aspects/)\\n"
-         "* [Superset Resources](https://github.com/apache/superset#resources)\\n"
+        (
+            "ASPECTS_HELP_MARKDOWN",
+            "## Help\\n"
+            "* [Aspects Reference](https://docs.openedx.org/projects/openedx-aspects/page/reference/)\\n"
+            "* [Superset Resources](https://github.com/apache/superset#resources)\\n",
         ),
         # ClickHouse xAPI settings
         ("ASPECTS_XAPI_DATABASE", "xapi"),

--- a/tutoraspects/plugin.py
+++ b/tutoraspects/plugin.py
@@ -50,12 +50,21 @@ hooks.Filters.CONFIG_DEFAULTS.add_items(
         # in the ClickHouse database. Make sure that you understand the legal
         # consequences of data storage and privacy before turning this on!
         ("ASPECTS_ENABLE_PII", False),
-        # Set this to empty string/False to omit Help tabs from the dashboard.
+        # Markdown comprising the Help tab for the Operator and Instructor dashboards.
+        # Set to empty string/False to omit Help tab entirely from the dashboard.
         # Newlines and double-quotes must be escaped.
         (
-            "ASPECTS_HELP_MARKDOWN",
+            "ASPECTS_INSTRUCTOR_HELP_MARKDOWN",
             "## Help\\n"
-            "* [Aspects Reference](https://docs.openedx.org/projects/openedx-aspects/page/reference/)\\n"
+            "* [Aspects Reference]"
+            "(https://docs.openedx.org/projects/openedx-aspects/page/reference/instructor_reports.html)\\n"
+            "* [Superset Resources](https://github.com/apache/superset#resources)\\n",
+        ),
+        (
+            "ASPECTS_OPERATOR_HELP_MARKDOWN",
+            "## Help\\n"
+            "* [Aspects Reference]"
+            "(https://docs.openedx.org/projects/openedx-aspects/page/reference/operator_reports.html)\\n"
             "* [Superset Resources](https://github.com/apache/superset#resources)\\n",
         ),
         # ClickHouse xAPI settings

--- a/tutoraspects/templates/aspects/build/aspects-superset/openedx-assets/assets/dashboards/Instructor_Dashboard.yaml
+++ b/tutoraspects/templates/aspects/build/aspects-superset/openedx-assets/assets/dashboards/Instructor_Dashboard.yaml
@@ -546,20 +546,10 @@ position:
     children: []
     id: MARKDOWN-904VlyNSAd
     meta:
-      code: '### Course Enrollment
-
-
-
-        These charts can help you understand how many students are enrolled in your
-        course by showing how enrollments have changed over time and which enrollment
-        modes students are choosing. More details about each chart can be found by
-        clicking the "3 dot" menu at the top right of the chart and selecting "Show
-        chart description".
-
-
-        You can filter these results by choosing selecting various options from the
-        filters on the left.'
-      height: 20
+      code: '<div align="right">
+        <a href="{{ASPECTS_DOCS_ROOT_URL}}/reference/intructor_reports.html#course-enrollment-tab">Reference</a>
+        </div>'
+      height: 7
       width: 12
     parents:
     - ROOT_ID
@@ -571,16 +561,10 @@ position:
     children: []
     id: MARKDOWN-Cs_pVxjPWd
     meta:
-      code: '### Problem Performance
-
-
-        These charts help show the difficulty of your problems by showing you which
-        answers your students choose and which require many tries or hints to complete
-        successfully.
-
-
-        **Select a problem from the filters on the left to populate the charts.**'
-      height: 19
+      code: '<div align="right">
+        <a href="{{ASPECTS_DOCS_ROOT_URL}}/reference/intructor_reports.html#problem-performance-tab">Reference</a>
+        </div>'
+      height: 7
       width: 12
     parents:
     - ROOT_ID
@@ -592,15 +576,10 @@ position:
     children: []
     id: MARKDOWN-EVIRENCcGc
     meta:
-      code: '### Video Performance
-
-
-        This section allows you to see which parts of a particular video are most
-        watched or skipped.
-
-
-        **Select a video from the filters on the left to populate these charts.**'
-      height: 15
+      code: '<div align="right">
+        <a href="{{ASPECTS_DOCS_ROOT_URL}}/reference/intructor_reports.html#video-performance-tab">Reference</a>
+        </div>'
+      height: 7
       width: 12
     parents:
     - ROOT_ID
@@ -612,17 +591,10 @@ position:
     children: []
     id: MARKDOWN-FhaKADKFSa
     meta:
-      code: '### Problem Engagement
-
-
-        These charts can help you learn which problems your students have engaged
-        with or skipped, and the relative difficulty of problems across your course.
-        More details about each chart can be found by clicking the "3 dot" menu at
-        the top right of the chart and selecting "Show chart description".
-
-
-        **Select a course from the filters on the left to populate these charts.**'
-      height: 19
+      code: '<div align="right">
+        <a href="{{ASPECTS_DOCS_ROOT_URL}}/reference/intructor_reports.html#problem-engagement-tab">Reference</a>
+        </div>'
+      height: 7
       width: 12
     parents:
     - ROOT_ID
@@ -634,16 +606,10 @@ position:
     children: []
     id: MARKDOWN-NaNsE4EBKf
     meta:
-      code: '### Video Engagement
-
-
-        These charts can help understand which videos are watched, and rewatched,
-        most often. It can also show how many users use the closed captions and transcript
-        features on your videos, and how often.
-
-
-        **Select a course from the filters on the left to populate these charts.**'
-      height: 18
+      code: '<div align="right">
+        <a href="{{ASPECTS_DOCS_ROOT_URL}}/reference/intructor_reports.html#video-engagement-tab">Reference</a>
+        </div>'
+      height: 7
       width: 12
     parents:
     - ROOT_ID
@@ -651,11 +617,37 @@ position:
     - TAB-7PGDduCA7
     - ROW-nNEywSG0jX
     type: MARKDOWN
+  MARKDOWN-vv8ZKwGrlB:
+    children: []
+    id: MARKDOWN-vv8ZKwGrlB
+    meta:
+      code: '<div align="right">
+        <a href="{{ASPECTS_DOCS_ROOT_URL}}/reference/intructor_reports.html#forum-interaction-tab">Reference</a>
+        </div>'
+      height: 7
+      width: 12
+    parents:
+    - ROOT_ID
+    - TABS-SNeKAJcjhd
+    - TAB-eE0OQxuju
+    - ROW-1cVixUyTcv
+    type: MARKDOWN
   ROOT_ID:
     children:
     - TABS-SNeKAJcjhd
     id: ROOT_ID
     type: ROOT
+  ROW-1cVixUyTcv:
+    children:
+    - MARKDOWN-vv8ZKwGrlB
+    id: ROW-1cVixUyTcv
+    meta:
+      background: BACKGROUND_TRANSPARENT
+    parents:
+    - ROOT_ID
+    - TABS-SNeKAJcjhd
+    - TAB-eE0OQxuju
+    type: ROW
   ROW-7H84y2hXCn:
     children:
     - MARKDOWN-Cs_pVxjPWd
@@ -874,6 +866,7 @@ position:
     type: TAB
   TAB-eE0OQxuju:
     children:
+    - ROW-1cVixUyTcv
     - ROW-la1XxBueHN
     id: TAB-eE0OQxuju
     meta:

--- a/tutoraspects/templates/aspects/build/aspects-superset/openedx-assets/assets/dashboards/Instructor_Dashboard.yaml
+++ b/tutoraspects/templates/aspects/build/aspects-superset/openedx-assets/assets/dashboards/Instructor_Dashboard.yaml
@@ -611,7 +611,7 @@ position:
     children: []
     id: MARKDOWN-LGvs7A8_15
     meta:
-      code: "{{ASPECTS_HELP_MARKDOWN}}"
+      code: "{{ASPECTS_INSTRUCTOR_HELP_MARKDOWN}}"
       height: 60
       width: 12
     parents:
@@ -898,7 +898,9 @@ position:
     - TAB-7PGDduCA7
     - TAB-CLiLC4zxo
     - TAB-eE0OQxuju
-    {% if ASPECTS_HELP_MARKDOWN %}- TAB-nXpinnLEX{% endif %}
+    # {% if ASPECTS_INSTRUCTOR_HELP_MARKDOWN %}
+    - TAB-nXpinnLEX
+    # {% endif %}
     id: TABS-SNeKAJcjhd
     meta: {}
     parents:

--- a/tutoraspects/templates/aspects/build/aspects-superset/openedx-assets/assets/dashboards/Instructor_Dashboard.yaml
+++ b/tutoraspects/templates/aspects/build/aspects-superset/openedx-assets/assets/dashboards/Instructor_Dashboard.yaml
@@ -546,9 +546,7 @@ position:
     children: []
     id: MARKDOWN-904VlyNSAd
     meta:
-      code: '<div align="right">
-        <a href="{{ASPECTS_DOCS_ROOT_URL}}/reference/intructor_reports.html#course-enrollment-tab">Reference</a>
-        </div>'
+      code: <div>Filter these results by selecting various options from the filters panel.</div>
       height: 7
       width: 12
     parents:
@@ -561,9 +559,7 @@ position:
     children: []
     id: MARKDOWN-Cs_pVxjPWd
     meta:
-      code: '<div align="right">
-        <a href="{{ASPECTS_DOCS_ROOT_URL}}/reference/intructor_reports.html#problem-performance-tab">Reference</a>
-        </div>'
+      code: <div>Select a problem from the Filters panel to populate the charts.</div>
       height: 7
       width: 12
     parents:
@@ -576,9 +572,7 @@ position:
     children: []
     id: MARKDOWN-EVIRENCcGc
     meta:
-      code: '<div align="right">
-        <a href="{{ASPECTS_DOCS_ROOT_URL}}/reference/intructor_reports.html#video-performance-tab">Reference</a>
-        </div>'
+      code: <div>Select a video from the Filters panel to populate these charts.</div>
       height: 7
       width: 12
     parents:
@@ -591,9 +585,7 @@ position:
     children: []
     id: MARKDOWN-FhaKADKFSa
     meta:
-      code: '<div align="right">
-        <a href="{{ASPECTS_DOCS_ROOT_URL}}/reference/intructor_reports.html#problem-engagement-tab">Reference</a>
-        </div>'
+      code: <div>Select a course from the Filters panel to populate these charts.</div>
       height: 7
       width: 12
     parents:
@@ -606,9 +598,7 @@ position:
     children: []
     id: MARKDOWN-NaNsE4EBKf
     meta:
-      code: '<div align="right">
-        <a href="{{ASPECTS_DOCS_ROOT_URL}}/reference/intructor_reports.html#video-engagement-tab">Reference</a>
-        </div>'
+      code: <div>Select a course from the Filters panel to populate these charts.</div>
       height: 7
       width: 12
     parents:
@@ -617,37 +607,24 @@ position:
     - TAB-7PGDduCA7
     - ROW-nNEywSG0jX
     type: MARKDOWN
-  MARKDOWN-vv8ZKwGrlB:
+  MARKDOWN-LGvs7A8_15:
     children: []
-    id: MARKDOWN-vv8ZKwGrlB
+    id: MARKDOWN-LGvs7A8_15
     meta:
-      code: '<div align="right">
-        <a href="{{ASPECTS_DOCS_ROOT_URL}}/reference/intructor_reports.html#forum-interaction-tab">Reference</a>
-        </div>'
-      height: 7
+      code: "{{ASPECTS_HELP_MARKDOWN}}"
+      height: 60
       width: 12
     parents:
     - ROOT_ID
     - TABS-SNeKAJcjhd
-    - TAB-eE0OQxuju
-    - ROW-1cVixUyTcv
+    - TAB-nXpinnLEX
+    - ROW-0rN_IHNT9-
     type: MARKDOWN
   ROOT_ID:
     children:
     - TABS-SNeKAJcjhd
     id: ROOT_ID
     type: ROOT
-  ROW-1cVixUyTcv:
-    children:
-    - MARKDOWN-vv8ZKwGrlB
-    id: ROW-1cVixUyTcv
-    meta:
-      background: BACKGROUND_TRANSPARENT
-    parents:
-    - ROOT_ID
-    - TABS-SNeKAJcjhd
-    - TAB-eE0OQxuju
-    type: ROW
   ROW-7H84y2hXCn:
     children:
     - MARKDOWN-Cs_pVxjPWd
@@ -807,6 +784,17 @@ position:
     - TABS-SNeKAJcjhd
     - TAB-NR4UTAs9K
     type: ROW
+  ROW-0rN_IHNT9-:
+    children:
+    - MARKDOWN-LGvs7A8_15
+    id: ROW-0rN_IHNT9-
+    meta:
+      background: BACKGROUND_TRANSPARENT
+    parents:
+    - ROOT_ID
+    - TABS-SNeKAJcjhd
+    - TAB-nXpinnLEX
+    type: ROW
   TAB-7PGDduCA7:
     children:
     - ROW-nNEywSG0jX
@@ -866,7 +854,6 @@ position:
     type: TAB
   TAB-eE0OQxuju:
     children:
-    - ROW-1cVixUyTcv
     - ROW-la1XxBueHN
     id: TAB-eE0OQxuju
     meta:
@@ -891,6 +878,18 @@ position:
     - ROOT_ID
     - TABS-SNeKAJcjhd
     type: TAB
+  TAB-nXpinnLEX:
+    children:
+    - ROW-0rN_IHNT9-
+    id: TAB-nXpinnLEX
+    meta:
+      defaultText: Tab title
+      placeholder: Tab title
+      text: Help
+    parents:
+    - ROOT_ID
+    - TABS-SNeKAJcjhd
+    type: TAB
   TABS-SNeKAJcjhd:
     children:
     - TAB-8BxDuJd9Jb
@@ -899,6 +898,7 @@ position:
     - TAB-7PGDduCA7
     - TAB-CLiLC4zxo
     - TAB-eE0OQxuju
+    {% if ASPECTS_HELP_MARKDOWN %}- TAB-nXpinnLEX{% endif %}
     id: TABS-SNeKAJcjhd
     meta: {}
     parents:

--- a/tutoraspects/templates/aspects/build/aspects-superset/openedx-assets/assets/dashboards/Operator_Dashboard.yaml
+++ b/tutoraspects/templates/aspects/build/aspects-superset/openedx-assets/assets/dashboards/Operator_Dashboard.yaml
@@ -894,6 +894,18 @@ position:
     - ROW-mPSz65tZ7E
     - COLUMN-GDahqg06nQ
     type: MARKDOWN
+  MARKDOWN-fLG7yz1R1t:
+    children: []
+    id: MARKDOWN-fLG7yz1R1t
+    meta:
+      code: "{{ASPECTS_OPERATOR_HELP_MARKDOWN}}"
+      height: 50
+      width: 4
+    parents:
+    - ROOT_ID
+    - GRID_ID
+    - ROW-yuEVxRJ4Of
+    type: MARKDOWN
   ROOT_ID:
     children:
     - GRID_ID
@@ -1029,6 +1041,18 @@ position:
     - TABS-7nA6MwltSD
     - TAB-z7LunkNp63
     type: ROW
+  ROW-lcH-BIR2I:
+    children:
+    - MARKDOWN-fLG7yz1R1t
+    id: ROW-lcH-BIR2I
+    meta:
+      background: BACKGROUND_TRANSPARENT
+    parents:
+    - ROOT_ID
+    - GRID_ID
+    - TABS-7nA6MwltSD
+    - TAB-RtC9PHwXy
+    type: ROW
   TAB-6Mdnw3FZh:
     children:
     - ROW-Z0QlRyckta
@@ -1114,6 +1138,19 @@ position:
     - GRID_ID
     - TABS-7nA6MwltSD
     type: TAB
+  TAB-RtC9PHwXy:
+    children:
+    - ROW-lcH-BIR2I
+    id: TAB-RtC9PHwXy
+    meta:
+      defaultText: Tab title
+      placeholder: Tab title
+      text: Help
+    parents:
+    - ROOT_ID
+    - GRID_ID
+    - TABS-7nA6MwltSD
+    type: TAB
   TABS-7nA6MwltSD:
     children:
     - TAB-DE73B5pXm
@@ -1122,6 +1159,9 @@ position:
     - TAB-EygpebMa1
     - TAB-gvqU89mvT
     - TAB-z7LunkNp63
+    # {% if ASPECTS_OPERATOR_HELP_MARKDOWN %}
+    - TAB-RtC9PHwXy
+    # {% endif %}
     id: TABS-7nA6MwltSD
     meta: {}
     parents:


### PR DESCRIPTION
Moves the lengthy text descriptions out of the Dashboards and Charts and replaces them with deep links into the openedx-aspects reference documentation.

The Help markdown is configurable for each of the Operator and Instructor Dashboards, or the Help tab(s) may be omitted entirely by setting:

```
# Hide Instructor Dashboard Help tab
tutor config save -s ASPECTS_INSTRUCTOR_HELP_MARKDOWN=""

# Hide the Operator Dashboard Help tab
tutor config save -s ASPECTS_OPERATOR_HELP_MARKDOWN=""
```

## Screenshots

![help_instructor](https://github.com/openedx/tutor-contrib-aspects/assets/7556571/ddacdab8-ca56-4111-9f2e-49e7a3f3c82d)

![help_operator](https://github.com/openedx/tutor-contrib-aspects/assets/7556571/25da6bf5-a3e3-4657-9788-74d1fa96c1f8)

## References

ref https://github.com/openedx/tutor-contrib-aspects/issues/169

Related to https://github.com/openedx/openedx-aspects/pull/100