### PR TITLE
fix: import databases from settings

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -47,10 +47,6 @@ Aspects is implemented as a Tutor plugin. Documentation will be coming soon to c
 
     tutor images build openedx --no-cache
 
-#. Because we need to bake the Aspects assets (charts, datasets, dashboards) into the Superset image you will need to rebuild it::
-
-    tutor images build aspects-superset --no-cache
-
 #. Run the initialization scripts::
 
     tutor local do init
@@ -99,6 +95,8 @@ when you update your deployment. To prevent your local changes from being overwr
 please create new assets and make your changes there instead. You can copy an existing
 asset by editing the asset in Superset and selecting "Save As" to save it to a new name.
 
+# Note: If you are using custom assets you will need to rebuild your aspects-superset
+# image on your local machine with `tutor images build aspects-superset --no-cache`.
 
 Sharing Charts and Dashboards
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/tutoraspects/plugin.py
+++ b/tutoraspects/plugin.py
@@ -254,6 +254,13 @@ hooks.Filters.CONFIG_DEFAULTS.add_items(
             "mysql://{{SUPERSET_DB_USERNAME}}:{{SUPERSET_DB_PASSWORD}}"
             "@{{SUPERSET_DB_HOST}}/{{SUPERSET_DB_METADATA_NAME}}",
         ),
+        (
+            "SUPERSET_DATABASES",
+            {
+                "OpenedX Clickhouse": "{{CLICKHOUSE_REPORT_SQLALCHEMY_URI}}",
+                "Superset Metadata": "{{SUPERSET_METADATA_SQLALCHEMY_URI}}",
+            },
+        ),
         ("SUPERSET_SENTRY_DSN", ""),
         (
             "SUPERSET_TALISMAN_CONFIG",

--- a/tutoraspects/templates/aspects/apps/superset/pythonpath/create_assets.py
+++ b/tutoraspects/templates/aspects/apps/superset/pythonpath/create_assets.py
@@ -103,9 +103,17 @@ def create_assets():
                     write_asset_to_file(asset, asset_name, folder, file_name, roles)
                     break
 
+    import_databases()
     import_assets()
     update_dashboard_roles(roles)
     update_embeddable_uuids()
+
+
+def import_databases():
+    """Import databases from settings"""
+    databases = {{SUPERSET_DATABASES}}
+    for database_name, uri in databases.items():
+        create_superset_db(database_name, uri)
 
 
 def get_uuid5(base_uuid, name):
@@ -118,7 +126,6 @@ def get_uuid5(base_uuid, name):
 def write_asset_to_file(asset, asset_name, folder, file_name, roles):
     """Write an asset to a file and generated translated assets"""
     if folder == "databases":
-        # This will fix the URI connection string by setting the right password.
         create_superset_db(asset["database_name"], asset["sqlalchemy_uri"])
 
     if folder in ["charts", "dashboards"]:


### PR DESCRIPTION
### Description

This PR allows developers to not need to build the Superset image if the assets and other settings match the defaults. This allows to easily tests Aspects without the need to build the Superset image on any single change