### PR TITLE
fix: install aspects-dbt package requirements before running dbt

### DIFF
--- a/tutoraspects/plugin.py
+++ b/tutoraspects/plugin.py
@@ -373,7 +373,7 @@ hooks.Filters.CONFIG_DEFAULTS.add_items(
         # For now we are pulling this from github, which should allow maximum
         # flexibility for forking, running branches, specific versions, etc.
         ("DBT_REPOSITORY", "https://github.com/openedx/aspects-dbt"),
-        ("DBT_BRANCH", "v3.9.0"),
+        ("DBT_BRANCH", "v3.9.1"),
         ("DBT_SSH_KEY", ""),
         ("DBT_STATE_DIR", "/app/aspects/dbt_state/"),
         # This is a pip compliant list of Python packages to install to run dbt

--- a/tutoraspects/templates/aspects/apps/aspects/scripts/dbt.sh
+++ b/tutoraspects/templates/aspects/apps/aspects/scripts/dbt.sh
@@ -3,10 +3,6 @@
 ## WARNING: If you modify this block, make sure to also update the
 ##          corresponding block in the init-aspects.sh file.
 
-echo "Installing dbt packages..."
-
-pip install -r /app/aspects/dbt/requirements.txt
-
 {% if DBT_SSH_KEY %}
 mkdir -p /root/.ssh
 echo "{{ DBT_SSH_KEY}}" | tr -d '\r' > /root/.ssh/id_rsa
@@ -23,6 +19,10 @@ echo "git clone -b {{ DBT_BRANCH }} {{ DBT_REPOSITORY }}"
 git clone -b {{ DBT_BRANCH }} {{ DBT_REPOSITORY }} aspects-dbt
 
 cd aspects-dbt || exit
+
+echo "Installing dbt python requirements"
+pip install -r ./requirements.txt
+pip install -r /app/aspects/dbt/requirements.txt
 
 export ASPECTS_EVENT_SINK_DATABASE={{ASPECTS_EVENT_SINK_DATABASE}}
 export ASPECTS_XAPI_DATABASE={{ASPECTS_XAPI_DATABASE}}


### PR DESCRIPTION
and bump aspects-dbt branch to [v3.9.1](https://github.com/openedx/aspects-dbt/releases/tag/v3.9.1) to fix dbt-core dependency issue (https://github.com/dbt-labs/dbt-core/issues/9759).

## Testing instructions

```
tutor dev|local config save
tutor dev|local do dbt -c "run"
```