### PR TITLE
fix: use tutor variables to expose clickhouse container ports in k8s

### DIFF
--- a/tutoraspects/patches/k8s-deployments
+++ b/tutoraspects/patches/k8s-deployments
@@ -30,9 +30,9 @@ spec:
           image: {{ DOCKER_IMAGE_CLICKHOUSE }}
           name: clickhouse
           ports:
-            - containerPort: "{{ CLICKHOUSE_HOST_INSECURE_HTTP_PORT }}"
-            - containerPort: "{{ CLICKHOUSE_HOST_INSECURE_NATIVE_PORT }}"
-            - containerPort: "{{ CLICKHOUSE_HOST_TLS_NATIVE_PORT }}"
+            - containerPort: {{ CLICKHOUSE_HOST_INSECURE_HTTP_PORT }}
+            - containerPort: {{ CLICKHOUSE_HOST_INSECURE_NATIVE_PORT }}
+            - containerPort: {{ CLICKHOUSE_HOST_TLS_NATIVE_PORT }}
           volumeMounts:
             - mountPath: /var/lib/clickhouse/
               name: data

--- a/tutoraspects/patches/k8s-deployments
+++ b/tutoraspects/patches/k8s-deployments
@@ -30,9 +30,9 @@ spec:
           image: {{ DOCKER_IMAGE_CLICKHOUSE }}
           name: clickhouse
           ports:
-            - containerPort: 8123
-            - containerPort: 9000
-            - containerPort: 9009
+            - containerPort: "{{ CLICKHOUSE_HOST_INSECURE_HTTP_PORT }}"
+            - containerPort: "{{ CLICKHOUSE_HOST_INSECURE_NATIVE_PORT }}"
+            - containerPort: "{{ CLICKHOUSE_HOST_TLS_NATIVE_PORT }}"
           volumeMounts:
             - mountPath: /var/lib/clickhouse/
               name: data


### PR DESCRIPTION
### Description

Updates the k8s configuration to use Tutor variables when exposing the Clickhouse container ports.

### Related information

Closes https://github.com/openedx/tutor-contrib-aspects/issues/387