### PR TITLE
feat: use `course_names` for operator dashboard filters

### DIFF
--- a/tutoraspects/templates/aspects/build/aspects-superset/openedx-assets/assets/dashboards/Operator_Dashboard.yaml
+++ b/tutoraspects/templates/aspects/build/aspects-superset/openedx-assets/assets/dashboards/Operator_Dashboard.yaml
@@ -190,9 +190,10 @@ metadata:
     targets:
     - column:
         name: course_name
-      datasetUuid: 352311fe-12f0-470c-8b8c-d4f6a3936b3d
+      datasetUuid: 41278a97-d0ff-4645-9514-d79f80d275df
     type: NATIVE_FILTER
-  - cascadeParentIds: []
+  - cascadeParentIds:
+    - NATIVE_FILTER-wqPao3yam
     chartsInScope:
     - 240
     - 272
@@ -219,7 +220,7 @@ metadata:
     targets:
     - column:
         name: course_run
-      datasetUuid: 352311fe-12f0-470c-8b8c-d4f6a3936b3d
+      datasetUuid: 41278a97-d0ff-4645-9514-d79f80d275df
     type: NATIVE_FILTER
   - cascadeParentIds: []
     chartsInScope:


### PR DESCRIPTION
This change updates the operator dashboard to use the `course_names` datatset for course name and course run filters, which performs better than using the `fact_enrollment_by_day` dataset.

This should address the "Filters on Enrollments tab" item in #535