### PR TITLE
build: push latest image on CI

### DIFF
--- a/.github/workflows/build-image.yaml
+++ b/.github/workflows/build-image.yaml
@@ -55,3 +55,4 @@ jobs:
         run: |
           tutor images build ${{ matrix.service.name }} --cache-to-registry -d '--tag=${{ matrix.service.repository }}:latest'
           tutor images push ${{ matrix.service.name }}
+          docker image push ${{ matrix.service.repository }}:latest


### PR DESCRIPTION
### Description

This PR push the latest image when needed on CI.

### Testing instructions

This has been tested in CI, by disabling checks so images are already pushed.

- Run: `docker pull edunext/aspects:latest` and the image should be downloaded