### PR TITLE
fix: Some dashboard assets do not have a name to localize

### DIFF
--- a/tutoraspects/templates/aspects/apps/superset/pythonpath/create_assets.py
+++ b/tutoraspects/templates/aspects/apps/superset/pythonpath/create_assets.py
@@ -227,9 +227,9 @@ def generate_translated_dashboard_filters(copy, language):
     metadata = copy.get("metadata", {})
 
     for filter in metadata.get("native_filter_configuration", []):
-        translation = get_translation(filter["name"], language)
-
-        filter["name"] = translation
+        for k in ("name", "description"):
+            if k in filter:
+                filter[k] = get_translation(filter[k], language)
 
 
 def create_superset_db(database_name, uri) -> None:


### PR DESCRIPTION
Some assets have a description instead of a name, so we now check that as well and fail with a clearer error if neither exists.

Closes: https://github.com/openedx/tutor-contrib-aspects/issues/626
