### PR TITLE
Upgrades platform-plugin-aspects and enables Instructor Dashboard plugin

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -81,7 +81,7 @@ jobs:
       - name: Build Aspects Docker Images
         if: github.event.action == 'opened' || github.event.action == 'synchronize'
         run: |
-          tutor images build ${{ matrix.service.name }} --cache-to-registry
+          tutor images build ${{ matrix.service.name }}
           tutor images push ${{ matrix.service.name }}
       - name: Build Aspects Docker Images Latest
         if: github.event.pull_request.merged == true && startsWith(github.head_ref, 'bot/v')

--- a/tutoraspects/patches/openedx-common-settings
+++ b/tutoraspects/patches/openedx-common-settings
@@ -16,3 +16,13 @@ EVENT_SINK_CLICKHOUSE_PII_MODELS = {{ EVENT_SINK_PII_MODELS }}
 
 ASPECTS_INSTRUCTOR_DASHBOARD_UUID = "{{ ASPECTS_INSTRUCTOR_DASHBOARD_UUID }}"
 SUPERSET_EXTRA_FILTERS_FORMAT = {{ ASPECTS_SUPERSET_EXTRA_FILTERS_FORMAT }}
+{% if ASPECTS_ENABLE_INSTRUCTOR_DASHBOARD_PLUGIN %}
+OPEN_EDX_FILTERS_CONFIG = {
+   "org.openedx.learning.instructor.dashboard.render.started.v1": {
+     "fail_silently": False,
+     "pipeline": [
+       "platform_plugin_aspects.extensions.filters.AddSupersetTab",
+     ]
+   },
+}
+{% endif %}

--- a/tutoraspects/patches/openedx-common-settings
+++ b/tutoraspects/patches/openedx-common-settings
@@ -7,10 +7,12 @@ EVENT_SINK_CLICKHOUSE_BACKEND_CONFIG = {
 	"timeout_secs": {{ ASPECTS_EVENT_SINK_CLICKHOUSE_TIMEOUT_SECS }}
 }
 SUPERSET_CONFIG = {
-	"service_url": "http://superset:{{ SUPERSET_PORT }}/",
-	"host": "{% if ENABLE_HTTPS %}https{% else %}http{% endif %}://{{ SUPERSET_HOST }}",
+	"internal_service_url": "http://superset:{{ SUPERSET_PORT }}/",
+	"service_url": "{% if ENABLE_HTTPS %}https{% else %}http{% endif %}://{{ SUPERSET_HOST }}",
 	"username": "{{ SUPERSET_LMS_USERNAME }}",
 	"password": "{{ SUPERSET_LMS_PASSWORD }}",
-	"email": "{{ SUPERSET_LMS_EMAIL }}",
 }
 EVENT_SINK_CLICKHOUSE_PII_MODELS = {{ EVENT_SINK_PII_MODELS }}
+
+ASPECTS_INSTRUCTOR_DASHBOARD_UUID = "{{ ASPECTS_INSTRUCTOR_DASHBOARD_UUID }}"
+SUPERSET_EXTRA_FILTERS_FORMAT = {{ ASPECTS_SUPERSET_EXTRA_FILTERS_FORMAT }}

--- a/tutoraspects/patches/openedx-common-settings
+++ b/tutoraspects/patches/openedx-common-settings
@@ -17,12 +17,14 @@ EVENT_SINK_CLICKHOUSE_PII_MODELS = {{ EVENT_SINK_PII_MODELS }}
 ASPECTS_INSTRUCTOR_DASHBOARD_UUID = "{{ ASPECTS_INSTRUCTOR_DASHBOARD_UUID }}"
 SUPERSET_EXTRA_FILTERS_FORMAT = {{ ASPECTS_SUPERSET_EXTRA_FILTERS_FORMAT }}
 {% if ASPECTS_ENABLE_INSTRUCTOR_DASHBOARD_PLUGIN %}
-OPEN_EDX_FILTERS_CONFIG = {
-   "org.openedx.learning.instructor.dashboard.render.started.v1": {
-     "fail_silently": False,
-     "pipeline": [
-       "platform_plugin_aspects.extensions.filters.AddSupersetTab",
-     ]
-   },
-}
+try:
+    not OPEN_EDX_FILTERS_CONFIG
+except NameError:  # OPEN_EDX_FILTERS_CONFIG is not defined
+    OPEN_EDX_FILTERS_CONFIG = {}
+if not OPEN_EDX_FILTERS_CONFIG.get("org.openedx.learning.instructor.dashboard.render.started.v1"):
+    OPEN_EDX_FILTERS_CONFIG["org.openedx.learning.instructor.dashboard.render.started.v1"] = {
+        "fail_silently": False,
+        "pipeline": [],
+    }
+OPEN_EDX_FILTERS_CONFIG["org.openedx.learning.instructor.dashboard.render.started.v1"]["pipeline"].append("platform_plugin_aspects.extensions.filters.AddSupersetTab")
 {% endif %}

--- a/tutoraspects/patches/openedx-development-settings
+++ b/tutoraspects/patches/openedx-development-settings
@@ -1,7 +1,6 @@
 SUPERSET_CONFIG = {
-    "service_url": "http://superset:{{ SUPERSET_PORT }}/",
-	"host": "{% if ENABLE_HTTPS %}https{% else %}http{% endif %}://{{ SUPERSET_HOST }}:{{ SUPERSET_PORT }}",
-	"username": "{{ SUPERSET_LMS_USERNAME }}",
-	"password": "{{ SUPERSET_LMS_PASSWORD }}",
-	"email": "{{ SUPERSET_LMS_EMAIL }}",
+    "internal_service_url": "http://superset:{{ SUPERSET_PORT }}/",
+    "service_url": "{% if ENABLE_HTTPS %}https{% else %}http{% endif %}://{{ SUPERSET_HOST }}:{{ SUPERSET_PORT }}",
+    "username": "{{ SUPERSET_LMS_USERNAME }}",
+    "password": "{{ SUPERSET_LMS_PASSWORD }}",
 }

--- a/tutoraspects/plugin.py
+++ b/tutoraspects/plugin.py
@@ -76,7 +76,7 @@ hooks.Filters.CONFIG_DEFAULTS.add_items(
             "reference/operator_reports.html)\\n"
             "* [Superset Resources](https://github.com/apache/superset#resources)\\n",
         ),
-        ("ASPECTS_ENABLE_INSTRUCTOR_DASHBOARD_PLUGIN", False),
+        ("ASPECTS_ENABLE_INSTRUCTOR_DASHBOARD_PLUGIN", True),
         # Use the base Instructor Dashboard uuid by default. TODO use locale
         ("ASPECTS_INSTRUCTOR_DASHBOARD_UUID", "1d6bf904-f53f-47fd-b1c9-6cd7e284d286"),
         ("ASPECTS_SUPERSET_EXTRA_FILTERS_FORMAT", []),

--- a/tutoraspects/plugin.py
+++ b/tutoraspects/plugin.py
@@ -41,7 +41,7 @@ hooks.Filters.CONFIG_DEFAULTS.add_items(
         (
             "OPENEDX_EXTRA_PIP_REQUIREMENTS",
             [
-                "platform-plugin-aspects==0.2.0",
+                "git+https://github.com/openedx/platform-plugin-aspects.git@jill/migrate-xblock#egg=platform-plugin-aspects==0.3.0",
                 "edx-event-routing-backends==v8.1.1",
             ],
         ),
@@ -76,6 +76,9 @@ hooks.Filters.CONFIG_DEFAULTS.add_items(
             "reference/operator_reports.html)\\n"
             "* [Superset Resources](https://github.com/apache/superset#resources)\\n",
         ),
+        # Use the base Instructor Dashboard uuid by default. TODO use locale
+        ("ASPECTS_INSTRUCTOR_DASHBOARD_UUID", "1d6bf904-f53f-47fd-b1c9-6cd7e284d286"),
+        ("ASPECTS_SUPERSET_EXTRA_FILTERS_FORMAT", []),
         # ClickHouse xAPI settings
         ("ASPECTS_XAPI_DATABASE", "xapi"),
         ("ASPECTS_RAW_XAPI_TABLE", "xapi_events_all"),

--- a/tutoraspects/plugin.py
+++ b/tutoraspects/plugin.py
@@ -41,10 +41,7 @@ hooks.Filters.CONFIG_DEFAULTS.add_items(
         (
             "OPENEDX_EXTRA_PIP_REQUIREMENTS",
             [
-                (
-                    "git+https://github.com/openedx/platform-plugin-aspects.git@jill/migrate-xblock"
-                    "#egg=platform-plugin-aspects==0.3.0"
-                ),
+                "platform-plugin-aspects==0.3.0",
                 "edx-event-routing-backends==v8.1.1",
             ],
         ),

--- a/tutoraspects/plugin.py
+++ b/tutoraspects/plugin.py
@@ -41,7 +41,10 @@ hooks.Filters.CONFIG_DEFAULTS.add_items(
         (
             "OPENEDX_EXTRA_PIP_REQUIREMENTS",
             [
-                "git+https://github.com/openedx/platform-plugin-aspects.git@jill/migrate-xblock#egg=platform-plugin-aspects==0.3.0",
+                (
+                    "git+https://github.com/openedx/platform-plugin-aspects.git@jill/migrate-xblock"
+                    "#egg=platform-plugin-aspects==0.3.0"
+                ),
                 "edx-event-routing-backends==v8.1.1",
             ],
         ),

--- a/tutoraspects/plugin.py
+++ b/tutoraspects/plugin.py
@@ -76,6 +76,7 @@ hooks.Filters.CONFIG_DEFAULTS.add_items(
             "reference/operator_reports.html)\\n"
             "* [Superset Resources](https://github.com/apache/superset#resources)\\n",
         ),
+        ("ASPECTS_ENABLE_INSTRUCTOR_DASHBOARD_PLUGIN", False),
         # Use the base Instructor Dashboard uuid by default. TODO use locale
         ("ASPECTS_INSTRUCTOR_DASHBOARD_UUID", "1d6bf904-f53f-47fd-b1c9-6cd7e284d286"),
         ("ASPECTS_SUPERSET_EXTRA_FILTERS_FORMAT", []),


### PR DESCRIPTION
### Description

Updates the dependencies and settings related to https://github.com/openedx/platform-plugin-aspects/pull/7

### Testing instructions

0. Install this branch to your Tutor virtualenv, and ensure this plugin is enabled.
1. (optional) change the default dashboard: `tutor config save -s ASPECTS_INSTRUCTOR_DASHBOARD_UUID=a4472382-0cb4-4874-8fd9-5eb42aadbf11`
2. Rebuild the openedx image (or `openedx-dev` if running Tutor dev): `tutor images build openedx --no-cache`
3. Restart openedx to use the new image: `tutor [dev|local] stop lms cms lms-worker cms-worker && tutor [dev|local] start -d lms cms lms-worker cms-worker`
4. Create a new course in Studio
5. Add `"superset"` to the Settings > Advanced Settings > Advanced Module List
6. Add a new section, subsection, unit
7. Add a Advanced > Superset Dashboard block to the course
    Ensure that it renders in Studio.
8. Edit the XBlock to change the Dashboard UUID.  Ensure that change renders in Studio.
9. Publish changes to your course

In LMS:
1. View the Superset XBlock as a course staff/instructor -- should display dashboard.
2. View as a student -- should display error message.


Instructor Dashboard:
1. Check that the instructor dashboard plugin is <strike>disabled</strike> enabled by default by visiting the LMS Instructor Dashboard. Should be an "Aspects" tab that displays the configured ASPECTS_INSTRUCTOR_DASHBOARD_UUID.
1. Disable the instructor dashboard plugin: `tutor config save -s ASPECTS_ENABLE_INSTRUCTOR_DASHBOARD_PLUGIN=False`
1. As course staff/instructor, visit the Instructor Dashboard. Should no longer be an "Aspects" tab showing.
