### PR TITLE
feat: add dataset columns/metrics translation support

### DIFF
--- a/scripts/translate_utils.py
+++ b/scripts/translate_utils.py
@@ -66,7 +66,9 @@ class TranslatableAsset:
 class DashboardAsset(TranslatableAsset):
     translatable_attributes = [
         "dashboard_title",
+        "description",
         "metadata.native_filter_configuration.name",
+        "metadata.native_filter_configuration.description",
         "position.*.meta.text",
         "position.*.meta.code",
     ]

--- a/scripts/translate_utils.py
+++ b/scripts/translate_utils.py
@@ -17,11 +17,6 @@ class TranslatableAsset:
         """
         Extract text from an asset.
         """
-
-    def extract_text(self):
-        """
-        Remove any variables from the content which should be omitted.
-        """
         strings = []
         for var_path in self.translatable_attributes:
             strings.extend(self.translate_var(self.asset, var_path.split(".")))

--- a/scripts/translate_utils.py
+++ b/scripts/translate_utils.py
@@ -28,24 +28,21 @@ class TranslatableAsset:
 
         return strings
 
-    def translate_var(self, content, var_path: list):
+    def translate_var(self, content, var_path):
         """
         Helper method to remove content from the content dict.
         """
         if not content:
             return []
         if len(var_path) == 1:
-            # If the content is a list, we need to iterate over each item in the list
             if isinstance(content, list):
                  strings = []
                  for item in content:
                      strings.append(item.get(var_path[0], ""))
                  return strings
-             # print("Translating asset: ", self.asset_type, "var_path: ", var_path)
             string = [content.get(var_path[0], "")]
             return string or []
         else:
-            # If the content is a list, we need to iterate over each item in the list
             if isinstance(content, list):
                 strings = []
                 for item in content:

--- a/scripts/translate_utils.py
+++ b/scripts/translate_utils.py
@@ -3,10 +3,93 @@ import os
 import shutil
 import yaml
 
+class TranslatableAsset:
+    translatable_attributes = []
+
+    def __init__(self, asset: dict):
+        self.asset = asset
+        for key in ASSET_FOLDER_MAPPING:
+            if key in asset:
+                self.asset_type = ASSET_FOLDER_MAPPING[key]
+                break
+
+    def extract_text(self):
+        """
+        Extract text from an asset.
+        """
+
+    def extract_text(self):
+        """
+        Remove any variables from the content which should be omitted.
+        """
+        strings = []
+        for var_path in self.translatable_attributes:
+            strings.extend(self.translate_var(self.asset, var_path.split(".")))
+
+        return strings
+
+    def translate_var(self, content, var_path: list):
+        """
+        Helper method to remove content from the content dict.
+        """
+        if not content:
+            return []
+        if len(var_path) == 1:
+            # If the content is a list, we need to iterate over each item in the list
+            if isinstance(content, list):
+                 strings = []
+                 for item in content:
+                     strings.append(item.get(var_path[0], ""))
+                 return strings
+             # print("Translating asset: ", self.asset_type, "var_path: ", var_path)
+            string = [content.get(var_path[0], "")]
+            return string or []
+        else:
+            # If the content is a list, we need to iterate over each item in the list
+            if isinstance(content, list):
+                strings = []
+                for item in content:
+                    strings.extend(self.translate_var(item, var_path[1:]))
+                return strings
+            if isinstance(content, dict):
+                if var_path[0] == "*":
+                    strings = []
+                    for key, value in content.items():
+                        strings.extend(self.translate_var(value, var_path[1:]))
+                    return strings
+                return self.translate_var(content.get(var_path[0]), var_path[1:])
+            else:
+                print("Could not translate var_path: ", var_path, content)
+                return []
+
+
+class DashboardAsset(TranslatableAsset):
+    translatable_attributes = [
+        "dashboard_title",
+        "metadata.native_filter_configuration.name",
+        "position.*.meta.text",
+        "position.*.meta.code",
+    ]
+
+class ChartAsset(TranslatableAsset):
+    translatable_attributes = [
+        "slice_name",
+        "description",
+        "params.x_axis_label",
+        "params.y_axis_label",
+    ]
+
+class DatasetAsset(TranslatableAsset):
+    translatable_attributes = [
+        "metrics.verbose_name",
+        "columns.verbose_name",
+    ]
+
+
 ASSET_FOLDER_MAPPING = {
-    "dashboard_title": "dashboards",
-    "slice_name": "charts",
-    "table_name": "datasets",
+    "dashboard_title": ("dashboards", DashboardAsset),
+    "slice_name": ("charts", ChartAsset),
+    "table_name": ("datasets", DatasetAsset),
 }
 
 
@@ -43,56 +126,11 @@ def mark_text_for_translation(asset):
     For every asset extract the text and mark it for translation
     """
 
-    def extract_text(asset, type):
-        """
-        Extract text from an asset
-        """
-        strings = []
-        if type == "dashboards":
-            strings.append(asset["dashboard_title"])
-
-            # Gets translatable fields from filters
-            for filter in asset["metadata"]["native_filter_configuration"]:
-                strings.append(filter["name"])
-
-            # Gets translatable fields from charts
-            for element in asset.get("position", {}).values():
-                if not isinstance(element, dict):
-                    continue
-
-                meta = element.get("meta", {})
-
-                if meta.get("text"):
-                    strings.append(meta["text"])
-
-                if meta.get("code"):
-                    strings.append(meta["code"])
-
-        elif type == "charts":
-            strings.append(asset["slice_name"])
-
-            if asset.get("description"):
-                strings.append(asset["description"])
-
-            if asset["params"].get("x_axis_label"):
-                strings.append(asset["params"]["x_axis_label"])
-
-            if asset["params"].get("y_axis_label"):
-                strings.append(asset["params"]["y_axis_label"])
-
-        elif type == "datasets":
-            for metric in asset.get("metrics", []):
-                strings.append(metric["verbose_name"])
-            for column in asset.get("columns", []):
-                strings.append(column["verbose_name"])
-
-        return strings
-
-    for key, value in ASSET_FOLDER_MAPPING.items():
+    for key, (asset_type, Asset) in ASSET_FOLDER_MAPPING.items():
         if key in asset:
-            strings = extract_text(asset, value)
+            strings = Asset(asset).extract_text()
             print(
-                f"Extracted {len(strings)} strings from {value} {asset.get('uuid')}"
+                f"Extracted {len(strings)} strings from {asset_type} {asset.get('uuid')}"
             )
             return strings
 
@@ -145,7 +183,7 @@ def compile_translations(root_path):
         outfile.write("---\n")
         # If we don't use an extremely large width, the jinja in our translations
         # can be broken by newlines. So we use the largest number there is.
-        yaml.dump(all_translations, outfile, width=math.inf)
+        yaml.dump(all_translations, outfile, width=math.inf, sort_keys=True)
         outfile.write("\n{{ patch('superset-extra-asset-translations')}}\n")
 
     # We remove these files to avoid confusion about where translations are coming
@@ -169,6 +207,7 @@ def extract_translations(root_path):
 
     print("Gathering text for translations...")
     STRINGS = set(get_text_for_translations(root_path))
+    print(f"Extracted {len(STRINGS)} strings for translation.")
     translations = {'en': {}}
 
     for string in STRINGS:

--- a/scripts/translate_utils.py
+++ b/scripts/translate_utils.py
@@ -6,6 +6,7 @@ import yaml
 ASSET_FOLDER_MAPPING = {
     "dashboard_title": "dashboards",
     "slice_name": "charts",
+    "table_name": "datasets",
 }
 
 
@@ -78,6 +79,12 @@ def mark_text_for_translation(asset):
 
             if asset["params"].get("y_axis_label"):
                 strings.append(asset["params"]["y_axis_label"])
+
+        elif type == "datasets":
+            for metric in asset.get("metrics", []):
+                strings.append(metric["verbose_name"])
+            for column in asset.get("columns", []):
+                strings.append(column["verbose_name"])
 
         return strings
 

--- a/tutoraspects/templates/aspects/apps/superset/pythonpath/create_assets.py
+++ b/tutoraspects/templates/aspects/apps/superset/pythonpath/create_assets.py
@@ -171,6 +171,7 @@ def generate_translated_asset(asset, asset_name, folder, language, roles):
 
     if folder == "dashboards":
         copy["slug"] = f"{copy['slug']}-{language}"
+        copy["description"] = get_translation(copy["description"], language)
 
         dashboard_roles = copy.pop("_roles", [])
         translated_dashboard_roles = []

--- a/tutoraspects/templates/aspects/build/aspects-superset/openedx-assets/assets/datasets/ab_user.yaml
+++ b/tutoraspects/templates/aspects/build/aspects-superset/openedx-assets/assets/datasets/ab_user.yaml
@@ -5,170 +5,170 @@ columns:
   column_name: created_on
   description: null
   expression: ''
-  extra: null
+  extra: {}
   filterable: true
   groupby: true
   is_active: true
   is_dttm: true
   python_date_format: null
   type: TIMESTAMP WITHOUT TIME ZONE
-  verbose_name: null
+  verbose_name: Created On
 - advanced_data_type: null
   column_name: changed_on
   description: null
   expression: ''
-  extra: null
+  extra: {}
   filterable: true
   groupby: true
   is_active: true
   is_dttm: true
   python_date_format: null
   type: TIMESTAMP WITHOUT TIME ZONE
-  verbose_name: null
+  verbose_name: Changed On
 - advanced_data_type: null
   column_name: last_login
   description: null
   expression: ''
-  extra: null
+  extra: {}
   filterable: true
   groupby: true
   is_active: true
   is_dttm: true
   python_date_format: null
   type: TIMESTAMP WITHOUT TIME ZONE
-  verbose_name: null
+  verbose_name: Last Login
 - advanced_data_type: null
   column_name: password
   description: null
   expression: ''
-  extra: null
+  extra: {}
   filterable: true
   groupby: true
   is_active: true
   is_dttm: false
   python_date_format: null
   type: VARCHAR(256)
-  verbose_name: null
+  verbose_name: Password
 - advanced_data_type: null
   column_name: last_name
   description: null
   expression: ''
-  extra: null
+  extra: {}
   filterable: true
   groupby: true
   is_active: true
   is_dttm: false
   python_date_format: null
   type: VARCHAR(64)
-  verbose_name: null
+  verbose_name: Last Name
 - advanced_data_type: null
   column_name: first_name
   description: null
   expression: ''
-  extra: null
+  extra: {}
   filterable: true
   groupby: true
   is_active: true
   is_dttm: false
   python_date_format: null
   type: VARCHAR(64)
-  verbose_name: null
+  verbose_name: First Name
 - advanced_data_type: null
   column_name: username
   description: null
   expression: ''
-  extra: null
+  extra: {}
   filterable: true
   groupby: true
   is_active: true
   is_dttm: false
   python_date_format: null
   type: VARCHAR(64)
-  verbose_name: null
+  verbose_name: Username
 - advanced_data_type: null
   column_name: email
   description: null
   expression: ''
-  extra: null
+  extra: {}
   filterable: true
   groupby: true
   is_active: true
   is_dttm: false
   python_date_format: null
   type: VARCHAR(64)
-  verbose_name: null
+  verbose_name: Email
 - advanced_data_type: null
   column_name: active
   description: null
   expression: ''
-  extra: null
+  extra: {}
   filterable: true
   groupby: true
   is_active: true
   is_dttm: false
   python_date_format: null
   type: BOOLEAN
-  verbose_name: null
+  verbose_name: Active
 - advanced_data_type: null
   column_name: created_by_fk
   description: null
   expression: ''
-  extra: null
+  extra: {}
   filterable: true
   groupby: true
   is_active: true
   is_dttm: false
   python_date_format: null
   type: INTEGER
-  verbose_name: null
+  verbose_name: Created By Fk
 - advanced_data_type: null
   column_name: changed_by_fk
   description: null
   expression: ''
-  extra: null
+  extra: {}
   filterable: true
   groupby: true
   is_active: true
   is_dttm: false
   python_date_format: null
   type: INTEGER
-  verbose_name: null
+  verbose_name: Changed By Fk
 - advanced_data_type: null
   column_name: fail_login_count
   description: null
   expression: ''
-  extra: null
+  extra: {}
   filterable: true
   groupby: true
   is_active: true
   is_dttm: false
   python_date_format: null
   type: INTEGER
-  verbose_name: null
+  verbose_name: Fail Login Count
 - advanced_data_type: null
   column_name: login_count
   description: null
   expression: ''
-  extra: null
+  extra: {}
   filterable: true
   groupby: true
   is_active: true
   is_dttm: false
   python_date_format: null
   type: INTEGER
-  verbose_name: null
+  verbose_name: Login Count
 - advanced_data_type: null
   column_name: id
   description: null
   expression: ''
-  extra: null
+  extra: {}
   filterable: true
   groupby: true
   is_active: true
   is_dttm: false
   python_date_format: null
   type: INTEGER
-  verbose_name: null
+  verbose_name: Id
 database_uuid: 06cd566f-e22a-4a79-b0e0-4c947de93ee0
 default_endpoint: null
 description: null
@@ -181,7 +181,8 @@ metrics:
   d3format: null
   description: null
   expression: COUNT(*)
-  extra: null
+  extra:
+    warning_markdown: ''
   metric_name: count
   metric_type: count
   verbose_name: COUNT(*)
@@ -190,7 +191,7 @@ normalize_columns: false
 offset: 0
 params: null
 schema: superset
-sql: null
+sql: ''
 table_name: ab_user
 template_params: null
 uuid: 304a5d6d-c589-483a-8e8d-3fadbccef648

--- a/tutoraspects/templates/aspects/build/aspects-superset/openedx-assets/assets/datasets/clickhouse_computed_metrics.yaml
+++ b/tutoraspects/templates/aspects/build/aspects-superset/openedx-assets/assets/datasets/clickhouse_computed_metrics.yaml
@@ -12,7 +12,7 @@ columns:
   is_dttm: false
   python_date_format: null
   type: Float64
-  verbose_name: null
+  verbose_name: Value
 - advanced_data_type: null
   column_name: name
   description: null
@@ -24,7 +24,7 @@ columns:
   is_dttm: false
   python_date_format: null
   type: String
-  verbose_name: null
+  verbose_name: Name
 - advanced_data_type: null
   column_name: description
   description: null
@@ -36,11 +36,11 @@ columns:
   is_dttm: false
   python_date_format: null
   type: String
-  verbose_name: null
+  verbose_name: Description
 database_uuid: 21174b6c-4d40-4958-8161-d6c3cf5e77b6
 default_endpoint: null
 description: null
-extra: null
+extra: {}
 fetch_values_predicate: null
 filter_select_enabled: true
 main_dttm_col: null

--- a/tutoraspects/templates/aspects/build/aspects-superset/openedx-assets/assets/datasets/course_blocks.yaml
+++ b/tutoraspects/templates/aspects/build/aspects-superset/openedx-assets/assets/datasets/course_blocks.yaml
@@ -5,114 +5,114 @@ columns:
   column_name: order
   description: null
   expression: null
-  extra: null
+  extra: {}
   filterable: true
   groupby: true
   is_active: true
   is_dttm: false
   python_date_format: null
   type: Int32
-  verbose_name: null
+  verbose_name: Order
 - advanced_data_type: null
   column_name: dump_id
   description: null
   expression: null
-  extra: null
+  extra: {}
   filterable: true
   groupby: true
   is_active: true
   is_dttm: false
   python_date_format: null
   type: UUID
-  verbose_name: null
+  verbose_name: Dump ID
 - advanced_data_type: null
   column_name: xblock_data_json
   description: null
   expression: null
-  extra: null
+  extra: {}
   filterable: true
   groupby: true
   is_active: true
   is_dttm: false
   python_date_format: null
   type: String
-  verbose_name: null
+  verbose_name: XBlock Data JSON
 - advanced_data_type: null
   column_name: time_last_dumped
   description: null
   expression: null
-  extra: null
+  extra: {}
   filterable: true
   groupby: true
   is_active: true
   is_dttm: false
   python_date_format: null
   type: String
-  verbose_name: null
+  verbose_name: Time Last Dumped
 - advanced_data_type: null
   column_name: display_name
   description: null
   expression: null
-  extra: null
+  extra: {}
   filterable: true
   groupby: true
   is_active: true
   is_dttm: false
   python_date_format: null
   type: String
-  verbose_name: null
+  verbose_name: Display Name
 - advanced_data_type: null
   column_name: course_key
   description: null
   expression: null
-  extra: null
+  extra: {}
   filterable: true
   groupby: true
   is_active: true
   is_dttm: false
   python_date_format: null
   type: String
-  verbose_name: null
+  verbose_name: Course Key
 - advanced_data_type: null
   column_name: edited_on
   description: null
   expression: null
-  extra: null
+  extra: {}
   filterable: true
   groupby: true
   is_active: true
   is_dttm: false
   python_date_format: null
   type: String
-  verbose_name: null
+  verbose_name: Edited On
 - advanced_data_type: null
   column_name: location
   description: null
   expression: null
-  extra: null
+  extra: {}
   filterable: true
   groupby: true
   is_active: true
   is_dttm: false
   python_date_format: null
   type: String
-  verbose_name: null
+  verbose_name: Location
 - advanced_data_type: null
   column_name: org
   description: null
   expression: null
-  extra: null
+  extra: {}
   filterable: true
   groupby: true
   is_active: true
   is_dttm: false
   python_date_format: null
   type: String
-  verbose_name: null
+  verbose_name: Organization
 database_uuid: 21174b6c-4d40-4958-8161-d6c3cf5e77b6
 default_endpoint: null
 description: null
-extra: null
+extra: {}
 fetch_values_predicate: null
 filter_select_enabled: false
 main_dttm_col: null
@@ -120,7 +120,7 @@ metrics:
 - d3format: null
   description: null
   expression: COUNT(*)
-  extra: null
+  extra: {}
   metric_name: count
   metric_type: count
   verbose_name: COUNT(*)

--- a/tutoraspects/templates/aspects/build/aspects-superset/openedx-assets/assets/datasets/course_names.yaml
+++ b/tutoraspects/templates/aspects/build/aspects-superset/openedx-assets/assets/datasets/course_names.yaml
@@ -5,54 +5,54 @@ columns:
   column_name: course_name
   description: null
   expression: null
-  extra: null
+  extra: {}
   filterable: true
   groupby: true
   is_active: true
   is_dttm: false
   python_date_format: null
   type: String
-  verbose_name: null
+  verbose_name: Course Name
 - advanced_data_type: null
   column_name: course_key
   description: null
   expression: null
-  extra: null
+  extra: {}
   filterable: true
   groupby: true
   is_active: true
   is_dttm: false
   python_date_format: null
   type: String
-  verbose_name: null
+  verbose_name: Course Key
 - advanced_data_type: null
   column_name: course_run
   description: null
   expression: null
-  extra: null
+  extra: {}
   filterable: true
   groupby: true
   is_active: true
   is_dttm: false
   python_date_format: null
   type: String
-  verbose_name: null
+  verbose_name: Course Run
 - advanced_data_type: null
   column_name: org
   description: null
   expression: null
-  extra: null
+  extra: {}
   filterable: true
   groupby: true
   is_active: true
   is_dttm: false
   python_date_format: null
   type: String
-  verbose_name: null
+  verbose_name: Organization
 database_uuid: 21174b6c-4d40-4958-8161-d6c3cf5e77b6
 default_endpoint: null
 description: null
-extra: null
+extra: {}
 fetch_values_predicate: null
 filter_select_enabled: false
 main_dttm_col: null
@@ -61,7 +61,7 @@ metrics:
   d3format: null
   description: null
   expression: COUNT(*)
-  extra: null
+  extra: {}
   metric_name: count
   metric_type: count
   verbose_name: COUNT(*)

--- a/tutoraspects/templates/aspects/build/aspects-superset/openedx-assets/assets/datasets/course_overviews.yaml
+++ b/tutoraspects/templates/aspects/build/aspects-superset/openedx-assets/assets/datasets/course_overviews.yaml
@@ -5,162 +5,162 @@ columns:
   column_name: self_paced
   description: null
   expression: null
-  extra: null
+  extra: {}
   filterable: true
   groupby: true
   is_active: true
   is_dttm: false
   python_date_format: null
   type: Bool
-  verbose_name: null
+  verbose_name: Self Paced
 - advanced_data_type: null
   column_name: dump_id
   description: null
   expression: null
-  extra: null
+  extra: {}
   filterable: true
   groupby: true
   is_active: true
   is_dttm: false
   python_date_format: null
   type: UUID
-  verbose_name: null
+  verbose_name: Dump ID
 - advanced_data_type: null
   column_name: course_data_json
   description: null
   expression: null
-  extra: null
+  extra: {}
   filterable: true
   groupby: true
   is_active: true
   is_dttm: false
   python_date_format: null
   type: String
-  verbose_name: null
+  verbose_name: Course Data JSON
 - advanced_data_type: null
   column_name: time_last_dumped
   description: null
   expression: null
-  extra: null
+  extra: {}
   filterable: true
   groupby: true
   is_active: true
   is_dttm: false
   python_date_format: null
   type: String
-  verbose_name: null
+  verbose_name: Time Last Dumped
 - advanced_data_type: null
   column_name: display_name
   description: null
   expression: null
-  extra: null
+  extra: {}
   filterable: true
   groupby: true
   is_active: true
   is_dttm: false
   python_date_format: null
   type: String
-  verbose_name: null
+  verbose_name: Display Name
 - advanced_data_type: null
   column_name: course_start
   description: null
   expression: null
-  extra: null
+  extra: {}
   filterable: true
   groupby: true
   is_active: true
   is_dttm: false
   python_date_format: null
   type: String
-  verbose_name: null
+  verbose_name: Course Start
 - advanced_data_type: null
   column_name: enrollment_start
   description: null
   expression: null
-  extra: null
+  extra: {}
   filterable: true
   groupby: true
   is_active: true
   is_dttm: false
   python_date_format: null
   type: String
-  verbose_name: null
+  verbose_name: Enrollment Start
 - advanced_data_type: null
   column_name: course_end
   description: null
   expression: null
-  extra: null
+  extra: {}
   filterable: true
   groupby: true
   is_active: true
   is_dttm: false
   python_date_format: null
   type: String
-  verbose_name: null
+  verbose_name: Course End
 - advanced_data_type: null
   column_name: course_key
   description: null
   expression: null
-  extra: null
+  extra: {}
   filterable: true
   groupby: true
   is_active: true
   is_dttm: false
   python_date_format: null
   type: String
-  verbose_name: null
+  verbose_name: Course Key
 - advanced_data_type: null
   column_name: enrollment_end
   description: null
   expression: null
-  extra: null
+  extra: {}
   filterable: true
   groupby: true
   is_active: true
   is_dttm: false
   python_date_format: null
   type: String
-  verbose_name: null
+  verbose_name: Enrollment End
 - advanced_data_type: null
   column_name: created
   description: null
   expression: null
-  extra: null
+  extra: {}
   filterable: true
   groupby: true
   is_active: true
   is_dttm: false
   python_date_format: null
   type: String
-  verbose_name: null
+  verbose_name: Created
 - advanced_data_type: null
   column_name: modified
   description: null
   expression: null
-  extra: null
+  extra: {}
   filterable: true
   groupby: true
   is_active: true
   is_dttm: false
   python_date_format: null
   type: String
-  verbose_name: null
+  verbose_name: Modified
 - advanced_data_type: null
   column_name: org
   description: null
   expression: null
-  extra: null
+  extra: {}
   filterable: true
   groupby: true
   is_active: true
   is_dttm: false
   python_date_format: null
   type: String
-  verbose_name: null
+  verbose_name: Organization
 database_uuid: 21174b6c-4d40-4958-8161-d6c3cf5e77b6
 default_endpoint: null
 description: null
-extra: null
+extra: {}
 fetch_values_predicate: null
 filter_select_enabled: false
 main_dttm_col: null
@@ -169,7 +169,7 @@ metrics:
   d3format: null
   description: null
   expression: COUNT(*)
-  extra: null
+  extra: {}
   metric_name: count
   metric_type: count
   verbose_name: COUNT(*)

--- a/tutoraspects/templates/aspects/build/aspects-superset/openedx-assets/assets/datasets/dashboards.yaml
+++ b/tutoraspects/templates/aspects/build/aspects-superset/openedx-assets/assets/datasets/dashboards.yaml
@@ -5,182 +5,182 @@ columns:
   column_name: created_on
   description: null
   expression: ''
-  extra: null
+  extra: {}
   filterable: true
   groupby: true
   is_active: true
   is_dttm: true
   python_date_format: null
   type: TIMESTAMP WITHOUT TIME ZONE
-  verbose_name: null
+  verbose_name: Created On
 - advanced_data_type: null
   column_name: changed_on
   description: null
   expression: ''
-  extra: null
+  extra: {}
   filterable: true
   groupby: true
   is_active: true
   is_dttm: true
   python_date_format: null
   type: TIMESTAMP WITHOUT TIME ZONE
-  verbose_name: null
+  verbose_name: Changed On
 - advanced_data_type: null
   column_name: dashboard_title
   description: null
   expression: ''
-  extra: null
+  extra: {}
   filterable: true
   groupby: true
   is_active: true
   is_dttm: false
   python_date_format: null
   type: VARCHAR(500)
-  verbose_name: null
+  verbose_name: Dashboard Title
 - advanced_data_type: null
   column_name: slug
   description: null
   expression: ''
-  extra: null
+  extra: {}
   filterable: true
   groupby: true
   is_active: true
   is_dttm: false
   python_date_format: null
   type: VARCHAR(255)
-  verbose_name: null
+  verbose_name: Slug
 - advanced_data_type: null
   column_name: published
   description: null
   expression: ''
-  extra: null
+  extra: {}
   filterable: true
   groupby: true
   is_active: true
   is_dttm: false
   python_date_format: null
   type: BOOLEAN
-  verbose_name: null
+  verbose_name: Published
 - advanced_data_type: null
   column_name: uuid
   description: null
   expression: ''
-  extra: null
+  extra: {}
   filterable: true
   groupby: true
   is_active: true
   is_dttm: false
   python_date_format: null
   type: UUID
-  verbose_name: null
+  verbose_name: UUID
 - advanced_data_type: null
   column_name: created_by_fk
   description: null
   expression: ''
-  extra: null
+  extra: {}
   filterable: true
   groupby: true
   is_active: true
   is_dttm: false
   python_date_format: null
   type: INTEGER
-  verbose_name: null
+  verbose_name: Created By FK
 - advanced_data_type: null
   column_name: changed_by_fk
   description: null
   expression: ''
-  extra: null
+  extra: {}
   filterable: true
   groupby: true
   is_active: true
   is_dttm: false
   python_date_format: null
   type: INTEGER
-  verbose_name: null
+  verbose_name: Changed By FK
 - advanced_data_type: null
   column_name: id
   description: null
   expression: ''
-  extra: null
+  extra: {}
   filterable: true
   groupby: true
   is_active: true
   is_dttm: false
   python_date_format: null
   type: INTEGER
-  verbose_name: null
+  verbose_name: ID
 - advanced_data_type: null
   column_name: json_metadata
   description: null
   expression: ''
-  extra: null
+  extra: {}
   filterable: true
   groupby: true
   is_active: true
   is_dttm: false
   python_date_format: null
   type: TEXT
-  verbose_name: null
+  verbose_name: JSON Metadata
 - advanced_data_type: null
   column_name: certification_details
   description: null
   expression: ''
-  extra: null
+  extra: {}
   filterable: true
   groupby: true
   is_active: true
   is_dttm: false
   python_date_format: null
   type: TEXT
-  verbose_name: null
+  verbose_name: Certification Details
 - advanced_data_type: null
   column_name: certified_by
   description: null
   expression: ''
-  extra: null
+  extra: {}
   filterable: true
   groupby: true
   is_active: true
   is_dttm: false
   python_date_format: null
   type: TEXT
-  verbose_name: null
+  verbose_name: Certified By
 - advanced_data_type: null
   column_name: position_json
   description: null
   expression: ''
-  extra: null
+  extra: {}
   filterable: true
   groupby: true
   is_active: true
   is_dttm: false
   python_date_format: null
   type: TEXT
-  verbose_name: null
+  verbose_name: Position JSON
 - advanced_data_type: null
   column_name: description
   description: null
   expression: ''
-  extra: null
+  extra: {}
   filterable: true
   groupby: true
   is_active: true
   is_dttm: false
   python_date_format: null
   type: TEXT
-  verbose_name: null
+  verbose_name: Description
 - advanced_data_type: null
   column_name: css
   description: null
   expression: ''
-  extra: null
+  extra: {}
   filterable: true
   groupby: true
   is_active: true
   is_dttm: false
   python_date_format: null
   type: TEXT
-  verbose_name: null
+  verbose_name: CSS
 database_uuid: 06cd566f-e22a-4a79-b0e0-4c947de93ee0
 default_endpoint: null
 description: null
@@ -193,7 +193,7 @@ metrics:
   d3format: null
   description: null
   expression: COUNT(*)
-  extra: null
+  extra: {}
   metric_name: count
   metric_type: count
   verbose_name: COUNT(*)

--- a/tutoraspects/templates/aspects/build/aspects-superset/openedx-assets/assets/datasets/dim_course_problems.yaml
+++ b/tutoraspects/templates/aspects/build/aspects-superset/openedx-assets/assets/datasets/dim_course_problems.yaml
@@ -5,90 +5,90 @@ columns:
   column_name: problem_name_with_location
   description: null
   expression: null
-  extra: null
+  extra: {}
   filterable: true
   groupby: true
   is_active: true
   is_dttm: false
   python_date_format: null
   type: String
-  verbose_name: null
+  verbose_name: Problem Name With Location
 - advanced_data_type: null
   column_name: problem_name
   description: null
   expression: null
-  extra: null
+  extra: {}
   filterable: true
   groupby: true
   is_active: true
   is_dttm: false
   python_date_format: null
   type: String
-  verbose_name: null
+  verbose_name: Problem Name
 - advanced_data_type: null
   column_name: course_name
   description: null
   expression: null
-  extra: null
+  extra: {}
   filterable: true
   groupby: true
   is_active: true
   is_dttm: false
   python_date_format: null
   type: String
-  verbose_name: null
+  verbose_name: Course Name
 - advanced_data_type: null
   column_name: problem_id
   description: null
   expression: null
-  extra: null
+  extra: {}
   filterable: true
   groupby: true
   is_active: true
   is_dttm: false
   python_date_format: null
   type: String
-  verbose_name: null
+  verbose_name: Problem Id
 - advanced_data_type: null
   column_name: course_key
   description: null
   expression: null
-  extra: null
+  extra: {}
   filterable: true
   groupby: true
   is_active: true
   is_dttm: false
   python_date_format: null
   type: String
-  verbose_name: null
+  verbose_name: Course Key
 - advanced_data_type: null
   column_name: course_run
   description: null
   expression: null
-  extra: null
+  extra: {}
   filterable: true
   groupby: true
   is_active: true
   is_dttm: false
   python_date_format: null
   type: String
-  verbose_name: null
+  verbose_name: Course Run
 - advanced_data_type: null
   column_name: org
   description: null
   expression: null
-  extra: null
+  extra: {}
   filterable: true
   groupby: true
   is_active: true
   is_dttm: false
   python_date_format: null
   type: String
-  verbose_name: null
+  verbose_name: Organization
 database_uuid: 21174b6c-4d40-4958-8161-d6c3cf5e77b6
 default_endpoint: null
 description: null
-extra: null
+extra: {}
 fetch_values_predicate: null
 filter_select_enabled: false
 main_dttm_col: null
@@ -97,7 +97,7 @@ metrics:
   d3format: null
   description: null
   expression: count(*)
-  extra: null
+  extra: {}
   metric_name: count
   metric_type: null
   verbose_name: null

--- a/tutoraspects/templates/aspects/build/aspects-superset/openedx-assets/assets/datasets/dim_course_videos.yaml
+++ b/tutoraspects/templates/aspects/build/aspects-superset/openedx-assets/assets/datasets/dim_course_videos.yaml
@@ -5,90 +5,90 @@ columns:
   column_name: video_name_with_location
   description: null
   expression: null
-  extra: null
+  extra: {}
   filterable: true
   groupby: true
   is_active: true
   is_dttm: false
   python_date_format: null
   type: String
-  verbose_name: null
+  verbose_name: Video Name With Location
 - advanced_data_type: null
   column_name: course_name
   description: null
   expression: null
-  extra: null
+  extra: {}
   filterable: true
   groupby: true
   is_active: true
   is_dttm: false
   python_date_format: null
   type: String
-  verbose_name: null
+  verbose_name: Course Name
 - advanced_data_type: null
   column_name: video_name
   description: null
   expression: null
-  extra: null
+  extra: {}
   filterable: true
   groupby: true
   is_active: true
   is_dttm: false
   python_date_format: null
   type: String
-  verbose_name: null
+  verbose_name: Video Name
 - advanced_data_type: null
   column_name: course_key
   description: null
   expression: null
-  extra: null
+  extra: {}
   filterable: true
   groupby: true
   is_active: true
   is_dttm: false
   python_date_format: null
   type: String
-  verbose_name: null
+  verbose_name: Course Key
 - advanced_data_type: null
   column_name: course_run
   description: null
   expression: null
-  extra: null
+  extra: {}
   filterable: true
   groupby: true
   is_active: true
   is_dttm: false
   python_date_format: null
   type: String
-  verbose_name: null
+  verbose_name: Course Run
 - advanced_data_type: null
   column_name: video_id
   description: null
   expression: null
-  extra: null
+  extra: {}
   filterable: true
   groupby: true
   is_active: true
   is_dttm: false
   python_date_format: null
   type: String
-  verbose_name: null
+  verbose_name: Video Id
 - advanced_data_type: null
   column_name: org
   description: null
   expression: null
-  extra: null
+  extra: {}
   filterable: true
   groupby: true
   is_active: true
   is_dttm: false
   python_date_format: null
   type: String
-  verbose_name: null
+  verbose_name: Organization
 database_uuid: 21174b6c-4d40-4958-8161-d6c3cf5e77b6
 default_endpoint: null
 description: null
-extra: null
+extra: {}
 fetch_values_predicate: null
 filter_select_enabled: false
 main_dttm_col: null
@@ -97,7 +97,7 @@ metrics:
   d3format: null
   description: null
   expression: count(*)
-  extra: null
+  extra: {}
   metric_name: count
   metric_type: null
   verbose_name: null

--- a/tutoraspects/templates/aspects/build/aspects-superset/openedx-assets/assets/datasets/fact_course_grades.yaml
+++ b/tutoraspects/templates/aspects/build/aspects-superset/openedx-assets/assets/datasets/fact_course_grades.yaml
@@ -5,126 +5,126 @@ columns:
   column_name: emission_time
   description: null
   expression: null
-  extra: null
+  extra: {}
   filterable: true
   groupby: true
   is_active: true
   is_dttm: true
   python_date_format: null
   type: DateTime
-  verbose_name: null
+  verbose_name: Emission Time
 - advanced_data_type: null
   column_name: scaled_score
   description: null
   expression: null
-  extra: null
+  extra: {}
   filterable: true
   groupby: true
   is_active: true
   is_dttm: false
   python_date_format: null
   type: Float
-  verbose_name: null
+  verbose_name: Scaled Score
 - advanced_data_type: null
   column_name: grade_bucket
   description: null
   expression: null
-  extra: null
+  extra: {}
   filterable: true
   groupby: true
   is_active: true
   is_dttm: false
   python_date_format: null
   type: String
-  verbose_name: null
+  verbose_name: Grade Bucket
 - advanced_data_type: null
   column_name: actor_id
   description: null
   expression: null
-  extra: null
+  extra: {}
   filterable: true
   groupby: true
   is_active: true
   is_dttm: false
   python_date_format: null
   type: String
-  verbose_name: null
+  verbose_name: Actor Id
 - advanced_data_type: null
   column_name: course_name
   description: null
   expression: null
-  extra: null
+  extra: {}
   filterable: true
   groupby: true
   is_active: true
   is_dttm: false
   python_date_format: null
   type: String
-  verbose_name: null
+  verbose_name: Course Name
 - advanced_data_type: null
   column_name: grade_type
   description: null
   expression: null
-  extra: null
+  extra: {}
   filterable: true
   groupby: true
   is_active: true
   is_dttm: false
   python_date_format: null
   type: String
-  verbose_name: null
+  verbose_name: Grade Type
 - advanced_data_type: null
   column_name: entity_name
   description: null
   expression: null
-  extra: null
+  extra: {}
   filterable: true
   groupby: true
   is_active: true
   is_dttm: false
   python_date_format: null
   type: String
-  verbose_name: null
+  verbose_name: Entity Name
 - advanced_data_type: null
   column_name: course_key
   description: null
   expression: null
-  extra: null
+  extra: {}
   filterable: true
   groupby: true
   is_active: true
   is_dttm: false
   python_date_format: null
   type: String
-  verbose_name: null
+  verbose_name: Course Key
 - advanced_data_type: null
   column_name: course_run
   description: null
   expression: null
-  extra: null
+  extra: {}
   filterable: true
   groupby: true
   is_active: true
   is_dttm: false
   python_date_format: null
   type: String
-  verbose_name: null
+  verbose_name: Course Run
 - advanced_data_type: null
   column_name: org
   description: null
   expression: null
-  extra: null
+  extra: {}
   filterable: true
   groupby: true
   is_active: true
   is_dttm: false
   python_date_format: null
   type: String
-  verbose_name: null
+  verbose_name: Organization
 database_uuid: 21174b6c-4d40-4958-8161-d6c3cf5e77b6
 default_endpoint: null
 description: null
-extra: null
+extra: {}
 fetch_values_predicate: null
 filter_select_enabled: false
 main_dttm_col: null
@@ -133,7 +133,7 @@ metrics:
   d3format: null
   description: null
   expression: count(*)
-  extra: null
+  extra: {}
   metric_name: count
   metric_type: null
   verbose_name: null

--- a/tutoraspects/templates/aspects/build/aspects-superset/openedx-assets/assets/datasets/fact_enrollments.yaml
+++ b/tutoraspects/templates/aspects/build/aspects-superset/openedx-assets/assets/datasets/fact_enrollments.yaml
@@ -5,102 +5,102 @@ columns:
   column_name: enrollment_mode
   description: null
   expression: null
-  extra: null
+  extra: {}
   filterable: true
   groupby: true
   is_active: true
   is_dttm: false
   python_date_format: null
   type: LowCardinality(String)
-  verbose_name: null
+  verbose_name: Enrollment Mode
 - advanced_data_type: null
   column_name: emission_time
   description: null
   expression: null
-  extra: null
+  extra: {}
   filterable: true
   groupby: true
   is_active: true
   is_dttm: true
   python_date_format: null
   type: DateTime
-  verbose_name: null
+  verbose_name: Emission Time
 - advanced_data_type: null
   column_name: actor_id
   description: null
   expression: null
-  extra: null
+  extra: {}
   filterable: true
   groupby: true
   is_active: true
   is_dttm: false
   python_date_format: null
   type: String
-  verbose_name: null
+  verbose_name: Actor Id
 - advanced_data_type: null
   column_name: course_name
   description: null
   expression: null
-  extra: null
+  extra: {}
   filterable: true
   groupby: true
   is_active: true
   is_dttm: false
   python_date_format: null
   type: String
-  verbose_name: null
+  verbose_name: Course Name
 - advanced_data_type: null
   column_name: enrollment_status
   description: null
   expression: null
-  extra: null
+  extra: {}
   filterable: true
   groupby: true
   is_active: true
   is_dttm: false
   python_date_format: null
   type: String
-  verbose_name: null
+  verbose_name: Enrollment Status
 - advanced_data_type: null
   column_name: course_key
   description: null
   expression: null
-  extra: null
+  extra: {}
   filterable: true
   groupby: true
   is_active: true
   is_dttm: false
   python_date_format: null
   type: String
-  verbose_name: null
+  verbose_name: Course Key
 - advanced_data_type: null
   column_name: course_run
   description: null
   expression: null
-  extra: null
+  extra: {}
   filterable: true
   groupby: true
   is_active: true
   is_dttm: false
   python_date_format: null
   type: String
-  verbose_name: null
+  verbose_name: Course Run
 - advanced_data_type: null
   column_name: org
   description: null
   expression: null
-  extra: null
+  extra: {}
   filterable: true
   groupby: true
   is_active: true
   is_dttm: false
   python_date_format: null
   type: String
-  verbose_name: null
+  verbose_name: Organization
 database_uuid: 21174b6c-4d40-4958-8161-d6c3cf5e77b6
 default_endpoint: null
 description: null
-extra: null
+extra: {}
 fetch_values_predicate: null
 filter_select_enabled: false
 main_dttm_col: null
@@ -109,7 +109,7 @@ metrics:
   d3format: null
   description: null
   expression: count(*)
-  extra: null
+  extra: {}
   metric_name: count
   metric_type: null
   verbose_name: null

--- a/tutoraspects/templates/aspects/build/aspects-superset/openedx-assets/assets/datasets/fact_enrollments_by_day.yaml
+++ b/tutoraspects/templates/aspects/build/aspects-superset/openedx-assets/assets/datasets/fact_enrollments_by_day.yaml
@@ -5,102 +5,102 @@ columns:
   column_name: enrollment_mode
   description: null
   expression: null
-  extra: null
+  extra: {}
   filterable: true
   groupby: true
   is_active: true
   is_dttm: false
   python_date_format: null
   type: LowCardinality(String)
-  verbose_name: null
+  verbose_name: Enrollment Mode
 - advanced_data_type: null
   column_name: enrollment_status_date
   description: null
   expression: null
-  extra: null
+  extra: {}
   filterable: true
   groupby: true
   is_active: true
   is_dttm: true
   python_date_format: null
   type: Date
-  verbose_name: null
+  verbose_name: Enrollment Status Date
 - advanced_data_type: null
   column_name: actor_id
   description: null
   expression: null
-  extra: null
+  extra: {}
   filterable: true
   groupby: true
   is_active: true
   is_dttm: false
   python_date_format: null
   type: String
-  verbose_name: null
+  verbose_name: Actor Id
 - advanced_data_type: null
   column_name: course_name
   description: null
   expression: null
-  extra: null
+  extra: {}
   filterable: true
   groupby: true
   is_active: true
   is_dttm: false
   python_date_format: null
   type: String
-  verbose_name: null
+  verbose_name: Course Name
 - advanced_data_type: null
   column_name: enrollment_status
   description: null
   expression: null
-  extra: null
+  extra: {}
   filterable: true
   groupby: true
   is_active: true
   is_dttm: false
   python_date_format: null
   type: String
-  verbose_name: null
+  verbose_name: Enrollment Status
 - advanced_data_type: null
   column_name: course_key
   description: null
   expression: null
-  extra: null
+  extra: {}
   filterable: true
   groupby: true
   is_active: true
   is_dttm: false
   python_date_format: null
   type: String
-  verbose_name: null
+  verbose_name: Course Key
 - advanced_data_type: null
   column_name: course_run
   description: null
   expression: null
-  extra: null
+  extra: {}
   filterable: true
   groupby: true
   is_active: true
   is_dttm: false
   python_date_format: null
   type: String
-  verbose_name: null
+  verbose_name: Course Run
 - advanced_data_type: null
   column_name: org
   description: null
   expression: null
-  extra: null
+  extra: {}
   filterable: true
   groupby: true
   is_active: true
   is_dttm: false
   python_date_format: null
   type: String
-  verbose_name: null
+  verbose_name: Organization
 database_uuid: 21174b6c-4d40-4958-8161-d6c3cf5e77b6
 default_endpoint: null
 description: null
-extra: null
+extra: {}
 fetch_values_predicate: null
 filter_select_enabled: false
 main_dttm_col: null
@@ -109,7 +109,7 @@ metrics:
   d3format: null
   description: null
   expression: count(*)
-  extra: null
+  extra: {}
   metric_name: count
   metric_type: null
   verbose_name: null

--- a/tutoraspects/templates/aspects/build/aspects-superset/openedx-assets/assets/datasets/fact_forum_interactions.yaml
+++ b/tutoraspects/templates/aspects/build/aspects-superset/openedx-assets/assets/datasets/fact_forum_interactions.yaml
@@ -12,107 +12,107 @@ columns:
   is_dttm: false
   python_date_format: null
   type: UUID
-  verbose_name: null
+  verbose_name: Event ID
 - advanced_data_type: null
   column_name: emission_time
   description: null
   expression: null
-  extra: null
+  extra: {}
   filterable: true
   groupby: true
   is_active: true
   is_dttm: true
   python_date_format: null
   type: DateTime
-  verbose_name: null
+  verbose_name: Emission Time
 - advanced_data_type: null
   column_name: actor_id
   description: null
   expression: null
-  extra: null
+  extra: {}
   filterable: true
   groupby: true
   is_active: true
   is_dttm: false
   python_date_format: null
   type: String
-  verbose_name: null
+  verbose_name: Actor Id
 - advanced_data_type: null
   column_name: course_name
   description: null
   expression: null
-  extra: null
+  extra: {}
   filterable: true
   groupby: true
   is_active: true
   is_dttm: false
   python_date_format: null
   type: String
-  verbose_name: null
+  verbose_name: Course Name
 - advanced_data_type: null
   column_name: object_id
   description: null
   expression: null
-  extra: null
+  extra: {}
   filterable: true
   groupby: true
   is_active: true
   is_dttm: false
   python_date_format: null
   type: String
-  verbose_name: null
+  verbose_name: Object ID
 - advanced_data_type: null
   column_name: verb_id
   description: null
   expression: null
-  extra: null
+  extra: {}
   filterable: true
   groupby: true
   is_active: true
   is_dttm: false
   python_date_format: null
   type: String
-  verbose_name: null
+  verbose_name: Verb ID
 - advanced_data_type: null
   column_name: course_key
   description: null
   expression: null
-  extra: null
+  extra: {}
   filterable: true
   groupby: true
   is_active: true
   is_dttm: false
   python_date_format: null
   type: String
-  verbose_name: null
+  verbose_name: Course Key
 - advanced_data_type: null
   column_name: course_run
   description: null
   expression: null
-  extra: null
+  extra: {}
   filterable: true
   groupby: true
   is_active: true
   is_dttm: false
   python_date_format: null
   type: String
-  verbose_name: null
+  verbose_name: Course Run
 - advanced_data_type: null
   column_name: org
   description: null
   expression: null
-  extra: null
+  extra: {}
   filterable: true
   groupby: true
   is_active: true
   is_dttm: false
   python_date_format: null
   type: String
-  verbose_name: null
+  verbose_name: Organization
 database_uuid: 21174b6c-4d40-4958-8161-d6c3cf5e77b6
 default_endpoint: null
 description: null
-extra: null
+extra: {}
 fetch_values_predicate: null
 filter_select_enabled: false
 main_dttm_col: null
@@ -121,7 +121,7 @@ metrics:
   d3format: null
   description: null
   expression: count(*)
-  extra: null
+  extra: {}
   metric_name: count
   metric_type: null
   verbose_name: null

--- a/tutoraspects/templates/aspects/build/aspects-superset/openedx-assets/assets/datasets/fact_learner_problem_course_summary.yaml
+++ b/tutoraspects/templates/aspects/build/aspects-superset/openedx-assets/assets/datasets/fact_learner_problem_course_summary.yaml
@@ -5,138 +5,138 @@ columns:
   column_name: attempts
   description: null
   expression: null
-  extra: null
+  extra: {}
   filterable: true
   groupby: true
   is_active: true
   is_dttm: false
   python_date_format: null
   type: Int16
-  verbose_name: null
+  verbose_name: Attempts
 - advanced_data_type: null
   column_name: num_answers_displayed
   description: null
   expression: null
-  extra: null
+  extra: {}
   filterable: true
   groupby: true
   is_active: true
   is_dttm: false
   python_date_format: null
   type: UInt64
-  verbose_name: null
+  verbose_name: Number of Answers Displayed
 - advanced_data_type: null
   column_name: num_hints_displayed
   description: null
   expression: null
-  extra: null
+  extra: {}
   filterable: true
   groupby: true
   is_active: true
   is_dttm: false
   python_date_format: null
   type: UInt64
-  verbose_name: null
+  verbose_name: Number of Hints Displayed
 - advanced_data_type: null
   column_name: success
   description: null
   expression: null
-  extra: null
+  extra: {}
   filterable: true
   groupby: true
   is_active: true
   is_dttm: false
   python_date_format: null
   type: Bool
-  verbose_name: null
+  verbose_name: Success
 - advanced_data_type: null
   column_name: problem_name_with_location
   description: null
   expression: null
-  extra: null
+  extra: {}
   filterable: true
   groupby: true
   is_active: true
   is_dttm: false
   python_date_format: null
   type: String
-  verbose_name: null
+  verbose_name: Problem Name With Location
 - advanced_data_type: null
   column_name: problem_name
   description: null
   expression: null
-  extra: null
+  extra: {}
   filterable: true
   groupby: true
   is_active: true
   is_dttm: false
   python_date_format: null
   type: String
-  verbose_name: null
+  verbose_name: Problem Name
 - advanced_data_type: null
   column_name: actor_id
   description: null
   expression: null
-  extra: null
+  extra: {}
   filterable: true
   groupby: true
   is_active: true
   is_dttm: false
   python_date_format: null
   type: String
-  verbose_name: null
+  verbose_name: Actor ID
 - advanced_data_type: null
   column_name: course_name
   description: null
   expression: null
-  extra: null
+  extra: {}
   filterable: true
   groupby: true
   is_active: true
   is_dttm: false
   python_date_format: null
   type: String
-  verbose_name: null
+  verbose_name: Course Name
 - advanced_data_type: null
   column_name: course_key
   description: null
   expression: null
-  extra: null
+  extra: {}
   filterable: true
   groupby: true
   is_active: true
   is_dttm: false
   python_date_format: null
   type: String
-  verbose_name: null
+  verbose_name: Course Key
 - advanced_data_type: null
   column_name: course_run
   description: null
   expression: null
-  extra: null
+  extra: {}
   filterable: true
   groupby: true
   is_active: true
   is_dttm: false
   python_date_format: null
   type: String
-  verbose_name: null
+  verbose_name: Course Run
 - advanced_data_type: null
   column_name: org
   description: null
   expression: null
-  extra: null
+  extra: {}
   filterable: true
   groupby: true
   is_active: true
   is_dttm: false
   python_date_format: null
   type: String
-  verbose_name: null
+  verbose_name: Organization
 database_uuid: 21174b6c-4d40-4958-8161-d6c3cf5e77b6
 default_endpoint: null
 description: null
-extra: null
+extra: {}
 fetch_values_predicate: null
 filter_select_enabled: false
 main_dttm_col: null
@@ -145,7 +145,7 @@ metrics:
   d3format: null
   description: null
   expression: count(*)
-  extra: null
+  extra: {}
   metric_name: count
   metric_type: null
   verbose_name: null

--- a/tutoraspects/templates/aspects/build/aspects-superset/openedx-assets/assets/datasets/fact_learner_problem_summary.yaml
+++ b/tutoraspects/templates/aspects/build/aspects-superset/openedx-assets/assets/datasets/fact_learner_problem_summary.yaml
@@ -5,138 +5,138 @@ columns:
   column_name: attempts
   description: null
   expression: null
-  extra: null
+  extra: {}
   filterable: true
   groupby: true
   is_active: true
   is_dttm: false
   python_date_format: null
   type: Int16
-  verbose_name: null
+  verbose_name: Attempts
 - advanced_data_type: null
   column_name: num_answers_displayed
   description: null
   expression: null
-  extra: null
+  extra: {}
   filterable: true
   groupby: true
   is_active: true
   is_dttm: false
   python_date_format: null
   type: UInt64
-  verbose_name: null
+  verbose_name: Number of Answers Displayed
 - advanced_data_type: null
   column_name: num_hints_displayed
   description: null
   expression: null
-  extra: null
+  extra: {}
   filterable: true
   groupby: true
   is_active: true
   is_dttm: false
   python_date_format: null
   type: UInt64
-  verbose_name: null
+  verbose_name: Number of Hints Displayed
 - advanced_data_type: null
   column_name: success
   description: null
   expression: null
-  extra: null
+  extra: {}
   filterable: true
   groupby: true
   is_active: true
   is_dttm: false
   python_date_format: null
   type: Bool
-  verbose_name: null
+  verbose_name: Success
 - advanced_data_type: null
   column_name: problem_name_with_location
   description: null
   expression: null
-  extra: null
+  extra: {}
   filterable: true
   groupby: true
   is_active: true
   is_dttm: false
   python_date_format: null
   type: String
-  verbose_name: null
+  verbose_name: Problem Name With Location
 - advanced_data_type: null
   column_name: problem_name
   description: null
   expression: null
-  extra: null
+  extra: {}
   filterable: true
   groupby: true
   is_active: true
   is_dttm: false
   python_date_format: null
   type: String
-  verbose_name: null
+  verbose_name: Problem Name
 - advanced_data_type: null
   column_name: actor_id
   description: null
   expression: null
-  extra: null
+  extra: {}
   filterable: true
   groupby: true
   is_active: true
   is_dttm: false
   python_date_format: null
   type: String
-  verbose_name: null
+  verbose_name: Actor ID
 - advanced_data_type: null
   column_name: course_name
   description: null
   expression: null
-  extra: null
+  extra: {}
   filterable: true
   groupby: true
   is_active: true
   is_dttm: false
   python_date_format: null
   type: String
-  verbose_name: null
+  verbose_name: Course Name
 - advanced_data_type: null
   column_name: course_key
   description: null
   expression: null
-  extra: null
+  extra: {}
   filterable: true
   groupby: true
   is_active: true
   is_dttm: false
   python_date_format: null
   type: String
-  verbose_name: null
+  verbose_name: Course Key
 - advanced_data_type: null
   column_name: course_run
   description: null
   expression: null
-  extra: null
+  extra: {}
   filterable: true
   groupby: true
   is_active: true
   is_dttm: false
   python_date_format: null
   type: String
-  verbose_name: null
+  verbose_name: Course Run
 - advanced_data_type: null
   column_name: org
   description: null
   expression: null
-  extra: null
+  extra: {}
   filterable: true
   groupby: true
   is_active: true
   is_dttm: false
   python_date_format: null
   type: String
-  verbose_name: null
+  verbose_name: Organization
 database_uuid: 21174b6c-4d40-4958-8161-d6c3cf5e77b6
 default_endpoint: null
 description: null
-extra: null
+extra: {}
 fetch_values_predicate: null
 filter_select_enabled: false
 main_dttm_col: null
@@ -145,7 +145,7 @@ metrics:
   d3format: null
   description: null
   expression: count(*)
-  extra: null
+  extra: {}
   metric_name: count
   metric_type: null
   verbose_name: null

--- a/tutoraspects/templates/aspects/build/aspects-superset/openedx-assets/assets/datasets/fact_problem_grades.yaml
+++ b/tutoraspects/templates/aspects/build/aspects-superset/openedx-assets/assets/datasets/fact_problem_grades.yaml
@@ -5,126 +5,126 @@ columns:
   column_name: emission_time
   description: null
   expression: null
-  extra: null
+  extra: {}
   filterable: true
   groupby: true
   is_active: true
   is_dttm: true
   python_date_format: null
   type: DateTime
-  verbose_name: null
+  verbose_name: Emission Time
 - advanced_data_type: null
   column_name: scaled_score
   description: null
   expression: null
-  extra: null
+  extra: {}
   filterable: true
   groupby: true
   is_active: true
   is_dttm: false
   python_date_format: null
   type: Float
-  verbose_name: null
+  verbose_name: Scaled Score
 - advanced_data_type: null
   column_name: grade_bucket
   description: null
   expression: null
-  extra: null
+  extra: {}
   filterable: true
   groupby: true
   is_active: true
   is_dttm: false
   python_date_format: null
   type: String
-  verbose_name: null
+  verbose_name: Grade Bucket
 - advanced_data_type: null
   column_name: actor_id
   description: null
   expression: null
-  extra: null
+  extra: {}
   filterable: true
   groupby: true
   is_active: true
   is_dttm: false
   python_date_format: null
   type: String
-  verbose_name: null
+  verbose_name: Actor Id
 - advanced_data_type: null
   column_name: course_name
   description: null
   expression: null
-  extra: null
+  extra: {}
   filterable: true
   groupby: true
   is_active: true
   is_dttm: false
   python_date_format: null
   type: String
-  verbose_name: null
+  verbose_name: Course Name
 - advanced_data_type: null
   column_name: grade_type
   description: null
   expression: null
-  extra: null
+  extra: {}
   filterable: true
   groupby: true
   is_active: true
   is_dttm: false
   python_date_format: null
   type: String
-  verbose_name: null
+  verbose_name: Grade Type
 - advanced_data_type: null
   column_name: entity_name
   description: null
   expression: null
-  extra: null
+  extra: {}
   filterable: true
   groupby: true
   is_active: true
   is_dttm: false
   python_date_format: null
   type: String
-  verbose_name: null
+  verbose_name: Entity Name
 - advanced_data_type: null
   column_name: course_key
   description: null
   expression: null
-  extra: null
+  extra: {}
   filterable: true
   groupby: true
   is_active: true
   is_dttm: false
   python_date_format: null
   type: String
-  verbose_name: null
+  verbose_name: Course Key
 - advanced_data_type: null
   column_name: course_run
   description: null
   expression: null
-  extra: null
+  extra: {}
   filterable: true
   groupby: true
   is_active: true
   is_dttm: false
   python_date_format: null
   type: String
-  verbose_name: null
+  verbose_name: Course Run
 - advanced_data_type: null
   column_name: org
   description: null
   expression: null
-  extra: null
+  extra: {}
   filterable: true
   groupby: true
   is_active: true
   is_dttm: false
   python_date_format: null
   type: String
-  verbose_name: null
+  verbose_name: Organization
 database_uuid: 21174b6c-4d40-4958-8161-d6c3cf5e77b6
 default_endpoint: null
 description: null
-extra: null
+extra: {}
 fetch_values_predicate: null
 filter_select_enabled: false
 main_dttm_col: null
@@ -133,7 +133,7 @@ metrics:
   d3format: null
   description: null
   expression: count(*)
-  extra: null
+  extra: {}
   metric_name: count
   metric_type: null
   verbose_name: null

--- a/tutoraspects/templates/aspects/build/aspects-superset/openedx-assets/assets/datasets/fact_problem_responses.yaml
+++ b/tutoraspects/templates/aspects/build/aspects-superset/openedx-assets/assets/datasets/fact_problem_responses.yaml
@@ -5,126 +5,126 @@ columns:
   column_name: attempts
   description: null
   expression: null
-  extra: null
+  extra: {}
   filterable: true
   groupby: true
   is_active: true
   is_dttm: false
   python_date_format: null
   type: Int16
-  verbose_name: null
+  verbose_name: Attempts
 - advanced_data_type: null
   column_name: success
   description: null
   expression: null
-  extra: null
+  extra: {}
   filterable: true
   groupby: true
   is_active: true
   is_dttm: false
   python_date_format: null
   type: Bool
-  verbose_name: null
+  verbose_name: Success
 - advanced_data_type: null
   column_name: emission_time
   description: null
   expression: null
-  extra: null
+  extra: {}
   filterable: true
   groupby: true
   is_active: true
   is_dttm: true
   python_date_format: null
   type: DateTime
-  verbose_name: null
+  verbose_name: Emission Time
 - advanced_data_type: null
   column_name: problem_name_with_location
   description: null
   expression: null
-  extra: null
+  extra: {}
   filterable: true
   groupby: true
   is_active: true
   is_dttm: false
   python_date_format: null
   type: String
-  verbose_name: null
+  verbose_name: Problem Name With Location
 - advanced_data_type: null
   column_name: problem_name
   description: null
   expression: null
-  extra: null
+  extra: {}
   filterable: true
   groupby: true
   is_active: true
   is_dttm: false
   python_date_format: null
   type: String
-  verbose_name: null
+  verbose_name: Problem Name
 - advanced_data_type: null
   column_name: actor_id
   description: null
   expression: null
-  extra: null
+  extra: {}
   filterable: true
   groupby: true
   is_active: true
   is_dttm: false
   python_date_format: null
   type: String
-  verbose_name: null
+  verbose_name: Actor ID
 - advanced_data_type: null
   column_name: course_name
   description: null
   expression: null
-  extra: null
+  extra: {}
   filterable: true
   groupby: true
   is_active: true
   is_dttm: false
   python_date_format: null
   type: String
-  verbose_name: null
+  verbose_name: Course Name
 - advanced_data_type: null
   column_name: course_run
   description: null
   expression: null
-  extra: null
+  extra: {}
   filterable: true
   groupby: true
   is_active: true
   is_dttm: false
   python_date_format: null
   type: String
-  verbose_name: null
+  verbose_name: Course Run
 - advanced_data_type: null
   column_name: responses
   description: null
   expression: null
-  extra: null
+  extra: {}
   filterable: true
   groupby: true
   is_active: true
   is_dttm: false
   python_date_format: null
   type: String
-  verbose_name: null
+  verbose_name: Responses
 - advanced_data_type: null
   column_name: org
   description: null
   expression: null
-  extra: null
+  extra: {}
   filterable: true
   groupby: true
   is_active: true
   is_dttm: false
   python_date_format: null
   type: String
-  verbose_name: null
+  verbose_name: Organization
 database_uuid: 21174b6c-4d40-4958-8161-d6c3cf5e77b6
 default_endpoint: null
 description: null
-extra: null
+extra: {}
 fetch_values_predicate: null
 filter_select_enabled: false
 main_dttm_col: null
@@ -133,7 +133,7 @@ metrics:
   d3format: null
   description: null
   expression: count(*)
-  extra: null
+  extra: {}
   metric_name: count
   metric_type: null
   verbose_name: null

--- a/tutoraspects/templates/aspects/build/aspects-superset/openedx-assets/assets/datasets/fact_transcript_usage.yaml
+++ b/tutoraspects/templates/aspects/build/aspects-superset/openedx-assets/assets/datasets/fact_transcript_usage.yaml
@@ -12,7 +12,7 @@ columns:
   is_dttm: true
   python_date_format: null
   type: DateTime
-  verbose_name: null
+  verbose_name: Emission Time
 - advanced_data_type: null
   column_name: video_name_with_location
   description: null
@@ -24,7 +24,7 @@ columns:
   is_dttm: false
   python_date_format: null
   type: String
-  verbose_name: null
+  verbose_name: Video Name With Location
 - advanced_data_type: null
   column_name: actor_id
   description: null
@@ -36,7 +36,7 @@ columns:
   is_dttm: false
   python_date_format: null
   type: String
-  verbose_name: null
+  verbose_name: Actor ID
 - advanced_data_type: null
   column_name: course_name
   description: null
@@ -48,7 +48,7 @@ columns:
   is_dttm: false
   python_date_format: null
   type: String
-  verbose_name: null
+  verbose_name: Course Name
 - advanced_data_type: null
   column_name: video_name
   description: null
@@ -60,7 +60,7 @@ columns:
   is_dttm: false
   python_date_format: null
   type: String
-  verbose_name: null
+  verbose_name: Video Name
 - advanced_data_type: null
   column_name: course_run
   description: null
@@ -72,7 +72,7 @@ columns:
   is_dttm: false
   python_date_format: null
   type: String
-  verbose_name: null
+  verbose_name: Course Run
 - advanced_data_type: null
   column_name: org
   description: null
@@ -84,23 +84,23 @@ columns:
   is_dttm: false
   python_date_format: null
   type: String
-  verbose_name: null
+  verbose_name: Organization
 - advanced_data_type: null
   column_name: course_key
   description: null
   expression: null
-  extra: null
+  extra: {}
   filterable: true
   groupby: true
   is_active: true
   is_dttm: false
   python_date_format: null
   type: String
-  verbose_name: null
+  verbose_name: Course Key
 database_uuid: 21174b6c-4d40-4958-8161-d6c3cf5e77b6
 default_endpoint: null
 description: null
-extra: null
+extra: {}
 fetch_values_predicate: null
 filter_select_enabled: false
 main_dttm_col: null

--- a/tutoraspects/templates/aspects/build/aspects-superset/openedx-assets/assets/datasets/fact_video_plays.yaml
+++ b/tutoraspects/templates/aspects/build/aspects-superset/openedx-assets/assets/datasets/fact_video_plays.yaml
@@ -12,7 +12,7 @@ columns:
   is_dttm: true
   python_date_format: null
   type: DateTime
-  verbose_name: null
+  verbose_name: Emission Time
 - advanced_data_type: null
   column_name: video_name_with_location
   description: null
@@ -24,7 +24,7 @@ columns:
   is_dttm: false
   python_date_format: null
   type: String
-  verbose_name: null
+  verbose_name: Video Name With Location
 - advanced_data_type: null
   column_name: actor_id
   description: null
@@ -36,7 +36,7 @@ columns:
   is_dttm: false
   python_date_format: null
   type: String
-  verbose_name: null
+  verbose_name: Actor ID
 - advanced_data_type: null
   column_name: course_name
   description: null
@@ -48,7 +48,7 @@ columns:
   is_dttm: false
   python_date_format: null
   type: String
-  verbose_name: null
+  verbose_name: Course Name
 - advanced_data_type: null
   column_name: video_name
   description: null
@@ -60,7 +60,7 @@ columns:
   is_dttm: false
   python_date_format: null
   type: String
-  verbose_name: null
+  verbose_name: Video Name
 - advanced_data_type: null
   column_name: course_run
   description: null
@@ -72,7 +72,7 @@ columns:
   is_dttm: false
   python_date_format: null
   type: String
-  verbose_name: null
+  verbose_name: Course Run
 - advanced_data_type: null
   column_name: org
   description: null
@@ -84,23 +84,23 @@ columns:
   is_dttm: false
   python_date_format: null
   type: String
-  verbose_name: null
+  verbose_name: Organization
 - advanced_data_type: null
   column_name: course_key
   description: null
   expression: null
-  extra: null
+  extra: {}
   filterable: true
   groupby: true
   is_active: true
   is_dttm: false
   python_date_format: null
   type: String
-  verbose_name: null
+  verbose_name: Course Key
 database_uuid: 21174b6c-4d40-4958-8161-d6c3cf5e77b6
 default_endpoint: null
 description: null
-extra: null
+extra: {}
 fetch_values_predicate: null
 filter_select_enabled: false
 main_dttm_col: null

--- a/tutoraspects/templates/aspects/build/aspects-superset/openedx-assets/assets/datasets/fact_watched_video_segments.yaml
+++ b/tutoraspects/templates/aspects/build/aspects-superset/openedx-assets/assets/datasets/fact_watched_video_segments.yaml
@@ -12,7 +12,7 @@ columns:
   is_dttm: false
   python_date_format: null
   type: Int32
-  verbose_name: null
+  verbose_name: Segment Start
 - advanced_data_type: null
   column_name: started_at
   description: null
@@ -24,7 +24,7 @@ columns:
   is_dttm: true
   python_date_format: null
   type: DateTime
-  verbose_name: null
+  verbose_name: Started At
 - advanced_data_type: null
   column_name: video_name_with_location
   description: null
@@ -36,7 +36,7 @@ columns:
   is_dttm: false
   python_date_format: null
   type: String
-  verbose_name: null
+  verbose_name: Video Name With Location
 - advanced_data_type: null
   column_name: actor_id
   description: null
@@ -48,7 +48,7 @@ columns:
   is_dttm: false
   python_date_format: null
   type: String
-  verbose_name: null
+  verbose_name: Actor ID
 - advanced_data_type: null
   column_name: course_name
   description: null
@@ -60,7 +60,7 @@ columns:
   is_dttm: false
   python_date_format: null
   type: String
-  verbose_name: null
+  verbose_name: Course Name
 - advanced_data_type: null
   column_name: video_name
   description: null
@@ -72,7 +72,7 @@ columns:
   is_dttm: false
   python_date_format: null
   type: String
-  verbose_name: null
+  verbose_name: Video Name
 - advanced_data_type: null
   column_name: course_run
   description: null
@@ -84,7 +84,7 @@ columns:
   is_dttm: false
   python_date_format: null
   type: String
-  verbose_name: null
+  verbose_name: Course Run
 - advanced_data_type: null
   column_name: org
   description: null
@@ -96,23 +96,23 @@ columns:
   is_dttm: false
   python_date_format: null
   type: String
-  verbose_name: null
+  verbose_name: Organization
 - advanced_data_type: null
   column_name: course_key
   description: null
   expression: null
-  extra: null
+  extra: {}
   filterable: true
   groupby: true
   is_active: true
   is_dttm: false
   python_date_format: null
   type: String
-  verbose_name: null
+  verbose_name: Course Key
 database_uuid: 21174b6c-4d40-4958-8161-d6c3cf5e77b6
 default_endpoint: null
 description: null
-extra: null
+extra: {}
 fetch_values_predicate: null
 filter_select_enabled: false
 main_dttm_col: null
@@ -124,7 +124,7 @@ metrics:
   extra: {}
   metric_name: repeat_views
   metric_type: null
-  verbose_name: Repeat views
+  verbose_name: Repeat Views
   warning_text: null
 - currency: null
   d3format: null
@@ -134,7 +134,7 @@ metrics:
     warning_markdown: ''
   metric_name: count
   metric_type: null
-  verbose_name: Total views
+  verbose_name: Total Views
   warning_text: null
 - currency: null
   d3format: null
@@ -143,7 +143,7 @@ metrics:
   extra: {}
   metric_name: unique_viewers
   metric_type: null
-  verbose_name: Unique viewers
+  verbose_name: Unique Viewers
   warning_text: null
 normalize_columns: true
 offset: 0

--- a/tutoraspects/templates/aspects/build/aspects-superset/openedx-assets/assets/datasets/hints_per_success.yaml
+++ b/tutoraspects/templates/aspects/build/aspects-superset/openedx-assets/assets/datasets/hints_per_success.yaml
@@ -5,102 +5,102 @@ columns:
   column_name: total_hints
   description: null
   expression: null
-  extra: null
+  extra: {}
   filterable: true
   groupby: true
   is_active: true
   is_dttm: false
   python_date_format: null
   type: UInt64
-  verbose_name: null
+  verbose_name: Total Hints
 - advanced_data_type: null
   column_name: problem_name_with_location
   description: null
   expression: null
-  extra: null
+  extra: {}
   filterable: true
   groupby: true
   is_active: true
   is_dttm: false
   python_date_format: null
   type: String
-  verbose_name: null
+  verbose_name: Problem Name With Location
 - advanced_data_type: null
   column_name: problem_name
   description: null
   expression: null
-  extra: null
+  extra: {}
   filterable: true
   groupby: true
   is_active: true
   is_dttm: false
   python_date_format: null
   type: String
-  verbose_name: null
+  verbose_name: Problem Name
 - advanced_data_type: null
   column_name: actor_id
   description: null
   expression: null
-  extra: null
+  extra: {}
   filterable: true
   groupby: true
   is_active: true
   is_dttm: false
   python_date_format: null
   type: String
-  verbose_name: null
+  verbose_name: Actor ID
 - advanced_data_type: null
   column_name: course_name
   description: null
   expression: null
-  extra: null
+  extra: {}
   filterable: true
   groupby: true
   is_active: true
   is_dttm: false
   python_date_format: null
   type: String
-  verbose_name: null
+  verbose_name: Course Name
 - advanced_data_type: null
   column_name: course_key
   description: null
   expression: null
-  extra: null
+  extra: {}
   filterable: true
   groupby: true
   is_active: true
   is_dttm: false
   python_date_format: null
   type: String
-  verbose_name: null
+  verbose_name: Course Key
 - advanced_data_type: null
   column_name: course_run
   description: null
   expression: null
-  extra: null
+  extra: {}
   filterable: true
   groupby: true
   is_active: true
   is_dttm: false
   python_date_format: null
   type: String
-  verbose_name: null
+  verbose_name: Course Run
 - advanced_data_type: null
   column_name: org
   description: null
   expression: null
-  extra: null
+  extra: {}
   filterable: true
   groupby: true
   is_active: true
   is_dttm: false
   python_date_format: null
   type: String
-  verbose_name: null
+  verbose_name: Organization
 database_uuid: 21174b6c-4d40-4958-8161-d6c3cf5e77b6
 default_endpoint: null
 description: null
-extra: null
+extra: {}
 fetch_values_predicate: null
 filter_select_enabled: false
 main_dttm_col: null
@@ -109,7 +109,7 @@ metrics:
   d3format: null
   description: null
   expression: count(*)
-  extra: null
+  extra: {}
   metric_name: count
   metric_type: null
   verbose_name: null

--- a/tutoraspects/templates/aspects/build/aspects-superset/openedx-assets/assets/datasets/indexed_events.yaml
+++ b/tutoraspects/templates/aspects/build/aspects-superset/openedx-assets/assets/datasets/indexed_events.yaml
@@ -12,7 +12,7 @@ columns:
   is_dttm: false
   python_date_format: null
   type: UUID
-  verbose_name: null
+  verbose_name: Event ID
 - advanced_data_type: null
   column_name: emission_time
   description: null
@@ -24,7 +24,7 @@ columns:
   is_dttm: true
   python_date_format: null
   type: DateTime
-  verbose_name: null
+  verbose_name: Emission Time
 - advanced_data_type: null
   column_name: actor_id
   description: null
@@ -36,7 +36,7 @@ columns:
   is_dttm: false
   python_date_format: null
   type: String
-  verbose_name: null
+  verbose_name: Actor ID
 - advanced_data_type: null
   column_name: course_name
   description: null
@@ -48,7 +48,7 @@ columns:
   is_dttm: false
   python_date_format: null
   type: String
-  verbose_name: null
+  verbose_name: Course Name
 - advanced_data_type: null
   column_name: object_id
   description: null
@@ -60,7 +60,7 @@ columns:
   is_dttm: false
   python_date_format: null
   type: String
-  verbose_name: null
+  verbose_name: Object ID
 - advanced_data_type: null
   column_name: verb_id
   description: null
@@ -72,7 +72,7 @@ columns:
   is_dttm: false
   python_date_format: null
   type: String
-  verbose_name: null
+  verbose_name: Verb ID
 - advanced_data_type: null
   column_name: course_key
   description: null
@@ -84,7 +84,7 @@ columns:
   is_dttm: false
   python_date_format: null
   type: String
-  verbose_name: null
+  verbose_name: Course Key
 - advanced_data_type: null
   column_name: course_run
   description: null
@@ -96,7 +96,7 @@ columns:
   is_dttm: false
   python_date_format: null
   type: String
-  verbose_name: null
+  verbose_name: Course Run
 - advanced_data_type: null
   column_name: org
   description: null
@@ -108,11 +108,11 @@ columns:
   is_dttm: false
   python_date_format: null
   type: String
-  verbose_name: null
+  verbose_name: Organization
 database_uuid: 21174b6c-4d40-4958-8161-d6c3cf5e77b6
 default_endpoint: null
 description: null
-extra: null
+extra: {}
 fetch_values_predicate: null
 filter_select_enabled: true
 main_dttm_col: emission_time

--- a/tutoraspects/templates/aspects/build/aspects-superset/openedx-assets/assets/datasets/posts_per_user.yaml
+++ b/tutoraspects/templates/aspects/build/aspects-superset/openedx-assets/assets/datasets/posts_per_user.yaml
@@ -5,78 +5,78 @@ columns:
   column_name: num_posts
   description: null
   expression: null
-  extra: null
+  extra: {}
   filterable: true
   groupby: true
   is_active: true
   is_dttm: false
   python_date_format: null
   type: UInt64
-  verbose_name: null
+  verbose_name: Number of Posts
 - advanced_data_type: null
   column_name: actor_id
   description: null
   expression: null
-  extra: null
+  extra: {}
   filterable: true
   groupby: true
   is_active: true
   is_dttm: false
   python_date_format: null
   type: String
-  verbose_name: null
+  verbose_name: Actor ID
 - advanced_data_type: null
   column_name: course_name
   description: null
   expression: null
-  extra: null
+  extra: {}
   filterable: true
   groupby: true
   is_active: true
   is_dttm: false
   python_date_format: null
   type: String
-  verbose_name: null
+  verbose_name: Course Name
 - advanced_data_type: null
   column_name: course_key
   description: null
   expression: null
-  extra: null
+  extra: {}
   filterable: true
   groupby: true
   is_active: true
   is_dttm: false
   python_date_format: null
   type: String
-  verbose_name: null
+  verbose_name: Course Key
 - advanced_data_type: null
   column_name: course_run
   description: null
   expression: null
-  extra: null
+  extra: {}
   filterable: true
   groupby: true
   is_active: true
   is_dttm: false
   python_date_format: null
   type: String
-  verbose_name: null
+  verbose_name: Course Run
 - advanced_data_type: null
   column_name: org
   description: null
   expression: null
-  extra: null
+  extra: {}
   filterable: true
   groupby: true
   is_active: true
   is_dttm: false
   python_date_format: null
   type: String
-  verbose_name: null
+  verbose_name: Organization
 database_uuid: 21174b6c-4d40-4958-8161-d6c3cf5e77b6
 default_endpoint: null
 description: null
-extra: null
+extra: {}
 fetch_values_predicate: null
 filter_select_enabled: false
 main_dttm_col: null
@@ -85,7 +85,7 @@ metrics:
   d3format: null
   description: null
   expression: count(*)
-  extra: null
+  extra: {}
   metric_name: count
   metric_type: null
   verbose_name: null

--- a/tutoraspects/templates/aspects/build/aspects-superset/openedx-assets/assets/datasets/slices.yaml
+++ b/tutoraspects/templates/aspects/build/aspects-superset/openedx-assets/assets/datasets/slices.yaml
@@ -5,254 +5,254 @@ columns:
   column_name: last_saved_at
   description: null
   expression: ''
-  extra: null
+  extra: {}
   filterable: true
   groupby: true
   is_active: true
   is_dttm: true
   python_date_format: null
   type: TIMESTAMP WITHOUT TIME ZONE
-  verbose_name: null
+  verbose_name: Last Saved At
 - advanced_data_type: null
   column_name: created_on
   description: null
   expression: ''
-  extra: null
+  extra: {}
   filterable: true
   groupby: true
   is_active: true
   is_dttm: true
   python_date_format: null
   type: TIMESTAMP WITHOUT TIME ZONE
-  verbose_name: null
+  verbose_name: Created On
 - advanced_data_type: null
   column_name: changed_on
   description: null
   expression: ''
-  extra: null
+  extra: {}
   filterable: true
   groupby: true
   is_active: true
   is_dttm: true
   python_date_format: null
   type: TIMESTAMP WITHOUT TIME ZONE
-  verbose_name: null
+  verbose_name: Changed On
 - advanced_data_type: null
   column_name: schema_perm
   description: null
   expression: ''
-  extra: null
+  extra: {}
   filterable: true
   groupby: true
   is_active: true
   is_dttm: false
   python_date_format: null
   type: VARCHAR(1000)
-  verbose_name: null
+  verbose_name: Schema Perm
 - advanced_data_type: null
   column_name: datasource_name
   description: null
   expression: ''
-  extra: null
+  extra: {}
   filterable: true
   groupby: true
   is_active: true
   is_dttm: false
   python_date_format: null
   type: VARCHAR(2000)
-  verbose_name: null
+  verbose_name: Datasource Name
 - advanced_data_type: null
   column_name: perm
   description: null
   expression: ''
-  extra: null
+  extra: {}
   filterable: true
   groupby: true
   is_active: true
   is_dttm: false
   python_date_format: null
   type: VARCHAR(2000)
-  verbose_name: null
+  verbose_name: Perm
 - advanced_data_type: null
   column_name: datasource_type
   description: null
   expression: ''
-  extra: null
+  extra: {}
   filterable: true
   groupby: true
   is_active: true
   is_dttm: false
   python_date_format: null
   type: VARCHAR(200)
-  verbose_name: null
+  verbose_name: Datasource Type
 - advanced_data_type: null
   column_name: slice_name
   description: null
   expression: ''
-  extra: null
+  extra: {}
   filterable: true
   groupby: true
   is_active: true
   is_dttm: false
   python_date_format: null
   type: VARCHAR(250)
-  verbose_name: null
+  verbose_name: Slice Name
 - advanced_data_type: null
   column_name: viz_type
   description: null
   expression: ''
-  extra: null
+  extra: {}
   filterable: true
   groupby: true
   is_active: true
   is_dttm: false
   python_date_format: null
   type: VARCHAR(250)
-  verbose_name: null
+  verbose_name: Viz Type
 - advanced_data_type: null
   column_name: uuid
   description: null
   expression: ''
-  extra: null
+  extra: {}
   filterable: true
   groupby: true
   is_active: true
   is_dttm: false
   python_date_format: null
   type: UUID
-  verbose_name: null
+  verbose_name: UUID
 - advanced_data_type: null
   column_name: last_saved_by_fk
   description: null
   expression: ''
-  extra: null
+  extra: {}
   filterable: true
   groupby: true
   is_active: true
   is_dttm: false
   python_date_format: null
   type: INTEGER
-  verbose_name: null
+  verbose_name: Last Saved By Fk
 - advanced_data_type: null
   column_name: created_by_fk
   description: null
   expression: ''
-  extra: null
+  extra: {}
   filterable: true
   groupby: true
   is_active: true
   is_dttm: false
   python_date_format: null
   type: INTEGER
-  verbose_name: null
+  verbose_name: Created By Fk
 - advanced_data_type: null
   column_name: changed_by_fk
   description: null
   expression: ''
-  extra: null
+  extra: {}
   filterable: true
   groupby: true
   is_active: true
   is_dttm: false
   python_date_format: null
   type: INTEGER
-  verbose_name: null
+  verbose_name: Changed By Fk
 - advanced_data_type: null
   column_name: datasource_id
   description: null
   expression: ''
-  extra: null
+  extra: {}
   filterable: true
   groupby: true
   is_active: true
   is_dttm: false
   python_date_format: null
   type: INTEGER
-  verbose_name: null
+  verbose_name: Datasource ID
 - advanced_data_type: null
   column_name: cache_timeout
   description: null
   expression: ''
-  extra: null
+  extra: {}
   filterable: true
   groupby: true
   is_active: true
   is_dttm: false
   python_date_format: null
   type: INTEGER
-  verbose_name: null
+  verbose_name: Cache Timeout
 - advanced_data_type: null
   column_name: id
   description: null
   expression: ''
-  extra: null
+  extra: {}
   filterable: true
   groupby: true
   is_active: true
   is_dttm: false
   python_date_format: null
   type: INTEGER
-  verbose_name: null
+  verbose_name: ID
 - advanced_data_type: null
   column_name: certification_details
   description: null
   expression: ''
-  extra: null
+  extra: {}
   filterable: true
   groupby: true
   is_active: true
   is_dttm: false
   python_date_format: null
   type: TEXT
-  verbose_name: null
+  verbose_name: Certification Details
 - advanced_data_type: null
   column_name: certified_by
   description: null
   expression: ''
-  extra: null
+  extra: {}
   filterable: true
   groupby: true
   is_active: true
   is_dttm: false
   python_date_format: null
   type: TEXT
-  verbose_name: null
+  verbose_name: Certified By
 - advanced_data_type: null
   column_name: query_context
   description: null
   expression: ''
-  extra: null
+  extra: {}
   filterable: true
   groupby: true
   is_active: true
   is_dttm: false
   python_date_format: null
   type: TEXT
-  verbose_name: null
+  verbose_name: Query Context
 - advanced_data_type: null
   column_name: params
   description: null
   expression: ''
-  extra: null
+  extra: {}
   filterable: true
   groupby: true
   is_active: true
   is_dttm: false
   python_date_format: null
   type: TEXT
-  verbose_name: null
+  verbose_name: Parameters
 - advanced_data_type: null
   column_name: description
   description: null
   expression: ''
-  extra: null
+  extra: {}
   filterable: true
   groupby: true
   is_active: true
   is_dttm: false
   python_date_format: null
   type: TEXT
-  verbose_name: null
+  verbose_name: Description
 database_uuid: 06cd566f-e22a-4a79-b0e0-4c947de93ee0
 default_endpoint: null
 description: null
@@ -265,7 +265,7 @@ metrics:
   d3format: null
   description: null
   expression: COUNT(*)
-  extra: null
+  extra: {}
   metric_name: count
   metric_type: count
   verbose_name: COUNT(*)

--- a/tutoraspects/templates/aspects/build/aspects-superset/openedx-assets/assets/datasets/slowest_clickhouse_queries.yaml
+++ b/tutoraspects/templates/aspects/build/aspects-superset/openedx-assets/assets/datasets/slowest_clickhouse_queries.yaml
@@ -83,7 +83,7 @@ offset: 0
 params: null
 schema: xapi
 sql: |-
-  {% filter indent(width=2) %}{% include 'openedx-assets/queries/superset_action_log.sql' %}{% endfilter %}
+  {% filter indent(width=2) %}{% include 'openedx-assets/queries/slowest_clickhouse_queries.sql' %}{% endfilter %}
 table_name: slowest_clickhouse_queries
 template_params: null
 uuid: e8748c23-6220-413d-bd61-de8306163e10

--- a/tutoraspects/templates/aspects/build/aspects-superset/openedx-assets/assets/datasets/slowest_clickhouse_queries.yaml
+++ b/tutoraspects/templates/aspects/build/aspects-superset/openedx-assets/assets/datasets/slowest_clickhouse_queries.yaml
@@ -5,66 +5,66 @@ columns:
   column_name: memory_usage_kb
   description: null
   expression: null
-  extra: null
+  extra: {}
   filterable: true
   groupby: true
   is_active: true
   is_dttm: false
   python_date_format: null
   type: Float64
-  verbose_name: null
+  verbose_name: Memory Usage (KB)
 - advanced_data_type: null
   column_name: duration_secs
   description: null
   expression: null
-  extra: null
+  extra: {}
   filterable: true
   groupby: true
   is_active: true
   is_dttm: false
   python_date_format: null
   type: Float64
-  verbose_name: null
+  verbose_name: Duration (Seconds)
 - advanced_data_type: null
   column_name: read_rows
   description: null
   expression: null
-  extra: null
+  extra: {}
   filterable: true
   groupby: true
   is_active: true
   is_dttm: false
   python_date_format: null
   type: UInt64
-  verbose_name: null
+  verbose_name: Read Rows
 - advanced_data_type: null
   column_name: event_time
   description: null
   expression: null
-  extra: null
+  extra: {}
   filterable: true
   groupby: true
   is_active: true
   is_dttm: true
   python_date_format: null
   type: DateTime
-  verbose_name: null
+  verbose_name: Event Time
 - advanced_data_type: null
   column_name: query
   description: null
   expression: null
-  extra: null
+  extra: {}
   filterable: true
   groupby: true
   is_active: true
   is_dttm: false
   python_date_format: null
   type: String
-  verbose_name: null
+  verbose_name: Query
 database_uuid: 21174b6c-4d40-4958-8161-d6c3cf5e77b6
 default_endpoint: null
 description: null
-extra: null
+extra: {}
 fetch_values_predicate: null
 filter_select_enabled: true
 main_dttm_col: event_time
@@ -73,7 +73,7 @@ metrics:
   d3format: null
   description: null
   expression: COUNT(*)
-  extra: null
+  extra: {}
   metric_name: count
   metric_type: count
   verbose_name: COUNT(*)

--- a/tutoraspects/templates/aspects/build/aspects-superset/openedx-assets/assets/datasets/superset_action_log.yaml
+++ b/tutoraspects/templates/aspects/build/aspects-superset/openedx-assets/assets/datasets/superset_action_log.yaml
@@ -12,7 +12,7 @@ columns:
   is_dttm: true
   python_date_format: null
   type: DATETIME
-  verbose_name: null
+  verbose_name: User Registration Date
 - advanced_data_type: null
   column_name: action_date
   description: null
@@ -24,7 +24,7 @@ columns:
   is_dttm: true
   python_date_format: null
   type: DATETIME
-  verbose_name: null
+  verbose_name: Action Date
 - advanced_data_type: null
   column_name: dashboard_status
   description: null
@@ -36,7 +36,7 @@ columns:
   is_dttm: false
   python_date_format: null
   type: STRING
-  verbose_name: null
+  verbose_name: Dashboard Status
 - advanced_data_type: null
   column_name: dashboard_title
   description: null
@@ -48,7 +48,7 @@ columns:
   is_dttm: false
   python_date_format: null
   type: STRING
-  verbose_name: null
+  verbose_name: Dashboard Title
 - advanced_data_type: null
   column_name: user_name
   description: null
@@ -60,7 +60,7 @@ columns:
   is_dttm: false
   python_date_format: null
   type: STRING
-  verbose_name: null
+  verbose_name: User Name
 - advanced_data_type: null
   column_name: action
   description: null
@@ -72,7 +72,7 @@ columns:
   is_dttm: false
   python_date_format: null
   type: STRING
-  verbose_name: null
+  verbose_name: Action
 - advanced_data_type: null
   column_name: dashboard_id
   description: null
@@ -84,7 +84,7 @@ columns:
   is_dttm: false
   python_date_format: null
   type: INT
-  verbose_name: null
+  verbose_name: Dashboard ID
 - advanced_data_type: null
   column_name: action_count
   description: null
@@ -96,7 +96,7 @@ columns:
   is_dttm: false
   python_date_format: null
   type: INT
-  verbose_name: null
+  verbose_name: Action Count
 - advanced_data_type: null
   column_name: slice_id
   description: null
@@ -108,7 +108,7 @@ columns:
   is_dttm: false
   python_date_format: null
   type: INT
-  verbose_name: null
+  verbose_name: Slice ID
 - advanced_data_type: null
   column_name: user_id
   description: null
@@ -120,7 +120,7 @@ columns:
   is_dttm: false
   python_date_format: null
   type: INT
-  verbose_name: null
+  verbose_name: User ID
 - advanced_data_type: null
   column_name: datasource_id
   description: null
@@ -132,7 +132,7 @@ columns:
   is_dttm: false
   python_date_format: null
   type: null
-  verbose_name: null
+  verbose_name: Datasource ID
 - advanced_data_type: null
   column_name: datasource_name
   description: null
@@ -144,7 +144,7 @@ columns:
   is_dttm: null
   python_date_format: null
   type: null
-  verbose_name: null
+  verbose_name: Datasource Name
 - advanced_data_type: null
   column_name: datasource_type
   description: null
@@ -156,7 +156,7 @@ columns:
   is_dttm: null
   python_date_format: null
   type: null
-  verbose_name: null
+  verbose_name: Datasource Type
 - advanced_data_type: null
   column_name: slice_name
   description: null
@@ -168,11 +168,11 @@ columns:
   is_dttm: null
   python_date_format: null
   type: null
-  verbose_name: null
+  verbose_name: Slice Name
 database_uuid: 06cd566f-e22a-4a79-b0e0-4c947de93ee0
 default_endpoint: null
 description: null
-extra: null
+extra: {}
 fetch_values_predicate: null
 filter_select_enabled: false
 main_dttm_col: null

--- a/tutoraspects/templates/aspects/build/aspects-superset/openedx-assets/assets/datasets/user_pii.yaml
+++ b/tutoraspects/templates/aspects/build/aspects-superset/openedx-assets/assets/datasets/user_pii.yaml
@@ -11,7 +11,7 @@ params: null
 template_params: null
 filter_select_enabled: true
 fetch_values_predicate: null
-extra: null
+extra: {}
 normalize_columns: false
 uuid: 5f3d28a1-ebb4-4e4a-95ea-2930623d774d
 metrics:
@@ -22,11 +22,11 @@ metrics:
   description: null
   d3format: null
   currency: null
-  extra: null
+  extra: {}
   warning_text: null
 columns:
 - column_name: user_id
-  verbose_name: null
+  verbose_name: User ID
   is_dttm: false
   is_active: true
   type: INT32
@@ -36,9 +36,9 @@ columns:
   expression: null
   description: null
   python_date_format: null
-  extra: null
+  extra: {}
 - column_name: external_user_id
-  verbose_name: null
+  verbose_name: External User ID
   is_dttm: false
   is_active: true
   type: UUID
@@ -48,9 +48,9 @@ columns:
   expression: null
   description: null
   python_date_format: null
-  extra: null
+  extra: {}
 - column_name: profile_image_uploaded_at
-  verbose_name: null
+  verbose_name: Profile Image Uploaded At
   is_dttm: false
   is_active: true
   type: STRING
@@ -60,9 +60,9 @@ columns:
   expression: null
   description: null
   python_date_format: null
-  extra: null
+  extra: {}
 - column_name: year_of_birth
-  verbose_name: null
+  verbose_name: Year of Birth
   is_dttm: false
   is_active: true
   type: STRING
@@ -72,9 +72,9 @@ columns:
   expression: null
   description: null
   python_date_format: null
-  extra: null
+  extra: {}
 - column_name: level_of_education
-  verbose_name: null
+  verbose_name: Level of Education
   is_dttm: false
   is_active: true
   type: STRING
@@ -84,9 +84,9 @@ columns:
   expression: null
   description: null
   python_date_format: null
-  extra: null
+  extra: {}
 - column_name: external_id_type
-  verbose_name: null
+  verbose_name: External ID Type
   is_dttm: false
   is_active: true
   type: STRING
@@ -96,9 +96,9 @@ columns:
   expression: null
   description: null
   python_date_format: null
-  extra: null
+  extra: {}
 - column_name: mailing_address
-  verbose_name: null
+  verbose_name: Mailing Address
   is_dttm: false
   is_active: true
   type: STRING
@@ -108,9 +108,9 @@ columns:
   expression: null
   description: null
   python_date_format: null
-  extra: null
+  extra: {}
 - column_name: phone_number
-  verbose_name: null
+  verbose_name: Phone Number
   is_dttm: false
   is_active: true
   type: STRING
@@ -120,9 +120,9 @@ columns:
   expression: null
   description: null
   python_date_format: null
-  extra: null
+  extra: {}
 - column_name: language
-  verbose_name: null
+  verbose_name: Language
   is_dttm: false
   is_active: true
   type: STRING
@@ -132,9 +132,9 @@ columns:
   expression: null
   description: null
   python_date_format: null
-  extra: null
+  extra: {}
 - column_name: courseware
-  verbose_name: null
+  verbose_name: Courseware
   is_dttm: false
   is_active: true
   type: STRING
@@ -144,9 +144,9 @@ columns:
   expression: null
   description: null
   python_date_format: null
-  extra: null
+  extra: {}
 - column_name: location
-  verbose_name: null
+  verbose_name: Location
   is_dttm: false
   is_active: true
   type: STRING
@@ -156,9 +156,9 @@ columns:
   expression: null
   description: null
   python_date_format: null
-  extra: null
+  extra: {}
 - column_name: username
-  verbose_name: null
+  verbose_name: Username
   is_dttm: false
   is_active: true
   type: STRING
@@ -168,9 +168,9 @@ columns:
   expression: null
   description: null
   python_date_format: null
-  extra: null
+  extra: {}
 - column_name: name
-  verbose_name: null
+  verbose_name: Name
   is_dttm: false
   is_active: true
   type: STRING
@@ -180,9 +180,9 @@ columns:
   expression: null
   description: null
   python_date_format: null
-  extra: null
+  extra: {}
 - column_name: meta
-  verbose_name: null
+  verbose_name: Meta
   is_dttm: false
   is_active: true
   type: STRING
@@ -192,9 +192,9 @@ columns:
   expression: null
   description: null
   python_date_format: null
-  extra: null
+  extra: {}
 - column_name: state
-  verbose_name: null
+  verbose_name: State
   is_dttm: false
   is_active: true
   type: STRING
@@ -204,9 +204,9 @@ columns:
   expression: null
   description: null
   python_date_format: null
-  extra: null
+  extra: {}
 - column_name: goals
-  verbose_name: null
+  verbose_name: Goals
   is_dttm: false
   is_active: true
   type: STRING
@@ -216,9 +216,9 @@ columns:
   expression: null
   description: null
   python_date_format: null
-  extra: null
+  extra: {}
 - column_name: bio
-  verbose_name: null
+  verbose_name: Bio
   is_dttm: false
   is_active: true
   type: STRING
@@ -228,9 +228,9 @@ columns:
   expression: null
   description: null
   python_date_format: null
-  extra: null
+  extra: {}
 - column_name: city
-  verbose_name: null
+  verbose_name: City
   is_dttm: false
   is_active: true
   type: STRING
@@ -240,9 +240,9 @@ columns:
   expression: null
   description: null
   python_date_format: null
-  extra: null
+  extra: {}
 - column_name: country
-  verbose_name: null
+  verbose_name: Country
   is_dttm: false
   is_active: true
   type: STRING
@@ -252,9 +252,9 @@ columns:
   expression: null
   description: null
   python_date_format: null
-  extra: null
+  extra: {}
 - column_name: gender
-  verbose_name: null
+  verbose_name: Gender
   is_dttm: false
   is_active: true
   type: STRING
@@ -264,6 +264,6 @@ columns:
   expression: null
   description: null
   python_date_format: null
-  extra: null
+  extra: {}
 version: 1.0.0
 database_uuid: 21174b6c-4d40-4958-8161-d6c3cf5e77b6

--- a/tutoraspects/templates/aspects/build/aspects-superset/openedx-assets/assets/datasets/xapi_events_all_parsed.yaml
+++ b/tutoraspects/templates/aspects/build/aspects-superset/openedx-assets/assets/datasets/xapi_events_all_parsed.yaml
@@ -13,7 +13,7 @@ columns:
   is_dttm: false
   python_date_format: null
   type: null
-  verbose_name: verb
+  verbose_name: Verb
 - advanced_data_type: null
   column_name: video_event
   description: Set to true when the event is a video event.
@@ -26,7 +26,7 @@ columns:
   is_dttm: false
   python_date_format: null
   type: null
-  verbose_name: video_event
+  verbose_name: Video Event
 - advanced_data_type: null
   column_name: object_type
   description: 'Parsed JSON: last word in the event.object.definition.type field'
@@ -39,7 +39,7 @@ columns:
   is_dttm: false
   python_date_format: null
   type: null
-  verbose_name: object_type
+  verbose_name: Object Type
 - advanced_data_type: null
   column_name: course_key_short
   description: 'Course key without the course-v1: prefix'
@@ -52,7 +52,7 @@ columns:
   is_dttm: false
   python_date_format: null
   type: null
-  verbose_name: course_key
+  verbose_name: Course Key Short
 - advanced_data_type: null
   column_name: course_key
   description: Course key part of the course_id URL
@@ -65,7 +65,7 @@ columns:
   is_dttm: false
   python_date_format: null
   type: null
-  verbose_name: course_key
+  verbose_name: Course Key
 - advanced_data_type: null
   column_name: event_id
   description: null
@@ -77,7 +77,7 @@ columns:
   is_dttm: false
   python_date_format: null
   type: UUID
-  verbose_name: null
+  verbose_name: Event ID
 - advanced_data_type: null
   column_name: emission_time
   description: null
@@ -89,7 +89,7 @@ columns:
   is_dttm: true
   python_date_format: null
   type: DateTime
-  verbose_name: null
+  verbose_name: Emission Time
 - advanced_data_type: null
   column_name: object_id
   description: null
@@ -101,7 +101,7 @@ columns:
   is_dttm: false
   python_date_format: null
   type: String
-  verbose_name: null
+  verbose_name: Object ID
 - advanced_data_type: null
   column_name: actor_id
   description: null
@@ -113,7 +113,7 @@ columns:
   is_dttm: false
   python_date_format: null
   type: String
-  verbose_name: null
+  verbose_name: Actor ID
 - advanced_data_type: null
   column_name: verb_id
   description: null
@@ -125,7 +125,7 @@ columns:
   is_dttm: false
   python_date_format: null
   type: String
-  verbose_name: null
+  verbose_name: Verb ID
 - advanced_data_type: null
   column_name: course_id
   description: null
@@ -137,7 +137,7 @@ columns:
   is_dttm: false
   python_date_format: null
   type: String
-  verbose_name: null
+  verbose_name: Course ID
 - advanced_data_type: null
   column_name: event_str
   description: null
@@ -149,7 +149,7 @@ columns:
   is_dttm: false
   python_date_format: null
   type: String
-  verbose_name: null
+  verbose_name: Event String
 - advanced_data_type: null
   column_name: org
   description: null
@@ -161,11 +161,11 @@ columns:
   is_dttm: false
   python_date_format: null
   type: String
-  verbose_name: null
+  verbose_name: Organization
 database_uuid: 21174b6c-4d40-4958-8161-d6c3cf5e77b6
 default_endpoint: null
 description: null
-extra: null
+extra: {}
 fetch_values_predicate: null
 filter_select_enabled: false
 main_dttm_col: emission_time


### PR DESCRIPTION
### Description

This PR allows translating columns and metrics names from the datasets. It doesn't affect the queries as the value changed is only the `verbose_name`.

A new dataset is created for every supported language and associated with the corresponding chart.