### PR TITLE
fix: Add importlib-resources to base requirements

### DIFF
--- a/requirements/base.in
+++ b/requirements/base.in
@@ -1,5 +1,6 @@
 click
 bcrypt
+importlib-resources
 openedx-atlas
 transifex-python
 tutor>=15


### PR DESCRIPTION
When installed with old Tutor versions this requirement isn't included and causes errors.