### PR TITLE
build: do not build images on bot PRs

### DIFF
--- a/.github/workflows/build-image.yaml
+++ b/.github/workflows/build-image.yaml
@@ -1,0 +1,57 @@
+name: Build Image
+on:
+  pull_request:
+    types: [opened, synchronize, closed]
+
+env:
+  TUTOR_ROOT: ./.ci/
+
+jobs:
+  build:
+    strategy:
+      matrix:
+        service:
+          - name: aspects
+            repository: edunext/aspects
+          - name: aspects-superset
+            repository: edunext/aspects-superset
+          - name: openedx
+            repository: edunext/openedx-aspects
+    runs-on: ubuntu-latest
+    if: "!startsWith(github.head_ref, 'bot/') && !startsWith(github.head_ref, 'dependabot/')"
+    steps:
+      - name: Checkout
+        run:
+            echo ${{github.head_ref}}
+      - name: Log in to Docker Hub
+        uses: docker/login-action@343f7c4344506bcbf9b4de18042ae17996df046d
+        with:
+          username: ${{ secrets.EDUNEXT_DOCKER_USERNAME }}
+          password: ${{ secrets.EDUNEXT_DOCKER_PASSWORD }}
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Update ASPECTS_VERSION
+        if: github.event.action == 'opened' || github.event.action == 'synchronize'
+        run: |
+          ASPECTS_VERSION=pr-${{ github.event.pull_request.number }}
+          sed -i "s/ASPECTS_VERSION: .*/ASPECTS_VERSION: $ASPECTS_VERSION/" .ci/config.yml
+      - name: setup python
+        uses: actions/setup-python@v5
+        with:
+          python-version: 3.8
+      - name: Install aspects
+        run: pip install .
+      - name: Save config
+        run: tutor config save
+      - name: Setup Docker Buildx
+        uses: docker/setup-buildx-action@v3
+      - name: Build Aspects Docker Images
+        if: github.event.action == 'opened' || github.event.action == 'synchronize'
+        run: |
+          tutor images build ${{ matrix.service.name }}
+          tutor images push ${{ matrix.service.name }}
+      - name: Build Aspects Docker Images Latest
+        if: github.event.pull_request.merged == true && startsWith(github.head_ref, 'bot/v')
+        run: |
+          tutor images build ${{ matrix.service.name }} --cache-to-registry -d '--tag=${{ matrix.service.repository }}:latest'
+          tutor images push ${{ matrix.service.name }}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,7 +1,10 @@
 name: Release
 on:
   pull_request:
-    types: [opened, synchronize, closed]
+    types:
+      - closed
+    branches:
+      - main
 
 env:
   TUTOR_ROOT: ./.ci/
@@ -43,48 +46,3 @@ jobs:
         with:
             user: __token__
             password: ${{ secrets.PYPI_UPLOAD_TOKEN }}
-
-  build:
-    strategy:
-      matrix:
-        service:
-          - name: aspects
-            repository: edunext/aspects
-          - name: aspects-superset
-            repository: edunext/aspects-superset
-          - name: openedx
-            repository: edunext/openedx-aspects
-    runs-on: ubuntu-latest
-    steps:
-      - name: Log in to Docker Hub
-        uses: docker/login-action@343f7c4344506bcbf9b4de18042ae17996df046d
-        with:
-          username: ${{ secrets.EDUNEXT_DOCKER_USERNAME }}
-          password: ${{ secrets.EDUNEXT_DOCKER_PASSWORD }}
-      - name: Checkout
-        uses: actions/checkout@v4
-      - name: Update ASPECTS_VERSION
-        if: github.event.action == 'opened' || github.event.action == 'synchronize'
-        run: |
-          ASPECTS_VERSION=pr-${{ github.event.pull_request.number }}
-          sed -i "s/ASPECTS_VERSION: .*/ASPECTS_VERSION: $ASPECTS_VERSION/" .ci/config.yml
-      - name: setup python
-        uses: actions/setup-python@v5
-        with:
-          python-version: 3.8
-      - name: Install aspects
-        run: pip install .
-      - name: Save config
-        run: tutor config save
-      - name: Setup Docker Buildx
-        uses: docker/setup-buildx-action@v3
-      - name: Build Aspects Docker Images
-        if: github.event.action == 'opened' || github.event.action == 'synchronize'
-        run: |
-          tutor images build ${{ matrix.service.name }}
-          tutor images push ${{ matrix.service.name }}
-      - name: Build Aspects Docker Images Latest
-        if: github.event.pull_request.merged == true && startsWith(github.head_ref, 'bot/v')
-        run: |
-          tutor images build ${{ matrix.service.name }} --cache-to-registry -d '--tag=${{ matrix.service.repository }}:latest'
-          tutor images push ${{ matrix.service.name }}


### PR DESCRIPTION
### Description

This PR separates the `build` job and the `release` job. It also prevents the `build` job to run when the PR is from a bot.