### PR TITLE
Use shortened course key on Operator Course charts

### DIFF
--- a/tutoraspects/templates/aspects/build/aspects-superset/openedx-assets/assets/charts/Events_per_course.yaml
+++ b/tutoraspects/templates/aspects/build/aspects-superset/openedx-assets/assets/charts/Events_per_course.yaml
@@ -12,7 +12,7 @@ params:
   extra_form_data: {}
   granularity_sqla: emission_time
   groupby:
-  - course_key
+  - course_key_short
   innerRadius: 30
   label_type: key
   labels_outside: true

--- a/tutoraspects/templates/aspects/build/aspects-superset/openedx-assets/assets/charts/Most_Active_Courses_Per_Day.yaml
+++ b/tutoraspects/templates/aspects/build/aspects-superset/openedx-assets/assets/charts/Most_Active_Courses_Per_Day.yaml
@@ -15,7 +15,7 @@ params:
   forecastPeriods: 10
   granularity_sqla: emission_time
   groupby:
-  - course_key
+  - course_key_short
   legendOrientation: top
   legendType: scroll
   limit: 50

--- a/tutoraspects/templates/aspects/build/aspects-superset/openedx-assets/assets/dashboards/Operator_Dashboard.yaml
+++ b/tutoraspects/templates/aspects/build/aspects-superset/openedx-assets/assets/dashboards/Operator_Dashboard.yaml
@@ -549,6 +549,22 @@ position:
     - TAB-DE73B5pXm
     - ROW-X7WD5wVoP
     type: CHART
+  CHART-wg5_o87Pu6:
+    children: []
+    id: CHART-wg5_o87Pu6
+    meta:
+      chartId: 276
+      height: 50
+      sliceName: Events per course
+      uuid: a445d9e5-ac98-411e-9a47-eda10081bd5b
+      width: 4
+    parents:
+    - ROOT_ID
+    - GRID_ID
+    - TABS-7nA6MwltSD
+    - TAB-6Mdnw3FZh
+    - ROW-Z0QlRyckta
+    type: CHART
   CHART-o87Pu6wg5_:
     children: []
     id: CHART-o87Pu6wg5_
@@ -557,7 +573,7 @@ position:
       height: 50
       sliceName: Most Active Courses Per Day
       uuid: a19a7c6a-e2c9-4033-86b3-b2e5878b5b69
-      width: 12
+      width: 8
     parents:
     - ROOT_ID
     - GRID_ID
@@ -904,7 +920,7 @@ position:
     parents:
     - ROOT_ID
     - GRID_ID
-    - ROW-yuEVxRJ4Of
+    - TAB-RtC9PHwXy
     type: MARKDOWN
   ROOT_ID:
     children:
@@ -952,6 +968,7 @@ position:
     type: ROW
   ROW-Z0QlRyckta:
     children:
+    - CHART-wg5_o87Pu6
     - CHART-o87Pu6wg5_
     id: ROW-Z0QlRyckta
     meta:

--- a/tutoraspects/templates/aspects/build/aspects-superset/openedx-assets/assets/datasets/xapi_events_all_parsed.yaml
+++ b/tutoraspects/templates/aspects/build/aspects-superset/openedx-assets/assets/datasets/xapi_events_all_parsed.yaml
@@ -50,6 +50,18 @@ columns:
   type: null
   verbose_name: course_key
 - advanced_data_type: null
+  column_name: course_key_short
+  description: "Course key without the course-v1: prefix"
+  expression: "splitByChar(':', splitByChar('/', course_id)[-1])[-1]"
+  extra: {}
+  filterable: true
+  groupby: true
+  is_active: true
+  is_dttm: false
+  python_date_format: null
+  type: null
+  verbose_name: course_key
+- advanced_data_type: null
   column_name: event_id
   description: null
   expression: null


### PR DESCRIPTION
### Description

Adds a computed `course_key_short` field to the `xapi_events_all_parsed` dataset, which strips the `course-v1:` prefix off of the beginning of the `course_key`.

Modifies the charts under the Operator > Courses tab to use `course_key_short` instead of `course_key` as the groupby/label.

Also re-adds the "Events per Course" chart to the Operator tab -- it must have gotten removed accidentally by https://github.com/openedx/tutor-contrib-aspects/pull/515?

### Screenshots

![operator_courses_charts](https://github.com/openedx/tutor-contrib-aspects/assets/7556571/ef91471e-f572-4c76-82f6-020300787dfa)

### Related information

Closes https://github.com/openedx/tutor-contrib-aspects/issues/245