### PR TITLE
refactor: Remove refs to ClickHouse allow_experimental_object_type

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -32,10 +32,10 @@ ABOUT = load_about()
 setup(
     name="tutor-contrib-aspects",
     version=ABOUT["__version__"],
-    url="https://github.com/open-craft/tutor-contrib-aspects",
+    url="https://github.com/openedx/tutor-contrib-aspects",
     project_urls={
-        "Code": "https://github.com/open-craft/tutor-contrib-aspects",
-        "Issue tracker": "https://github.com/open-craft/tutor-contrib-aspects/issues",
+        "Code": "https://github.com/openedx/tutor-contrib-aspects",
+        "Issue tracker": "https://github.com/openedx/tutor-contrib-aspects/issues",
     },
     license="AGPLv3",
     author="The Open edX Community",

--- a/tutoraspects/plugin.py
+++ b/tutoraspects/plugin.py
@@ -384,8 +384,6 @@ hooks.Filters.CONFIG_DEFAULTS.add_items(
         # A dictionary/mapping of custom ClickHouse settings for the connection -
         # default is empty.
         ("DBT_PROFILE_CUSTOM_SETTINGS", ""),
-        # Allows the connection to understand the JSON type
-        ("DBT_PROFILE_ALLOW_EXPERIMENTAL_OBJECT_TYPE", "True"),
         # Timeout for server ping
         ("DBT_PROFILE_SYNC_REQUEST_TIMEOUT", "5"),
         # Compression block size if compression is enabled, this is the default value

--- a/tutoraspects/templates/aspects/apps/aspects/dbt/profiles.yml
+++ b/tutoraspects/templates/aspects/apps/aspects/dbt/profiles.yml
@@ -21,6 +21,5 @@ aspects: # this needs to match the profile in your dbt_project.yml file
       use_lw_deletes: {{ DBT_PROFILE_USE_LW_DELETES }}
       check_exchange: {{ DBT_PROFILE_CHECK_EXCHANGE }}
       custom_settings: {{ DBT_PROFILE_CUSTOM_SETTINGS }}
-      allow_experimental_object_type: {{ DBT_PROFILE_ALLOW_EXPERIMENTAL_OBJECT_TYPE }}
       sync_request_timeout: {{ DBT_PROFILE_SYNC_REQUEST_TIMEOUT }}
       compress_block_size: {{ DBT_PROFILE_COMPRESS_BLOCK_SIZE }}


### PR DESCRIPTION
We've removed the JSON column, so we can pull these settings, except in the old migrations.