### PR TITLE
feat: upgrade dbt to v3.9.0

### DIFF
--- a/tutoraspects/plugin.py
+++ b/tutoraspects/plugin.py
@@ -351,7 +351,7 @@ hooks.Filters.CONFIG_DEFAULTS.add_items(
         # For now we are pulling this from github, which should allow maximum
         # flexibility for forking, running branches, specific versions, etc.
         ("DBT_REPOSITORY", "https://github.com/openedx/aspects-dbt"),
-        ("DBT_BRANCH", "v3.5.0"),
+        ("DBT_BRANCH", "v3.9.0"),
         ("DBT_SSH_KEY", ""),
         ("DBT_STATE_DIR", "/app/aspects/dbt_state/"),
         # This is a pip compliant list of Python packages to install to run dbt


### PR DESCRIPTION
### Description

This PR upgrades dbt to v3.9.0:

- video duration to playback events.
- add graded and block_type to dim_course_blocks.
- add fact_grade_status model.
- include models for pageview engagement.
