### PR TITLE
fix: write MVs to xapi schema (FC-0033)

### DIFF
--- a/tutoraspects/plugin.py
+++ b/tutoraspects/plugin.py
@@ -390,7 +390,7 @@ hooks.Filters.CONFIG_DEFAULTS.add_items(
         # For now we are pulling this from github, which should allow maximum
         # flexibility for forking, running branches, specific versions, etc.
         ("DBT_REPOSITORY", "https://github.com/openedx/aspects-dbt"),
-        ("DBT_BRANCH", "v3.1.1"),
+        ("DBT_BRANCH", "v3.1.2"),
         # Path to the dbt project inside the repository
         ("DBT_REPOSITORY_PATH", "aspects-dbt"),
         # This is a pip compliant list of Python packages to install to run dbt

--- a/tutoraspects/templates/aspects/apps/aspects/dbt/profiles.yml
+++ b/tutoraspects/templates/aspects/apps/aspects/dbt/profiles.yml
@@ -1,7 +1,7 @@
 aspects: # this needs to match the profile in your dbt_project.yml file
-  target: dev
+  target: prod
   outputs:
-    dev:
+    prod:
       type: clickhouse
       schema: {{ DBT_PROFILE_TARGET_DATABASE }}
       host: {{ CLICKHOUSE_HOST }}

--- a/tutoraspects/templates/aspects/apps/aspects/scripts/dbt.sh
+++ b/tutoraspects/templates/aspects/apps/aspects/scripts/dbt.sh
@@ -16,6 +16,7 @@ git clone -b {{ DBT_BRANCH }} {{ DBT_REPOSITORY }}
 cd {{ DBT_REPOSITORY_PATH }} || exit
 
 export ASPECTS_EVENT_SINK_DATABASE={{ASPECTS_EVENT_SINK_DATABASE}}
+export ASPECTS_XAPI_DATABASE={{ASPECTS_XAPI_DATABASE}}
 
 echo "Installing dbt dependencies"
 dbt deps --profiles-dir /app/aspects/dbt/

--- a/tutoraspects/templates/aspects/jobs/init/aspects/init-aspects.sh
+++ b/tutoraspects/templates/aspects/jobs/init/aspects/init-aspects.sh
@@ -25,6 +25,7 @@ git clone -b {{ DBT_BRANCH }} {{ DBT_REPOSITORY }}
 cd {{ DBT_REPOSITORY_PATH }} || exit
 
 export ASPECTS_EVENT_SINK_DATABASE={{ASPECTS_EVENT_SINK_DATABASE}}
+export ASPECTS_XAPI_DATABASE={{ASPECTS_XAPI_DATABASE}}
 
 echo "Installing dbt dependencies"
 dbt deps --profiles-dir /app/aspects/dbt/


### PR DESCRIPTION
This change pulls in the latest changes to aspects-dbt, which includes support for writing MVs to a custom schema. This reinstates the existing functionality where MVs were written to the `xapi` schema instead of `reporting`.