### PR TITLE
feat: prefer `course_names` for courses and organizations charts in operator dashboard (FC-0033)

### DIFF
--- a/tutoraspects/templates/aspects/build/aspects-superset/openedx-assets/assets/charts/Courses.yaml
+++ b/tutoraspects/templates/aspects/build/aspects-superset/openedx-assets/assets/charts/Courses.yaml
@@ -2,11 +2,11 @@ _file_name: Courses.yaml
 cache_timeout: null
 certification_details: null
 certified_by: null
-dataset_uuid: 2a2498dc-03ce-41a0-b798-d84f808f7da6
+dataset_uuid: 41278a97-d0ff-4645-9514-d79f80d275df
 description: null
 params:
   adhoc_filters: []
-  datasource: 4__table
+  datasource: 50__table
   extra_form_data: {}
   granularity_sqla: emission_time
   header_font_size: 0.4
@@ -16,7 +16,7 @@ params:
       advanced_data_type: null
       certification_details: null
       certified_by: null
-      column_name: course_id
+      column_name: course_key
       description: null
       expression: null
       filterable: true
@@ -32,7 +32,7 @@ params:
     expressionType: SIMPLE
     hasCustomLabel: false
     isNew: false
-    label: COUNT_DISTINCT(course_id)
+    label: COUNT_DISTINCT(course_key)
     optionName: metric_72own1pj0bq_yfm1efl7ggi
     sqlExpression: null
   subheader_font_size: 0.15

--- a/tutoraspects/templates/aspects/build/aspects-superset/openedx-assets/assets/charts/Total_Organizations.yaml
+++ b/tutoraspects/templates/aspects/build/aspects-superset/openedx-assets/assets/charts/Total_Organizations.yaml
@@ -2,11 +2,11 @@ _file_name: Total_Organizations.yaml
 cache_timeout: null
 certification_details: null
 certified_by: null
-dataset_uuid: 2a2498dc-03ce-41a0-b798-d84f808f7da6
+dataset_uuid: 41278a97-d0ff-4645-9514-d79f80d275df
 description: null
 params:
   adhoc_filters: []
-  datasource: 6__table
+  datasource: 50__table
   extra_form_data: {}
   granularity_sqla: emission_time
   header_font_size: 0.4


### PR DESCRIPTION
This change updates the "Total Courses" and "Total Organizations" charts in the operator dashboard so that they use the smaller `event_sink.course_names` dataset. This should help with the performance issues mentioned in #535. Both charts still work with the `course_key` filter applied.