### PR TITLE
docs: annotates the PII tables in Aspects as per OEP-30

### DIFF
--- a/tutoraspects/templates/aspects/apps/aspects/migrations/alembic/versions/0016_event_sink_user_profile.py
+++ b/tutoraspects/templates/aspects/apps/aspects/migrations/alembic/versions/0016_event_sink_user_profile.py
@@ -1,5 +1,11 @@
 """
 create user_profile sink table
+
+This table is always created, but it will only be populated if ASPECTS_ENABLE_PII.
+
+.. pii: Stores Open edX user profile data.
+.. pii_types: user_id, name, username, location, phone_number, email_address, birth_date, biography, gender
+.. pii_retirement: local_api, consumer_api
 """
 from alembic import op
 

--- a/tutoraspects/templates/aspects/apps/aspects/migrations/alembic/versions/0026_event_sink_external_id.py
+++ b/tutoraspects/templates/aspects/apps/aspects/migrations/alembic/versions/0026_event_sink_external_id.py
@@ -1,5 +1,11 @@
 """
 create external_id sink table
+
+This table is always created, but it will only be populated if ASPECTS_ENABLE_PII.
+
+.. pii: Stores a mapping between an Open edX user and their external_id values stored in Open edX.
+.. pii_types: user_id, username
+.. pii_retirement: local_api, consumer_api
 """
 from alembic import op
 

--- a/tutoraspects/templates/aspects/apps/aspects/migrations/alembic/versions/0027_partition_event_sink_user_profile.py
+++ b/tutoraspects/templates/aspects/apps/aspects/migrations/alembic/versions/0027_partition_event_sink_user_profile.py
@@ -1,5 +1,9 @@
 """
 Partition the event_sink.user_profile table
+
+.. pii: Stores Open edX user profile data.
+.. pii_types: user_id, name, username, location, phone_number, email_address, birth_date, biography, gender
+.. pii_retirement: local_api, consumer_api
 """
 from alembic import op
 

--- a/tutoraspects/templates/aspects/apps/aspects/migrations/alembic/versions/0028_user_pii.py
+++ b/tutoraspects/templates/aspects/apps/aspects/migrations/alembic/versions/0028_user_pii.py
@@ -1,5 +1,12 @@
 """
 create user_pii table sourced from an in-memory dictionary joining the PII tables.
+
+This table is always created, but it will only be populated if ASPECTS_ENABLE_PII.
+Once accessed, data from this dictionary is cached in-memory for ASPECTS_PII_CACHE_LIFETIME seconds.
+
+.. pii: Stores Open edX user and profile data in a dictionary for use by Superset charts.
+.. pii_types: user_id, name, username, location, phone_number, email_address, birth_date, biography, gender
+.. pii_retirement: local_api, consumer_api
 """
 from alembic import op
 


### PR DESCRIPTION
### Description

Adds PII annotation docstrings to the PII tables created by Aspects.

### Supporting information

Relates to https://github.com/openedx/openedx-aspects/pull/106

Reference: [OEP-30 PII Markup and Auditing](https://open-edx-proposals.readthedocs.io/en/latest/architectural-decisions/oep-0030-arch-pii-markup-and-auditing.html#docstring-annotations)