### PR TITLE
feat: grant permissions to embed dashboard to Public role

### DIFF
--- a/tutoraspects/templates/aspects/apps/superset/security/roles.json
+++ b/tutoraspects/templates/aspects/apps/superset/security/roles.json
@@ -3972,9 +3972,56 @@
     ]
   },
   {
-    "name":"Public",
-    "permissions":[
-
+    "name": "Public",
+    "permissions": [
+      {
+        "permission": {
+          "name": "can_read"
+        },
+        "view_menu": {
+          "name": "Chart"
+        }
+      },
+      {
+        "permission": {
+          "name": "can_read"
+        },
+        "view_menu": {
+          "name": "Dashboard"
+        }
+      },
+      {
+        "permission": {
+          "name": "can_time_range"
+        },
+        "view_menu": {
+          "name": "Api"
+        }
+      },
+      {
+        "permission": {
+          "name": "can_filter"
+        },
+        "view_menu": {
+          "name": "Superset"
+        }
+      },
+      {
+        "permission": {
+          "name": "can_csv"
+        },
+        "view_menu": {
+          "name": "Superset"
+        }
+      },
+      {
+        "permission": {
+          "name": "can_explore_json"
+        },
+        "view_menu": {
+          "name": "Superset"
+        }
+      }
     ]
   },
   {


### PR DESCRIPTION
### Description

This PR grants the necessary permissions for the Public role to use an embedded dashboard in the LMS and to download the CSV report. The Public role is the one used to determine the guest tokens permissions which are used to embed the dashboards in the LMS Instructor Dashboard.

You can read more information about the Superset Public role here: https://superset.apache.org/docs/security/#public. It's safe to assign those permissions as we are using the Dashboard RBAC feature and to grant access to the data itself we would need to grant permissions over the datasets.

![image](https://github.com/openedx/tutor-contrib-aspects/assets/33465240/f10426ca-8259-4f8c-82f0-6c0ff9735d2e)

