### PR TITLE
refactor: moves the openedx pip requirements into a patch

### DIFF
--- a/tutoraspects/patches/openedx-dockerfile-post-python-requirements
+++ b/tutoraspects/patches/openedx-dockerfile-post-python-requirements
@@ -1,2 +1,4 @@
 RUN --mount=type=cache,target=/openedx/.cache/pip,sharing=shared \
-    pip install "platform-plugin-aspects==0.3.1" "edx-event-routing-backends==v8.1.1"
+    pip install "platform-plugin-aspects==0.3.1"
+RUN --mount=type=cache,target=/openedx/.cache/pip,sharing=shared \
+    pip install "edx-event-routing-backends==v8.1.1"

--- a/tutoraspects/patches/openedx-dockerfile-post-python-requirements
+++ b/tutoraspects/patches/openedx-dockerfile-post-python-requirements
@@ -1,0 +1,2 @@
+RUN --mount=type=cache,target=/openedx/.cache/pip,sharing=shared \
+    pip install "platform-plugin-aspects==0.3.1" "edx-event-routing-backends==v8.1.1"

--- a/tutoraspects/plugin.py
+++ b/tutoraspects/plugin.py
@@ -39,13 +39,6 @@ hooks.Filters.CONFIG_DEFAULTS.add_items(
         ("DOCKER_IMAGE_SUPERSET", "edunext/aspects-superset:{{ ASPECTS_VERSION }}"),
         ("DOCKER_IMAGE_VECTOR", "timberio/vector:0.30.0-alpine"),
         (
-            "OPENEDX_EXTRA_PIP_REQUIREMENTS",
-            [
-                "platform-plugin-aspects==0.3.1",
-                "edx-event-routing-backends==v8.1.1",
-            ],
-        ),
-        (
             "EVENT_SINK_MODELS_ENABLED",
             ["course_overviews"],
         ),


### PR DESCRIPTION
Uses a [patch to add extra python requirements to Open edX](https://github.com/overhangio/tutor/blob/f211b982fd8d970a538eb8452e16259a5eaae92b/tutor/templates/build/openedx/Dockerfile#L116-L117) instead of using the `OPENEDX_EXTRA_PIP_REQUIREMENTS` variable.

I've been running into issues with using Aspects with other Tutor plugins that also overwrite `OPENEDX_EXTRA_PIP_REQUIREMENTS `, and someone on my team suggested this patch approach.

This change allows Tutor operators to use this variable to override or add their own extra requirements without disrupting Aspects.

**Testing instructions**

Rebuild your `openedx(-dev)` image using this branch.
Note that the platform-plugin-aspects and edx-event-routing-backends packages get installed as expected.