### PR TITLE
chore: Update python to 3.12 wherever possible

### DIFF
--- a/.github/workflows/bump-version.yaml
+++ b/.github/workflows/bump-version.yaml
@@ -24,10 +24,10 @@ jobs:
           default_bump: false
           default_prerelease_bump: false
           dry_run: true
-      - name: Set up Python 3.8
+      - name: Set up Python 3.12
         uses: actions/setup-python@v5
         with:
-          python-version: "3.8"
+          python-version: "3.12"
       - name: Create bumpversion
         if: steps.tag_version.outputs.new_version
         run: |

--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -24,7 +24,7 @@ jobs:
       - name: setup python
         uses: actions/setup-python@v5
         with:
-          python-version: 3.9
+          python-version: 3.12
       - name: Install python reqs
         run: pip install -r requirements/dev.txt
       - name: Install aspects
@@ -78,7 +78,7 @@ jobs:
       - name: setup python
         uses: actions/setup-python@v5
         with:
-          python-version: 3.9
+          python-version: 3.12
       - name: Install python reqs
         run: pip install -r requirements/dev.txt
       - name: Install aspects
@@ -130,7 +130,7 @@ jobs:
       - name: setup python
         uses: actions/setup-python@v5
         with:
-          python-version: 3.9
+          python-version: 3.12
       - name: Generate env
         run: |
           pip install -r requirements/dev.txt

--- a/.github/workflows/pull-translations.yaml
+++ b/.github/workflows/pull-translations.yaml
@@ -16,7 +16,7 @@ jobs:
       - name: setup python
         uses: actions/setup-python@v5
         with:
-          python-version: 3.9
+          python-version: 3.12
       - name: Install aspects
         run: pip install .
       - name: Install requirements

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -36,7 +36,7 @@ jobs:
       - name: setup python
         uses: actions/setup-python@v5
         with:
-            python-version: 3.8
+            python-version: 3.12
       - name: Install pip
         run: pip install -r requirements/pip.txt
       - name: Build package
@@ -60,7 +60,7 @@ jobs:
       - name: setup python
         uses: actions/setup-python@v5
         with:
-          python-version: 3.9
+          python-version: 3.12
       - name: Install aspects
         run: pip install .
       - name: Save config
@@ -85,7 +85,7 @@ jobs:
       - name: setup python
         uses: actions/setup-python@v5
         with:
-          python-version: 3.9
+          python-version: 3.12
       - name: Install aspects
         run: pip install .
       - name: Save config
@@ -110,7 +110,7 @@ jobs:
       - name: setup python
         uses: actions/setup-python@v5
         with:
-          python-version: 3.9
+          python-version: 3.12
       - name: Install aspects
         run: pip install .
       - name: Save config
@@ -121,7 +121,7 @@ jobs:
         run: |
           tutor images build openedx --cache-to-registry
           tutor images push openedx
-  
+
   build-openedx-dev:
     runs-on: ubuntu-latest
     needs: release
@@ -136,7 +136,7 @@ jobs:
       - name: setup python
         uses: actions/setup-python@v5
         with:
-          python-version: 3.9
+          python-version: 3.12
       - name: Install aspects
         run: pip install .
       - name: Save config

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,7 +16,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
-          python-version: 3.8
+          python-version: 3.12
 
       - name: Install development dependencies
         run: make dev-requirements

--- a/setup.py
+++ b/setup.py
@@ -53,9 +53,10 @@ setup(
         "License :: OSI Approved :: GNU Affero General Public License v3",
         "Operating System :: OS Independent",
         "Programming Language :: Python",
-        "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",
         "Programming Language :: Python :: 3.10",
+        "Programming Language :: Python :: 3.11",
+        "Programming Language :: Python :: 3.12",
     ],
 )

--- a/tutoraspects/commands_v0.py
+++ b/tutoraspects/commands_v0.py
@@ -32,7 +32,7 @@ def dbt(context, command) -> None:
     runner = context.job_runner(config)
 
     command = f"""echo 'Making dbt script executable...'
-    echo 'Running dbt {command}' 
+    echo 'Running dbt {command}'
     bash /app/aspects/scripts/dbt.sh {command}
     echo 'Done!';
     """

--- a/tutoraspects/templates/aspects/build/aspects/Dockerfile
+++ b/tutoraspects/templates/aspects/build/aspects/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.8
+FROM python:3.12
 
 WORKDIR /app
 


### PR DESCRIPTION
Python 3.8 is nearing end of life, and we're using a bunch of different versions of Python in the various tooling and Aspects image in this repo. This is just consolidating everything to 3.12 so we don't have to worry about it again for a few years.