### PR TITLE
feat: improve enrollment query performance by removing CTEs

### DIFF
--- a/tutoraspects/templates/openedx-assets/queries/fact_enrollments.sql
+++ b/tutoraspects/templates/openedx-assets/queries/fact_enrollments.sql
@@ -1,11 +1,3 @@
-with enrollments as (
-select *
-from {{ DBT_PROFILE_TARGET_DATABASE }}.fact_enrollments
-where
-    1=1
-    {% include 'openedx-assets/queries/common_filters.sql' %}
-)
-
 select
     emission_time,
     org,
@@ -15,4 +7,7 @@ select
     actor_id,
     enrollment_mode,
     enrollment_status
-from enrollments
+from {{ DBT_PROFILE_TARGET_DATABASE }}.fact_enrollments
+where
+    1=1
+    {% include 'openedx-assets/queries/common_filters.sql' %}


### PR DESCRIPTION
Following advice from Altinity, this PR removes CTEs from the `fact_enrollments` and `fact_enrollments_by_day` dataset queries. The Clickhouse benchmark tooling shows speedups and the query plans for these queries are shorter than before.