### PR TITLE
fix: allow to setup private dbt repository

### DIFF
--- a/tutoraspects/plugin.py
+++ b/tutoraspects/plugin.py
@@ -352,6 +352,7 @@ hooks.Filters.CONFIG_DEFAULTS.add_items(
         # flexibility for forking, running branches, specific versions, etc.
         ("DBT_REPOSITORY", "https://github.com/openedx/aspects-dbt"),
         ("DBT_BRANCH", "v3.4.1"),
+        ("DBT_SSH_KEY", ""),
         # Path to the dbt project inside the repository
         ("DBT_REPOSITORY_PATH", "aspects-dbt"),
         # This is a pip compliant list of Python packages to install to run dbt

--- a/tutoraspects/templates/aspects/apps/aspects/scripts/dbt.sh
+++ b/tutoraspects/templates/aspects/apps/aspects/scripts/dbt.sh
@@ -7,6 +7,15 @@ echo "Installing dbt packages..."
 
 pip install -r /app/aspects/dbt/requirements.txt
 
+{% if DBT_SSH_KEY %}
+mkdir -p /root/.ssh
+echo "{{ DBT_SSH_KEY}}" | tr -d '\r' > /root/.ssh/id_rsa
+chmod 600 /root/.ssh/id_rsa
+eval `ssh-agent -s`
+ssh -o StrictHostKeyChecking=no git@github.com || true
+ssh-add /root/.ssh/id_rsa
+{% endif %}
+
 rm -rf {{ DBT_REPOSITORY_PATH }}
 
 echo "Installing aspects-dbt"

--- a/tutoraspects/templates/aspects/jobs/init/aspects/init-aspects.sh
+++ b/tutoraspects/templates/aspects/jobs/init/aspects/init-aspects.sh
@@ -16,6 +16,15 @@ echo "Installing dbt packages..."
 
 pip install -r /app/aspects/dbt/requirements.txt
 
+{% if DBT_SSH_KEY %}
+mkdir -p /root/.ssh
+echo "{{ DBT_SSH_KEY}}" | tr -d '\r' > /root/.ssh/id_rsa
+chmod 600 /root/.ssh/id_rsa
+eval `ssh-agent -s`
+ssh -o StrictHostKeyChecking=no git@github.com || true
+ssh-add /root/.ssh/id_rsa
+{% endif %}
+
 rm -rf {{ DBT_REPOSITORY_PATH }}
 
 echo "Installing aspects-dbt"


### PR DESCRIPTION
### Description

This PR adds a new setting to allow to setup an SSH key to clone private DBT repositories. Fixes #578 

# WARNING

This has been tested only on `github.com`.