### PR TITLE
feat: Use dbt state to avoid large table rebuilds

### DIFF
--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -57,8 +57,15 @@ jobs:
         run: |
           tutor local do alembic -c "downgrade base"
           tutor local do alembic -c "upgrade head"
-      - name: Test DBT
-        run: tutor local do dbt -c "test"
+      # This should:
+      # 1. Find no models on the first run, since state should be up to date
+      # 2. Force run all models
+      # 3. Successfully run tests
+      - name: Test dbt
+        run: |
+          tutor local do dbt -c "run"
+          tutor local do dbt --only_changed False -c "run"
+          tutor local do dbt --only_changed False -c "test"
       - name: Load test
         run: tutor local do load-xapi-test-data
       - name: Import demo course
@@ -111,8 +118,15 @@ jobs:
         run: |
           tutor dev do alembic -c "downgrade base"
           tutor dev do alembic -c "upgrade head"
-      - name: Test DBT
-        run: tutor dev do dbt -c "test"
+      # This should:
+      # 1. Find no models on the first run, since state should be up to date
+      # 2. Force run all models
+      # 3. Successfully run tests
+      - name: Test dbt
+        run: |
+          tutor dev do dbt -c "run"
+          tutor dev do dbt --only_changed False -c "run"
+          tutor dev do dbt --only_changed False -c "test"
       - name: Load test
         run: tutor dev do load-xapi-test-data
       - name: Import demo course
@@ -183,8 +197,15 @@ jobs:
         run: |
           tutor k8s do alembic -c "downgrade base"
           tutor k8s do alembic -c "upgrade head"
+      # This should:
+      # 1. Find no models on the first run, since state should be up to date
+      # 2. Force run all models
+      # 3. Successfully run tests
       - name: Test DBT
-        run: tutor k8s do dbt -c "test"
+        run: |
+          tutor k8s do dbt -c "run"
+          tutor k8s do dbt --only_changed False -c "run"
+          tutor k8s do dbt --only_changed False -c "test"
       - name: Load test
         run: tutor k8s do load-xapi-test-data
       - name: Import demo course

--- a/tutoraspects/commands_v0.py
+++ b/tutoraspects/commands_v0.py
@@ -23,8 +23,22 @@ from tutor import env
          tutor local do dbt -c "run -m enrollments_by_day --threads 4"
          """,
 )
+@click.option(
+    "--only_changed",
+    default=True,
+    type=click.UNPROCESSED,
+    help="""Whether to only run models that have changed since the last dbt run. Since
+         re-running materialized views will recreate potentially huge datasets and 
+         incur downtime, this defaults to true.
+
+         If no prior state is found, the command will run as if this was False.
+
+         If your command fails due to an issue with "state:modified", you may need to 
+         set this to False.
+         """,
+)
 @click.pass_obj
-def dbt(context, command) -> None:
+def dbt(context, only_changed, command) -> None:
     """
     Job that proxies dbt commands to a container which runs them against ClickHouse.
     """
@@ -33,7 +47,7 @@ def dbt(context, command) -> None:
 
     command = f"""echo 'Making dbt script executable...'
     echo 'Running dbt {command}'
-    bash /app/aspects/scripts/dbt.sh {command}
+    bash /app/aspects/scripts/dbt.sh {only_changed} {command}
     echo 'Done!';
     """
     runner.run_job("aspects", command)

--- a/tutoraspects/patches/k8s-jobs
+++ b/tutoraspects/patches/k8s-jobs
@@ -18,6 +18,8 @@ spec:
             value: {{ ASPECTS_XAPI_DATABASE }}
           - name: ASPECTS_ENROLLMENT_EVENTS_TABLE
             value: {{ ASPECTS_ENROLLMENT_EVENTS_TABLE }}
+          - name: DBT_STATE
+            value: {{ DBT_STATE_DIR }}
         image: {{ DOCKER_IMAGE_ASPECTS }}
         securityContext:
           allowPrivilegeEscalation: false
@@ -35,7 +37,12 @@ spec:
             name: alembic
           - mountPath: /app/aspects/migrations/alembic/versions
             name: versions
+          - mountPath: {{ DBT_STATE_DIR }}
+            name: dbt-state
       volumes:
+        - name: dbt-state
+          persistentVolumeClaim:
+            claimName: aspects-dbt
         - name: scripts
           configMap:
             name: aspects-scripts

--- a/tutoraspects/patches/k8s-volumes
+++ b/tutoraspects/patches/k8s-volumes
@@ -1,3 +1,18 @@
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: aspects-dbt
+  labels:
+    app.kubernetes.io/component: volume
+    app.kubernetes.io/name: aspects-dbt
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 10M
+
 {% if RUN_CLICKHOUSE %}
 ---
 apiVersion: v1

--- a/tutoraspects/patches/local-docker-compose-jobs-services
+++ b/tutoraspects/patches/local-docker-compose-jobs-services
@@ -7,6 +7,7 @@ aspects-job:
   volumes:
     - ../../env/plugins/aspects/apps/aspects:/app/aspects
     - ../../env/plugins/aspects/apps/aspects/scripts/:/app/aspects/scripts:ro
+    - ../../data/aspects-dbt:{{ DBT_STATE_DIR }}
   {% if RUN_SUPERSET or RUN_CLICKHOUSE or RUN_RALPH %}depends_on:{% if RUN_SUPERSET %}
     - superset{% endif %}{% if RUN_CLICKHOUSE%}
     - clickhouse{% endif %}{% if RUN_RALPH %}

--- a/tutoraspects/plugin.py
+++ b/tutoraspects/plugin.py
@@ -353,6 +353,7 @@ hooks.Filters.CONFIG_DEFAULTS.add_items(
         ("DBT_REPOSITORY", "https://github.com/openedx/aspects-dbt"),
         ("DBT_BRANCH", "v3.5.0"),
         ("DBT_SSH_KEY", ""),
+        ("DBT_STATE_DIR", "/app/aspects/dbt_state/"),
         # This is a pip compliant list of Python packages to install to run dbt
         # make sure packages with versions are enclosed in double quotes
         ("EXTRA_DBT_PACKAGES", []),

--- a/tutoraspects/templates/aspects/jobs/init/aspects/init-aspects.sh
+++ b/tutoraspects/templates/aspects/jobs/init/aspects/init-aspects.sh
@@ -2,4 +2,4 @@
 
 bash /app/aspects/scripts/alembic.sh upgrade head
 
-bash /app/aspects/scripts/dbt.sh run
+bash /app/aspects/scripts/dbt.sh True run


### PR DESCRIPTION
This is a work in progress to avoid rebuilding our large materialized views when we can avoid it. This dbt feature is complicated and requires storing the state of the last run so it can decide what's changed. 

Closes: https://github.com/openedx/tutor-contrib-aspects/issues/546

Open questions:

- How to work around this option being automatically added for commands that it doesn't make sense for (maybe just document that it needs to be turned off for them?)
- Is a k8s PVC the right way to go to store the state there?
- Are there other ways to surface that this is happening, or is some documentation enough
- What things should we consider safe to ignore for "changed" state? Tests, probably. Anything else? https://docs.getdbt.com/reference/node-selection/state-comparison-caveats