### PR TITLE
feat: add dataset and chart for video engagement dropoff (FC-0051)

### DIFF
--- a/tutoraspects/plugin.py
+++ b/tutoraspects/plugin.py
@@ -379,7 +379,7 @@ hooks.Filters.CONFIG_DEFAULTS.add_items(
         # For now we are pulling this from github, which should allow maximum
         # flexibility for forking, running branches, specific versions, etc.
         ("DBT_REPOSITORY", "https://github.com/openedx/aspects-dbt"),
-        ("DBT_BRANCH", "v3.9.2"),
+        ("DBT_BRANCH", "v3.11.0"),
         ("DBT_SSH_KEY", ""),
         ("DBT_STATE_DIR", "/app/aspects/dbt_state/"),
         # This is a pip compliant list of Python packages to install to run dbt

--- a/tutoraspects/templates/aspects/build/aspects-superset/openedx-assets/assets/charts/Video_engagement_by_section_subsection.yaml
+++ b/tutoraspects/templates/aspects/build/aspects-superset/openedx-assets/assets/charts/Video_engagement_by_section_subsection.yaml
@@ -33,7 +33,7 @@ params:
     label: At least one video viewed
     optionName: metric_uly1n6wzzl_t4av1e6urzi
     sqlExpression: |-
-      countIf("section/subsection video engagement" = 'All pages viewed' or "section/subsection video engagement" = 'At least one video viewed')
+      countIf("section/subsection video engagement" = 'All videos viewed' or "section/subsection video engagement" = 'At least one video viewed')
   only_total: true
   order_desc: true
   orientation: vertical

--- a/tutoraspects/templates/aspects/build/aspects-superset/openedx-assets/assets/charts/Video_engagement_by_section_subsection.yaml
+++ b/tutoraspects/templates/aspects/build/aspects-superset/openedx-assets/assets/charts/Video_engagement_by_section_subsection.yaml
@@ -1,0 +1,68 @@
+_file_name: Video_engagement_by_section_subsection.yaml
+cache_timeout: null
+certification_details: null
+certified_by: null
+dataset_uuid: 247a55b3-d44e-442e-ba92-71bf7976b192
+description: null
+params:
+  adhoc_filters: []
+  annotation_layers: []
+  color_scheme: supersetColors
+  comparison_type: values
+  extra_form_data: {}
+  forecastInterval: 0.8
+  forecastPeriods: 10
+  groupby: []
+  legendOrientation: top
+  legendType: scroll
+  metrics:
+  - aggregate: null
+    column: null
+    datasourceWarning: false
+    expressionType: SQL
+    hasCustomLabel: true
+    label: All videos viewed
+    optionName: metric_ybd2rhz43lp_s2rxtvynidt
+    sqlExpression: |-
+      countIf("section/subsection video engagement" = 'All videos viewed')
+  - aggregate: null
+    column: null
+    datasourceWarning: false
+    expressionType: SQL
+    hasCustomLabel: true
+    label: At least one video viewed
+    optionName: metric_uly1n6wzzl_t4av1e6urzi
+    sqlExpression: |-
+      countIf("section/subsection video engagement" = 'All pages viewed' or "section/subsection video engagement" = 'At least one video viewed')
+  only_total: true
+  order_desc: true
+  orientation: vertical
+  rich_tooltip: true
+  row_limit: 10000
+  show_empty_columns: true
+  show_legend: true
+  sort_series_type: sum
+  time_grain_sqla: P1D
+  tooltipTimeFormat: smart_date
+  truncate_metric: true
+  viz_type: echarts_timeseries_bar
+  xAxisLabelRotation: 45
+  x_axis: section/subsection name
+  x_axis_sort_asc: true
+  x_axis_sort_series: name
+  x_axis_sort_series_ascending: true
+  x_axis_time_format: smart_date
+  x_axis_title_margin: 15
+  y_axis_bounds:
+  - null
+  - null
+  y_axis_format: SMART_NUMBER
+  y_axis_title: Number of Learners
+  y_axis_title_margin: 30
+  y_axis_title_position: Left
+query_context: |-
+  {"datasource":{"id":226,"type":"table"},"force":false,"queries":[{"filters":[],"extras":{"having":"","where":""},"applied_time_extras":{},"columns":[{"timeGrain":"P1D","columnType":"BASE_AXIS","sqlExpression":"section/subsection name","label":"section/subsection name","expressionType":"SQL"}],"metrics":[{"expressionType":"SQL","sqlExpression":"countIf(\"section/subsection video engagement\" = 'All videos viewed')","column":null,"aggregate":null,"datasourceWarning":false,"hasCustomLabel":true,"label":"All videos viewed","optionName":"metric_ybd2rhz43lp_s2rxtvynidt"},{"expressionType":"SQL","sqlExpression":"countIf(\"section/subsection video engagement\" = 'All pages viewed' or \"section/subsection video engagement\" = 'At least one video viewed')","column":null,"aggregate":null,"datasourceWarning":false,"hasCustomLabel":true,"label":"At least one video viewed","optionName":"metric_uly1n6wzzl_t4av1e6urzi"}],"orderby":[[{"expressionType":"SQL","sqlExpression":"countIf(\"section/subsection video engagement\" = 'All videos viewed')","column":null,"aggregate":null,"datasourceWarning":false,"hasCustomLabel":true,"label":"All videos viewed","optionName":"metric_ybd2rhz43lp_s2rxtvynidt"},false]],"annotation_layers":[],"row_limit":10000,"series_columns":[],"series_limit":0,"order_desc":true,"url_params":{},"custom_params":{},"custom_form_data":{},"time_offsets":[],"post_processing":[{"operation":"pivot","options":{"index":["section/subsection name"],"columns":[],"aggregates":{"All videos viewed":{"operator":"mean"},"At least one video viewed":{"operator":"mean"}},"drop_missing_columns":false}},{"operation":"flatten"}]}],"form_data":{"datasource":"553__table","viz_type":"echarts_timeseries_bar","x_axis":"section/subsection name","time_grain_sqla":"P1D","x_axis_sort_asc":true,"x_axis_sort_series":"name","x_axis_sort_series_ascending":true,"metrics":[{"expressionType":"SQL","sqlExpression":"countIf(\"section/subsection video engagement\" = 'All videos viewed')","column":null,"aggregate":null,"datasourceWarning":false,"hasCustomLabel":true,"label":"All videos viewed","optionName":"metric_ybd2rhz43lp_s2rxtvynidt"},{"expressionType":"SQL","sqlExpression":"countIf(\"section/subsection video engagement\" = 'All pages viewed' or \"section/subsection video engagement\" = 'At least one video viewed')","column":null,"aggregate":null,"datasourceWarning":false,"hasCustomLabel":true,"label":"At least one video viewed","optionName":"metric_uly1n6wzzl_t4av1e6urzi"}],"groupby":[],"adhoc_filters":[],"order_desc":true,"row_limit":10000,"truncate_metric":true,"show_empty_columns":true,"comparison_type":"values","annotation_layers":[],"forecastPeriods":10,"forecastInterval":0.8,"orientation":"vertical","x_axis_title_margin":15,"y_axis_title":"Number of Learners","y_axis_title_margin":30,"y_axis_title_position":"Left","sort_series_type":"sum","color_scheme":"supersetColors","only_total":true,"show_legend":true,"legendType":"scroll","legendOrientation":"top","x_axis_time_format":"smart_date","xAxisLabelRotation":45,"y_axis_format":"SMART_NUMBER","y_axis_bounds":[null,null],"rich_tooltip":true,"tooltipTimeFormat":"smart_date","extra_form_data":{},"dashboards":[817],"force":false,"result_format":"json","result_type":"full"},"result_format":"json","result_type":"full"}
+slice_name: Video engagement by section/subsection
+uuid: 21861f47-9e8b-4715-b1ff-e7f4aa595c14
+version: 1.0.0
+viz_type: echarts_timeseries_bar

--- a/tutoraspects/templates/aspects/build/aspects-superset/openedx-assets/assets/dashboards/Instructor_Dashboard.yaml
+++ b/tutoraspects/templates/aspects/build/aspects-superset/openedx-assets/assets/dashboards/Instructor_Dashboard.yaml
@@ -6,63 +6,86 @@ dashboard_title: Instructor Dashboard
 description: null
 metadata:
   chart_configuration:
-    '1804':
+    '114':
       crossFilters:
         chartsInScope:
-        - 24
-        - 25
-        - 32
-        - 34
-        - 37
-        - 45
-        - 46
-        - 47
-        - 52
-        - 865
-        - 879
-        - 894
-        - 908
-        - 922
+        - 154
+        - 156
+        - 229
+        - 325
+        - 327
+        - 339
+        - 516
+        - 597
+        - 625
+        - 682
+        - 695
+        - 701
+        - 770
+        - 783
+        - 816
         scope: global
-      id: 1804
-    '32':
+      id: 114
+    '156':
       crossFilters:
         chartsInScope:
-        - 24
-        - 25
-        - 34
-        - 37
-        - 45
-        - 46
-        - 47
-        - 52
-        - 865
-        - 879
-        - 894
-        - 908
-        - 922
-        - 1804
+        - 114
+        - 154
+        - 229
+        - 325
+        - 327
+        - 339
+        - 516
+        - 597
+        - 625
+        - 682
+        - 695
+        - 701
+        - 770
+        - 783
+        - 816
         scope: global
-      id: 32
-    '34':
+      id: 156
+    '325':
       crossFilters:
         chartsInScope:
-        - 24
-        - 25
-        - 32
-        - 37
-        - 45
-        - 46
-        - 47
-        - 52
-        - 865
-        - 879
-        - 894
-        - 908
-        - 922
-        - 1804
+        - 114
+        - 154
+        - 156
+        - 229
+        - 327
+        - 339
+        - 516
+        - 597
+        - 625
+        - 682
+        - 695
+        - 701
+        - 770
+        - 783
+        - 816
         scope: global
-      id: 34
+      id: 325
+    '816':
+      crossFilters:
+        chartsInScope:
+        - 114
+        - 154
+        - 156
+        - 229
+        - 325
+        - 327
+        - 339
+        - 516
+        - 597
+        - 625
+        - 682
+        - 695
+        - 701
+        - 770
+        - 783
+        scope: global
+      id: 816
   color_scheme: ''
   color_scheme_domain: []
   cross_filters_enabled: false
@@ -70,21 +93,22 @@ metadata:
   expanded_slices: {}
   global_chart_configuration:
     chartsInScope:
-    - 24
-    - 25
-    - 32
-    - 34
-    - 37
-    - 45
-    - 46
-    - 47
-    - 52
-    - 865
-    - 879
-    - 894
-    - 908
-    - 922
-    - 1804
+    - 114
+    - 154
+    - 156
+    - 229
+    - 325
+    - 327
+    - 339
+    - 516
+    - 597
+    - 625
+    - 682
+    - 695
+    - 701
+    - 770
+    - 783
+    - 816
     scope:
       excluded: []
       rootPath:
@@ -329,16 +353,14 @@ metadata:
       datasetUuid: 417b2035-8fa1-4c60-a405-4b1947c3c966
     type: NATIVE_FILTER
   refresh_frequency: 0
-  shared_label_colors:
-    All pages viewed: '#5AC189'
-    At least one page viewed: '#1FA8C9'
+  shared_label_colors: {}
   timed_refresh_immune_slices: []
 position:
   CHART-AZZnl_lpMv:
     children: []
     id: CHART-AZZnl_lpMv
     meta:
-      chartId: 25
+      chartId: 229
       height: 50
       sliceName: Watches Per Video
       uuid: 829c1d5b-2844-4115-876a-34ad3b3cad64
@@ -353,7 +375,7 @@ position:
     children: []
     id: CHART-GFCO8s2cxv
     meta:
-      chartId: 45
+      chartId: 625
       height: 50
       sliceName: Distribution Of Responses
       uuid: f1651c44-a8f4-4b44-ad49-962823009319
@@ -368,7 +390,7 @@ position:
     children: []
     id: CHART-GJJ8VYQ03v
     meta:
-      chartId: 922
+      chartId: 783
       height: 50
       sliceName: Posts per user
       uuid: bc191ce7-f39d-48db-86a9-d19949f4211d
@@ -383,7 +405,7 @@ position:
     children: []
     id: CHART-Jr-gNVms2Q
     meta:
-      chartId: 34
+      chartId: 114
       height: 50
       sliceName: Enrollment Events Per Day
       uuid: bb1147cc-b7bc-44b7-b06a-79b0db6626aa
@@ -398,7 +420,7 @@ position:
     children: []
     id: CHART-OMy4wjRBWt
     meta:
-      chartId: 52
+      chartId: 682
       height: 50
       sliceName: Watched Video Segments
       uuid: 2985a9db-c338-4008-af52-2930b81ee2e5
@@ -413,7 +435,7 @@ position:
     children: []
     id: CHART-RTO33WE9FH
     meta:
-      chartId: 894
+      chartId: 597
       height: 50
       sliceName: Responses Per Problem
       uuid: a3e79162-4ace-4349-ab34-89aa60ae75ed
@@ -428,7 +450,7 @@ position:
     children: []
     id: CHART-Tej2oLPBAl
     meta:
-      chartId: 24
+      chartId: 701
       height: 50
       sliceName: Transcripts / Captions Per Video
       uuid: 6b830def-f3ca-4b4c-9455-7a7b7354bce8
@@ -443,7 +465,7 @@ position:
     children: []
     id: CHART-evjVO-ZSSd
     meta:
-      chartId: 32
+      chartId: 156
       height: 50
       sliceName: Enrollments By Enrollment Mode
       uuid: 05ed7102-5464-4e2f-86ae-31700b787cc3
@@ -458,7 +480,7 @@ position:
     children: []
     id: CHART-j3trfNh8_p
     meta:
-      chartId: 1804
+      chartId: 325
       height: 50
       sliceName: Pageview engagement by section/subsection
       uuid: 366a8193-30c3-4aaf-a1ac-360609dfa0ed
@@ -469,11 +491,26 @@ position:
     - TAB-4Z1kfBQZO
     - ROW-Lt0M87yMb3
     type: CHART
+  CHART-jfm-20qPKn:
+    children: []
+    id: CHART-jfm-20qPKn
+    meta:
+      chartId: 816
+      height: 50
+      sliceName: Video engagement by section/subsection
+      uuid: 21861f47-9e8b-4715-b1ff-e7f4aa595c14
+      width: 12
+    parents:
+    - ROOT_ID
+    - TABS-SNeKAJcjhd
+    - TAB-7PGDduCA7
+    - ROW-HPGIhOIs65
+    type: CHART
   CHART-lTr8DL3XuI:
     children: []
     id: CHART-lTr8DL3XuI
     meta:
-      chartId: 46
+      chartId: 695
       height: 50
       sliceName: Distribution Of Hints Per Correct Answer
       uuid: ee94be4c-6fdd-4295-b43c-40890d6c549d
@@ -488,7 +525,7 @@ position:
     children: []
     id: CHART-o56v9yEe2I
     meta:
-      chartId: 865
+      chartId: 770
       height: 50
       sliceName: Distribution Of Problem Grades
       uuid: 4f7e3606-f5de-4643-97c0-bbb6340a3df2
@@ -503,7 +540,7 @@ position:
     children: []
     id: CHART-qG1WaGKl_b
     meta:
-      chartId: 908
+      chartId: 154
       height: 50
       sliceName: Distinct forum users
       uuid: feb323ad-c819-49ca-a336-584bd9ff1a2e
@@ -518,7 +555,7 @@ position:
     children: []
     id: CHART-rnb6PSwCOS
     meta:
-      chartId: 37
+      chartId: 339
       height: 50
       sliceName: Currently Enrolled Learners Per Day
       uuid: ed2fe731-6544-422f-bc55-42f399f48b2c
@@ -533,7 +570,7 @@ position:
     children: []
     id: CHART-tWnaoVNNTH
     meta:
-      chartId: 47
+      chartId: 327
       height: 50
       sliceName: Distribution Of Attempts
       uuid: db90930f-f16e-4c32-8050-0e4abae28f4c
@@ -548,7 +585,7 @@ position:
     children: []
     id: CHART-w-k4N2T_L8
     meta:
-      chartId: 879
+      chartId: 516
       height: 50
       sliceName: Course Grade Distribution
       uuid: f9adbc85-1f50-4c04-ace3-31ba7390de5e
@@ -743,6 +780,17 @@ position:
     - TABS-SNeKAJcjhd
     - TAB-pOd4znTAV
     type: ROW
+  ROW-HPGIhOIs65:
+    children:
+    - CHART-jfm-20qPKn
+    id: ROW-HPGIhOIs65
+    meta:
+      background: BACKGROUND_TRANSPARENT
+    parents:
+    - ROOT_ID
+    - TABS-SNeKAJcjhd
+    - TAB-7PGDduCA7
+    type: ROW
   ROW-K8s_8uq9IP:
     children:
     - CHART-rnb6PSwCOS
@@ -861,6 +909,7 @@ position:
     children:
     - ROW-nNEywSG0jX
     - ROW-BO2IHCiYF8
+    - ROW-HPGIhOIs65
     id: TAB-7PGDduCA7
     meta:
       defaultText: Tab title

--- a/tutoraspects/templates/aspects/build/aspects-superset/openedx-assets/assets/datasets/fact_video_engagement.yaml
+++ b/tutoraspects/templates/aspects/build/aspects-superset/openedx-assets/assets/datasets/fact_video_engagement.yaml
@@ -1,4 +1,4 @@
-_file_name: fact_pageview_engagement.yaml
+_file_name: fact_video_engagement.yaml
 cache_timeout: null
 columns:
 - advanced_data_type: null
@@ -107,8 +107,8 @@ offset: 0
 params: null
 schema: main
 sql: |-
-  {% filter indent(width=2) %}{% include 'openedx-assets/queries/fact_pageview_engagement.sql' %}{% endfilter %}
-table_name: fact_pageview_engagement
+  {% filter indent(width=2) %}{% include 'openedx-assets/queries/fact_video_engagement.sql' %}{% endfilter %}
+table_name: fact_video_engagement
 template_params: {}
-uuid: 9febd6be-5102-4dbf-86b9-45ebd3cbbc45
+uuid: 247a55b3-d44e-442e-ba92-71bf7976b192
 version: 1.0.0

--- a/tutoraspects/templates/openedx-assets/queries/fact_video_engagement.sql
+++ b/tutoraspects/templates/openedx-assets/queries/fact_video_engagement.sql
@@ -1,0 +1,73 @@
+with
+    subsection_counts as (
+        select
+            org,
+            course_key,
+            section_with_name,
+            subsection_with_name,
+            actor_id,
+            item_count,
+            countdistinct(video_id) as videos_viewed,
+            case
+                when videos_viewed = 0
+                then 'No videos viewed yet'
+                when videos_viewed = item_count
+                then 'All videos viewed'
+                else 'At least one video viewed'
+            end as engagement_level
+        from {{ DBT_PROFILE_TARGET_DATABASE }}.fact_video_engagement
+        where
+            1 = 1
+            {% raw %}
+            {% if from_dttm is not none %}
+                and viewed_on > date('{{ from_dttm }}')
+            {% endif %}
+            {% if to_dttm is not none %}
+                and viewed_on < date('{{ to_dttm }}')
+            {% endif %}
+            {% endraw %}
+            {% include 'openedx-assets/queries/common_filters.sql' %}
+        group by
+            org,
+            course_key,
+            section_with_name,
+            subsection_with_name,
+            actor_id,
+            item_count
+    ),
+    section_counts as (
+        select
+            org,
+            course_key,
+            section_with_name,
+            actor_id,
+            sum(item_count) as item_count,
+            sum(videos_viewed) as videos_viewed,
+            case
+                when videos_viewed = 0
+                then 'No videos viewed yet'
+                when videos_viewed = item_count
+                then 'All videos viewed'
+                else 'At least one video viewed'
+            end as engagement_level
+        from subsection_counts
+        group by org, course_key, section_with_name, actor_id
+    )
+
+select
+    org,
+    course_key,
+    subsection_with_name as `section/subsection name`,
+    'subsection' as `content level`,
+    actor_id as actor_id,
+    engagement_level as `section/subsection video engagement`
+from subsection_counts
+union all
+select
+    org,
+    course_key,
+    section_with_name as `section/subsection name`,
+    'section' as `content level`,
+    actor_id as actor_id,
+    engagement_level as `section/subsection video engagement`
+from section_counts

--- a/tutoraspects/templates/openedx-assets/queries/fact_video_engagement.sql
+++ b/tutoraspects/templates/openedx-assets/queries/fact_video_engagement.sql
@@ -7,7 +7,7 @@ with
             subsection_with_name,
             actor_id,
             item_count,
-            countdistinct(video_id) as videos_viewed,
+            countDistinct(video_id) as videos_viewed,
             case
                 when videos_viewed = 0
                 then 'No videos viewed yet'


### PR DESCRIPTION
This adds a dataset and chart for video engagement dropoff, modeled after the dataset and chart added in #673. This relies on the models in an [accompanying PR to aspects-dbt](https://github.com/openedx/aspects-dbt/pull/61).