### PR TITLE
feat: migrate to superset v4.0.0

### DIFF
--- a/tutoraspects/plugin.py
+++ b/tutoraspects/plugin.py
@@ -372,6 +372,10 @@ hooks.Filters.CONFIG_DEFAULTS.add_items(
         # By default it is on if Caddy is enabled, but it can be set separately in
         # case you are running a different proxy or otherwise have different needs.
         ("SUPERSET_ENABLE_PROXY_FIX", "{{ENABLE_WEB_PROXY}}"),
+        # This setting allows operators to automatically refresh the datasets
+        # in the Superset database. This is useful for keeping the columns up to
+        # date with the latest changes in DBT.
+        ("SUPERSET_REFRESH_DATASETS", False),
         ######################
         # dbt Settings
         # For the most part you shouldn't have to touch these

--- a/tutoraspects/templates/aspects/apps/superset/pythonpath/create_assets.py
+++ b/tutoraspects/templates/aspects/apps/superset/pythonpath/create_assets.py
@@ -286,7 +286,6 @@ def update_embeddable_uuids():
 def update_datasets():
     """Update the datasets"""
     print("Refreshing datasets")
-    g.user = security_manager.find_user(username="{{SUPERSET_ADMIN_USERNAME}}")
     datasets = (
         db.session.query(SqlaTable).all()
     )

--- a/tutoraspects/templates/aspects/apps/superset/pythonpath/create_assets.py
+++ b/tutoraspects/templates/aspects/apps/superset/pythonpath/create_assets.py
@@ -263,7 +263,6 @@ def update_dashboard_roles(roles):
         dashboard = db.session.query(Dashboard).filter_by(uuid=dashboard_uuid).one()
         print("Importing dashboard roles", dashboard_uuid, role_ids)
         dashboard.roles = role_ids
-        dashboard.published = True
         if owners:
             dashboard.owners = owners
         db.session.commit()

--- a/tutoraspects/templates/aspects/apps/superset/pythonpath/create_assets.py
+++ b/tutoraspects/templates/aspects/apps/superset/pythonpath/create_assets.py
@@ -19,7 +19,6 @@ from superset.connectors.sqla.models import SqlaTable
 from superset.utils.database import get_or_create_db
 from superset.models.embedded_dashboard import EmbeddedDashboard
 from pythonpath.localization import get_translation
-from superset.connectors.sqla.utils import get_columns_description
 
 BASE_DIR = "/app/assets/superset"
 
@@ -295,18 +294,6 @@ def update_datasets():
         print(f"Refreshing dataset {dataset.table_name}")
         dataset.fetch_metadata(commit=True)
 
-
-def dataset_is_empty(dataset):
-    """Check if a dataset is empty"""
-    sql = dataset.get_template_processor().process_template(
-        dataset.sql, **dataset.template_params_dict
-    )
-    try:
-        columns = get_columns_description(dataset.database, dataset.schema, sql)
-    except Exception as e:
-        print(f"Failed to get columns for dataset {dataset.table_name}: {e}")
-        return True
-    return columns == []
 
 if __name__ == "__main__":
     main()

--- a/tutoraspects/templates/aspects/apps/superset/pythonpath/create_assets.py
+++ b/tutoraspects/templates/aspects/apps/superset/pythonpath/create_assets.py
@@ -286,12 +286,13 @@ def update_embeddable_uuids():
 def update_datasets():
     """Update the datasets"""
     print("Refreshing datasets")
-    datasets = (
-        db.session.query(SqlaTable).all()
-    )
-    for dataset in datasets:
-        print(f"Refreshing dataset {dataset.table_name}")
-        dataset.fetch_metadata(commit=True)
+    if {{SUPERSET_REFRESH_DATASETS}}:
+        datasets = (
+            db.session.query(SqlaTable).all()
+        )
+        for dataset in datasets:
+            print(f"Refreshing dataset {dataset.table_name}")
+            dataset.fetch_metadata(commit=True)
 
 
 if __name__ == "__main__":

--- a/tutoraspects/templates/aspects/apps/superset/pythonpath/create_assets.py
+++ b/tutoraspects/templates/aspects/apps/superset/pythonpath/create_assets.py
@@ -12,7 +12,6 @@ from copy import deepcopy
 from pathlib import Path
 
 from superset import security_manager
-from superset.commands.dataset.refresh import RefreshDatasetCommand
 from superset.examples.utils import load_configs_from_directory
 from superset.extensions import db
 from superset.models.dashboard import Dashboard
@@ -20,7 +19,6 @@ from superset.connectors.sqla.models import SqlaTable
 from superset.utils.database import get_or_create_db
 from superset.models.embedded_dashboard import EmbeddedDashboard
 from pythonpath.localization import get_translation
-from flask import g
 from superset.connectors.sqla.utils import get_columns_description
 
 BASE_DIR = "/app/assets/superset"
@@ -294,14 +292,8 @@ def update_datasets():
         db.session.query(SqlaTable).all()
     )
     for dataset in datasets:
-        try:
-            if dataset_is_empty(dataset):
-                print(f"Dataset {dataset.table_name} is empty")
-                continue
-            RefreshDatasetCommand(dataset.id).run()
-            print(f"Refreshing dataset {dataset.table_name}")
-        except Exception as e:
-            print(f"Failed to refresh dataset {dataset.table_name}")
+        print(f"Refreshing dataset {dataset.table_name}")
+        dataset.fetch_metadata(commit=True)
 
 
 def dataset_is_empty(dataset):

--- a/tutoraspects/templates/aspects/apps/superset/pythonpath/performance_metrics.py
+++ b/tutoraspects/templates/aspects/apps/superset/pythonpath/performance_metrics.py
@@ -14,7 +14,7 @@ from unittest.mock import patch
 import sqlparse
 from flask import g
 from superset import security_manager
-from superset.charts.data.commands.get_data_command import ChartDataCommand
+from superset.commands.chart.data.get_data_command import ChartDataCommand
 from superset.charts.schemas import ChartDataQueryContextSchema
 from superset.extensions import db
 from superset.models.dashboard import Dashboard

--- a/tutoraspects/templates/aspects/apps/superset/pythonpath/superset_config_docker.py
+++ b/tutoraspects/templates/aspects/apps/superset/pythonpath/superset_config_docker.py
@@ -91,6 +91,7 @@ FEATURE_FLAGS = {
     "EMBEDDABLE_CHARTS": True,
     "EMBEDDED_SUPERSET": True,
     "ENABLE_TEMPLATE_PROCESSING": True,
+    "TAGGING_SYSTEM": True,
 }
 
 # Add this custom template processor which returns the list of courses the current user can access

--- a/tutoraspects/templates/aspects/build/aspects-superset/Dockerfile
+++ b/tutoraspects/templates/aspects/build/aspects-superset/Dockerfile
@@ -3,7 +3,7 @@
 # https://github.com/apache/superset/releases
 # https://github.com/apache/superset/blob/master/Dockerfile
 # https://superset.apache.org/docs/databases/installing-database-drivers
-FROM apache/superset:3.0.1
+FROM apache/superset:3.1.2
 
 USER root
 

--- a/tutoraspects/templates/aspects/build/aspects-superset/Dockerfile
+++ b/tutoraspects/templates/aspects/build/aspects-superset/Dockerfile
@@ -3,7 +3,7 @@
 # https://github.com/apache/superset/releases
 # https://github.com/apache/superset/blob/master/Dockerfile
 # https://superset.apache.org/docs/databases/installing-database-drivers
-FROM apache/superset:3.1.2
+FROM apache/superset:4.0.0
 
 USER root
 

--- a/tutoraspects/templates/aspects/build/aspects-superset/openedx-assets/assets/charts/Course_Grade_Distribution.yaml
+++ b/tutoraspects/templates/aspects/build/aspects-superset/openedx-assets/assets/charts/Course_Grade_Distribution.yaml
@@ -12,6 +12,7 @@ params:
     expressionType: SIMPLE
     operator: TEMPORAL_RANGE
     subject: emission_time
+  annotation_layers: []
   bottom_margin: auto
   color_scheme: supersetColors
   columns: []

--- a/tutoraspects/templates/aspects/build/aspects-superset/openedx-assets/assets/charts/Currently_Enrolled_Learners_Per_Day.yaml
+++ b/tutoraspects/templates/aspects/build/aspects-superset/openedx-assets/assets/charts/Currently_Enrolled_Learners_Per_Day.yaml
@@ -24,6 +24,7 @@ params:
     expressionType: SIMPLE
     operator: TEMPORAL_RANGE
     subject: enrollment_status_date
+  annotation_layers: []
   color_picker:
     a: 1
     b: 135

--- a/tutoraspects/templates/aspects/build/aspects-superset/openedx-assets/assets/charts/Distinct_forum_users.yaml
+++ b/tutoraspects/templates/aspects/build/aspects-superset/openedx-assets/assets/charts/Distinct_forum_users.yaml
@@ -11,6 +11,7 @@ params:
     expressionType: SIMPLE
     operator: TEMPORAL_RANGE
     subject: emission_time
+  annotation_layers: []
   extra_form_data: {}
   header_font_size: 0.4
   metric:

--- a/tutoraspects/templates/aspects/build/aspects-superset/openedx-assets/assets/charts/Distribution_Of_Attempts.yaml
+++ b/tutoraspects/templates/aspects/build/aspects-superset/openedx-assets/assets/charts/Distribution_Of_Attempts.yaml
@@ -17,6 +17,7 @@ params:
     operatorId: EQUALS
     sqlExpression: null
     subject: success
+  annotation_layers: []
   bottom_margin: auto
   color_scheme: supersetColors
   columns: []

--- a/tutoraspects/templates/aspects/build/aspects-superset/openedx-assets/assets/charts/Distribution_Of_Hints_Per_Correct_Answer.yaml
+++ b/tutoraspects/templates/aspects/build/aspects-superset/openedx-assets/assets/charts/Distribution_Of_Hints_Per_Correct_Answer.yaml
@@ -9,6 +9,7 @@ description: This chart displays counts of the number of times hints (including 
   group everyone into "0".
 params:
   adhoc_filters: []
+  annotation_layers: []
   bottom_margin: auto
   color_scheme: supersetColors
   columns: []

--- a/tutoraspects/templates/aspects/build/aspects-superset/openedx-assets/assets/charts/Distribution_Of_Problem_Grades.yaml
+++ b/tutoraspects/templates/aspects/build/aspects-superset/openedx-assets/assets/charts/Distribution_Of_Problem_Grades.yaml
@@ -13,6 +13,7 @@ params:
     expressionType: SIMPLE
     operator: TEMPORAL_RANGE
     subject: emission_time
+  annotation_layers: []
   bottom_margin: auto
   color_scheme: supersetColors
   columns: []

--- a/tutoraspects/templates/aspects/build/aspects-superset/openedx-assets/assets/charts/Distribution_Of_Responses.yaml
+++ b/tutoraspects/templates/aspects/build/aspects-superset/openedx-assets/assets/charts/Distribution_Of_Responses.yaml
@@ -13,6 +13,7 @@ params:
     expressionType: SIMPLE
     operator: TEMPORAL_RANGE
     subject: emission_time
+  annotation_layers: []
   bottom_margin: auto
   color_scheme: supersetColors
   columns: []

--- a/tutoraspects/templates/aspects/build/aspects-superset/openedx-assets/assets/charts/Enrollments_By_Enrollment_Mode.yaml
+++ b/tutoraspects/templates/aspects/build/aspects-superset/openedx-assets/assets/charts/Enrollments_By_Enrollment_Mode.yaml
@@ -23,6 +23,7 @@ params:
     expressionType: SIMPLE
     operator: TEMPORAL_RANGE
     subject: emission_time
+  annotation_layers: []
   color_scheme: supersetColors
   date_format: smart_date
   extra_form_data: {}

--- a/tutoraspects/templates/aspects/build/aspects-superset/openedx-assets/assets/charts/Posts_per_user.yaml
+++ b/tutoraspects/templates/aspects/build/aspects-superset/openedx-assets/assets/charts/Posts_per_user.yaml
@@ -6,6 +6,7 @@ dataset_uuid: a2823d2e-54c4-4378-98c2-817f000c14ab
 description: null
 params:
   adhoc_filters: []
+  annotation_layers: []
   bottom_margin: auto
   color_scheme: supersetColors
   columns: []

--- a/tutoraspects/templates/aspects/build/aspects-superset/openedx-assets/assets/charts/Responses_Per_Problem.yaml
+++ b/tutoraspects/templates/aspects/build/aspects-superset/openedx-assets/assets/charts/Responses_Per_Problem.yaml
@@ -8,6 +8,7 @@ description: The number of students who have responded to a question, and whethe
   but this chart counts each student only once per question.
 params:
   adhoc_filters: []
+  annotation_layers: []
   bar_stacked: true
   bottom_margin: auto
   color_scheme: supersetColors

--- a/tutoraspects/templates/aspects/build/aspects-superset/openedx-assets/assets/charts/Transcripts_Captions_Per_Video.yaml
+++ b/tutoraspects/templates/aspects/build/aspects-superset/openedx-assets/assets/charts/Transcripts_Captions_Per_Video.yaml
@@ -12,6 +12,7 @@ params:
     expressionType: SIMPLE
     operator: TEMPORAL_RANGE
     subject: emission_time
+  annotation_layers: []
   bottom_margin: auto
   color_scheme: supersetColors
   columns: []

--- a/tutoraspects/templates/aspects/build/aspects-superset/openedx-assets/assets/charts/Watched_Video_Segments.yaml
+++ b/tutoraspects/templates/aspects/build/aspects-superset/openedx-assets/assets/charts/Watched_Video_Segments.yaml
@@ -12,6 +12,7 @@ params:
     expressionType: SIMPLE
     operator: TEMPORAL_RANGE
     subject: started_at
+  annotation_layers: []
   bar_stacked: true
   bottom_margin: auto
   color_scheme: supersetColors

--- a/tutoraspects/templates/aspects/build/aspects-superset/openedx-assets/assets/charts/Watches_Per_Video.yaml
+++ b/tutoraspects/templates/aspects/build/aspects-superset/openedx-assets/assets/charts/Watches_Per_Video.yaml
@@ -13,6 +13,7 @@ params:
     expressionType: SIMPLE
     operator: TEMPORAL_RANGE
     subject: emission_time
+  annotation_layers: []
   bottom_margin: auto
   color_scheme: supersetColors
   columns: []

--- a/tutoraspects/templates/aspects/build/aspects-superset/openedx-assets/assets/dashboards/Instructor_Dashboard.yaml
+++ b/tutoraspects/templates/aspects/build/aspects-superset/openedx-assets/assets/dashboards/Instructor_Dashboard.yaml
@@ -1,6 +1,8 @@
 _file_name: Instructor_Dashboard.yaml
 _roles:
 - '{{ SUPERSET_ROLES_MAPPING.instructor }}'
+certification_details: null
+certified_by: null
 css: ''
 dashboard_title: Instructor Dashboard
 description: null
@@ -420,7 +422,7 @@ position:
     children: []
     id: CHART-AZZnl_lpMv
     meta:
-      chartId: 229
+      chartId: 21
       height: 50
       sliceName: Watches Per Video
       uuid: 829c1d5b-2844-4115-876a-34ad3b3cad64
@@ -435,7 +437,7 @@ position:
     children: []
     id: CHART-GFCO8s2cxv
     meta:
-      chartId: 625
+      chartId: 19
       height: 50
       sliceName: Distribution Of Responses
       uuid: f1651c44-a8f4-4b44-ad49-962823009319
@@ -450,7 +452,7 @@ position:
     children: []
     id: CHART-GJJ8VYQ03v
     meta:
-      chartId: 783
+      chartId: 6
       height: 50
       sliceName: Posts per user
       uuid: bc191ce7-f39d-48db-86a9-d19949f4211d
@@ -465,7 +467,7 @@ position:
     children: []
     id: CHART-Jr-gNVms2Q
     meta:
-      chartId: 114
+      chartId: 12
       height: 50
       sliceName: Enrollment Events Per Day
       uuid: bb1147cc-b7bc-44b7-b06a-79b0db6626aa
@@ -480,7 +482,7 @@ position:
     children: []
     id: CHART-OMy4wjRBWt
     meta:
-      chartId: 682
+      chartId: 27
       height: 50
       sliceName: Watched Video Segments
       uuid: 2985a9db-c338-4008-af52-2930b81ee2e5
@@ -495,7 +497,7 @@ position:
     children: []
     id: CHART-RTO33WE9FH
     meta:
-      chartId: 597
+      chartId: 15
       height: 50
       sliceName: Responses Per Problem
       uuid: a3e79162-4ace-4349-ab34-89aa60ae75ed
@@ -510,7 +512,7 @@ position:
     children: []
     id: CHART-Tej2oLPBAl
     meta:
-      chartId: 701
+      chartId: 37
       height: 50
       sliceName: Transcripts / Captions Per Video
       uuid: 6b830def-f3ca-4b4c-9455-7a7b7354bce8
@@ -555,7 +557,7 @@ position:
     children: []
     id: CHART-evjVO-ZSSd
     meta:
-      chartId: 156
+      chartId: 38
       height: 50
       sliceName: Enrollments By Enrollment Mode
       uuid: 05ed7102-5464-4e2f-86ae-31700b787cc3
@@ -570,7 +572,7 @@ position:
     children: []
     id: CHART-j3trfNh8_p
     meta:
-      chartId: 325
+      chartId: 29
       height: 50
       sliceName: Pageview engagement by section/subsection
       uuid: 366a8193-30c3-4aaf-a1ac-360609dfa0ed
@@ -600,7 +602,7 @@ position:
     children: []
     id: CHART-lTr8DL3XuI
     meta:
-      chartId: 695
+      chartId: 4
       height: 50
       sliceName: Distribution Of Hints Per Correct Answer
       uuid: ee94be4c-6fdd-4295-b43c-40890d6c549d
@@ -615,7 +617,7 @@ position:
     children: []
     id: CHART-o56v9yEe2I
     meta:
-      chartId: 770
+      chartId: 31
       height: 50
       sliceName: Distribution Of Problem Grades
       uuid: 4f7e3606-f5de-4643-97c0-bbb6340a3df2
@@ -630,7 +632,7 @@ position:
     children: []
     id: CHART-qG1WaGKl_b
     meta:
-      chartId: 154
+      chartId: 34
       height: 50
       sliceName: Distinct forum users
       uuid: feb323ad-c819-49ca-a336-584bd9ff1a2e
@@ -645,7 +647,7 @@ position:
     children: []
     id: CHART-rnb6PSwCOS
     meta:
-      chartId: 339
+      chartId: 16
       height: 50
       sliceName: Currently Enrolled Learners Per Day
       uuid: ed2fe731-6544-422f-bc55-42f399f48b2c
@@ -660,7 +662,7 @@ position:
     children: []
     id: CHART-tWnaoVNNTH
     meta:
-      chartId: 327
+      chartId: 11
       height: 50
       sliceName: Distribution Of Attempts
       uuid: db90930f-f16e-4c32-8050-0e4abae28f4c
@@ -675,7 +677,7 @@ position:
     children: []
     id: CHART-w-k4N2T_L8
     meta:
-      chartId: 516
+      chartId: 2
       height: 50
       sliceName: Course Grade Distribution
       uuid: f9adbc85-1f50-4c04-ace3-31ba7390de5e
@@ -1130,6 +1132,7 @@ position:
     parents:
     - ROOT_ID
     type: TABS
+published: true
 slug: instructor-dashboard
 uuid: 1d6bf904-f53f-47fd-b1c9-6cd7e284d286
 version: 1.0.0

--- a/tutoraspects/templates/aspects/build/aspects-superset/openedx-assets/assets/dashboards/Instructor_Dashboard.yaml
+++ b/tutoraspects/templates/aspects/build/aspects-superset/openedx-assets/assets/dashboards/Instructor_Dashboard.yaml
@@ -422,7 +422,7 @@ position:
     children: []
     id: CHART-AZZnl_lpMv
     meta:
-      chartId: 21
+      chartId: 22
       height: 50
       sliceName: Watches Per Video
       uuid: 829c1d5b-2844-4115-876a-34ad3b3cad64
@@ -437,7 +437,7 @@ position:
     children: []
     id: CHART-GFCO8s2cxv
     meta:
-      chartId: 19
+      chartId: 20
       height: 50
       sliceName: Distribution Of Responses
       uuid: f1651c44-a8f4-4b44-ad49-962823009319
@@ -467,7 +467,7 @@ position:
     children: []
     id: CHART-Jr-gNVms2Q
     meta:
-      chartId: 12
+      chartId: 13
       height: 50
       sliceName: Enrollment Events Per Day
       uuid: bb1147cc-b7bc-44b7-b06a-79b0db6626aa
@@ -482,7 +482,7 @@ position:
     children: []
     id: CHART-OMy4wjRBWt
     meta:
-      chartId: 27
+      chartId: 28
       height: 50
       sliceName: Watched Video Segments
       uuid: 2985a9db-c338-4008-af52-2930b81ee2e5
@@ -497,7 +497,7 @@ position:
     children: []
     id: CHART-RTO33WE9FH
     meta:
-      chartId: 15
+      chartId: 16
       height: 50
       sliceName: Responses Per Problem
       uuid: a3e79162-4ace-4349-ab34-89aa60ae75ed
@@ -512,7 +512,7 @@ position:
     children: []
     id: CHART-Tej2oLPBAl
     meta:
-      chartId: 37
+      chartId: 38
       height: 50
       sliceName: Transcripts / Captions Per Video
       uuid: 6b830def-f3ca-4b4c-9455-7a7b7354bce8
@@ -557,7 +557,7 @@ position:
     children: []
     id: CHART-evjVO-ZSSd
     meta:
-      chartId: 38
+      chartId: 39
       height: 50
       sliceName: Enrollments By Enrollment Mode
       uuid: 05ed7102-5464-4e2f-86ae-31700b787cc3
@@ -572,7 +572,7 @@ position:
     children: []
     id: CHART-j3trfNh8_p
     meta:
-      chartId: 29
+      chartId: 30
       height: 50
       sliceName: Pageview engagement by section/subsection
       uuid: 366a8193-30c3-4aaf-a1ac-360609dfa0ed
@@ -587,8 +587,8 @@ position:
     children: []
     id: CHART-jfm-20qPKn
     meta:
-      chartId: 816
-      height: 55
+      chartId: 11
+      height: 50
       sliceName: Video engagement by section/subsection
       uuid: 21861f47-9e8b-4715-b1ff-e7f4aa595c14
       width: 12
@@ -617,7 +617,7 @@ position:
     children: []
     id: CHART-o56v9yEe2I
     meta:
-      chartId: 31
+      chartId: 32
       height: 50
       sliceName: Distribution Of Problem Grades
       uuid: 4f7e3606-f5de-4643-97c0-bbb6340a3df2
@@ -632,7 +632,7 @@ position:
     children: []
     id: CHART-qG1WaGKl_b
     meta:
-      chartId: 34
+      chartId: 35
       height: 50
       sliceName: Distinct forum users
       uuid: feb323ad-c819-49ca-a336-584bd9ff1a2e
@@ -647,7 +647,7 @@ position:
     children: []
     id: CHART-rnb6PSwCOS
     meta:
-      chartId: 16
+      chartId: 17
       height: 50
       sliceName: Currently Enrolled Learners Per Day
       uuid: ed2fe731-6544-422f-bc55-42f399f48b2c
@@ -662,7 +662,7 @@ position:
     children: []
     id: CHART-tWnaoVNNTH
     meta:
-      chartId: 11
+      chartId: 12
       height: 50
       sliceName: Distribution Of Attempts
       uuid: db90930f-f16e-4c32-8050-0e4abae28f4c

--- a/tutoraspects/templates/aspects/build/aspects-superset/openedx-assets/assets/datasets/course_names.yaml
+++ b/tutoraspects/templates/aspects/build/aspects-superset/openedx-assets/assets/datasets/course_names.yaml
@@ -1,10 +1,11 @@
 _file_name: course_names.yaml
+always_filter_main_dttm: false
 cache_timeout: null
 columns:
 - advanced_data_type: null
   column_name: course_key
   description: null
-  expression: null
+  expression: ''
   extra: {}
   filterable: true
   groupby: true
@@ -16,7 +17,7 @@ columns:
 - advanced_data_type: null
   column_name: course_name
   description: null
-  expression: null
+  expression: ''
   extra: {}
   filterable: true
   groupby: true
@@ -28,7 +29,7 @@ columns:
 - advanced_data_type: null
   column_name: course_run
   description: null
-  expression: null
+  expression: ''
   extra: {}
   filterable: true
   groupby: true
@@ -40,7 +41,7 @@ columns:
 - advanced_data_type: null
   column_name: org
   description: null
-  expression: null
+  expression: ''
   extra: {}
   filterable: true
   groupby: true

--- a/tutoraspects/templates/aspects/build/aspects-superset/openedx-assets/assets/datasets/dashboards.yaml
+++ b/tutoraspects/templates/aspects/build/aspects-superset/openedx-assets/assets/datasets/dashboards.yaml
@@ -227,7 +227,7 @@ normalize_columns: true
 offset: 0
 params: null
 schema: superset
-sql: 'select * from '
+sql: 'select * from dashboards'
 table_name: dashboards
 template_params: null
 uuid: 3dee777a-3dd4-4fcb-a749-4d13651b3444

--- a/tutoraspects/templates/aspects/build/aspects-superset/openedx-assets/assets/datasets/dim_course_problems.yaml
+++ b/tutoraspects/templates/aspects/build/aspects-superset/openedx-assets/assets/datasets/dim_course_problems.yaml
@@ -1,10 +1,11 @@
 _file_name: dim_course_problems.yaml
+always_filter_main_dttm: false
 cache_timeout: null
 columns:
 - advanced_data_type: null
   column_name: problem_name_with_location
   description: null
-  expression: null
+  expression: ''
   extra: {}
   filterable: true
   groupby: true
@@ -16,7 +17,7 @@ columns:
 - advanced_data_type: null
   column_name: course_key
   description: null
-  expression: null
+  expression: ''
   extra: {}
   filterable: true
   groupby: true
@@ -28,7 +29,7 @@ columns:
 - advanced_data_type: null
   column_name: course_name
   description: null
-  expression: null
+  expression: ''
   extra: {}
   filterable: true
   groupby: true
@@ -40,7 +41,7 @@ columns:
 - advanced_data_type: null
   column_name: course_run
   description: null
-  expression: null
+  expression: ''
   extra: {}
   filterable: true
   groupby: true
@@ -52,7 +53,7 @@ columns:
 - advanced_data_type: null
   column_name: problem_id
   description: null
-  expression: null
+  expression: ''
   extra: {}
   filterable: true
   groupby: true
@@ -64,7 +65,7 @@ columns:
 - advanced_data_type: null
   column_name: problem_name
   description: null
-  expression: null
+  expression: ''
   extra: {}
   filterable: true
   groupby: true
@@ -76,7 +77,7 @@ columns:
 - advanced_data_type: null
   column_name: org
   description: null
-  expression: null
+  expression: ''
   extra: {}
   filterable: true
   groupby: true

--- a/tutoraspects/templates/aspects/build/aspects-superset/openedx-assets/assets/datasets/dim_course_videos.yaml
+++ b/tutoraspects/templates/aspects/build/aspects-superset/openedx-assets/assets/datasets/dim_course_videos.yaml
@@ -1,10 +1,11 @@
 _file_name: dim_course_videos.yaml
+always_filter_main_dttm: false
 cache_timeout: null
 columns:
 - advanced_data_type: null
   column_name: video_name_with_location
   description: null
-  expression: null
+  expression: ''
   extra: {}
   filterable: true
   groupby: true
@@ -16,7 +17,7 @@ columns:
 - advanced_data_type: null
   column_name: course_key
   description: null
-  expression: null
+  expression: ''
   extra: {}
   filterable: true
   groupby: true
@@ -28,7 +29,7 @@ columns:
 - advanced_data_type: null
   column_name: course_name
   description: null
-  expression: null
+  expression: ''
   extra: {}
   filterable: true
   groupby: true
@@ -40,7 +41,7 @@ columns:
 - advanced_data_type: null
   column_name: course_run
   description: null
-  expression: null
+  expression: ''
   extra: {}
   filterable: true
   groupby: true
@@ -52,7 +53,7 @@ columns:
 - advanced_data_type: null
   column_name: video_id
   description: null
-  expression: null
+  expression: ''
   extra: {}
   filterable: true
   groupby: true
@@ -64,7 +65,7 @@ columns:
 - advanced_data_type: null
   column_name: video_name
   description: null
-  expression: null
+  expression: ''
   extra: {}
   filterable: true
   groupby: true
@@ -76,7 +77,7 @@ columns:
 - advanced_data_type: null
   column_name: org
   description: null
-  expression: null
+  expression: ''
   extra: {}
   filterable: true
   groupby: true

--- a/tutoraspects/templates/aspects/build/aspects-superset/openedx-assets/assets/datasets/fact_course_grades.yaml
+++ b/tutoraspects/templates/aspects/build/aspects-superset/openedx-assets/assets/datasets/fact_course_grades.yaml
@@ -1,10 +1,35 @@
 _file_name: fact_course_grades.yaml
+always_filter_main_dttm: false
 cache_timeout: null
 columns:
 - advanced_data_type: null
+  column_name: grade_type
+  description: null
+  expression: ''
+  extra: {}
+  filterable: true
+  groupby: true
+  is_active: true
+  is_dttm: false
+  python_date_format: null
+  type: Nullable(String)
+  verbose_name: Grade Type
+- advanced_data_type: null
+  column_name: scaled_score
+  description: null
+  expression: ''
+  extra: {}
+  filterable: true
+  groupby: true
+  is_active: true
+  is_dttm: false
+  python_date_format: null
+  type: Float64
+  verbose_name: Scaled Score
+- advanced_data_type: null
   column_name: actor_id
   description: null
-  expression: null
+  expression: ''
   extra: {}
   filterable: true
   groupby: true
@@ -16,7 +41,7 @@ columns:
 - advanced_data_type: null
   column_name: grade_bucket
   description: null
-  expression: null
+  expression: ''
   extra: {}
   filterable: true
   groupby: true
@@ -28,7 +53,7 @@ columns:
 - advanced_data_type: null
   column_name: course_key
   description: null
-  expression: null
+  expression: ''
   extra: {}
   filterable: true
   groupby: true
@@ -40,7 +65,7 @@ columns:
 - advanced_data_type: null
   column_name: course_name
   description: null
-  expression: null
+  expression: ''
   extra: {}
   filterable: true
   groupby: true
@@ -52,7 +77,7 @@ columns:
 - advanced_data_type: null
   column_name: course_run
   description: null
-  expression: null
+  expression: ''
   extra: {}
   filterable: true
   groupby: true
@@ -64,7 +89,7 @@ columns:
 - advanced_data_type: null
   column_name: emission_time
   description: null
-  expression: null
+  expression: ''
   extra: {}
   filterable: true
   groupby: true
@@ -76,7 +101,7 @@ columns:
 - advanced_data_type: null
   column_name: entity_name
   description: null
-  expression: null
+  expression: ''
   extra: {}
   filterable: true
   groupby: true
@@ -86,33 +111,9 @@ columns:
   type: String
   verbose_name: Entity Name
 - advanced_data_type: null
-  column_name: scaled_score
-  description: null
-  expression: null
-  extra: {}
-  filterable: true
-  groupby: true
-  is_active: true
-  is_dttm: false
-  python_date_format: null
-  type: Float
-  verbose_name: Scaled Score
-- advanced_data_type: null
-  column_name: grade_type
-  description: null
-  expression: null
-  extra: {}
-  filterable: true
-  groupby: true
-  is_active: true
-  is_dttm: false
-  python_date_format: null
-  type: String
-  verbose_name: Grade Type
-- advanced_data_type: null
   column_name: org
   description: null
-  expression: null
+  expression: ''
   extra: {}
   filterable: true
   groupby: true
@@ -127,8 +128,17 @@ description: null
 extra: {}
 fetch_values_predicate: null
 filter_select_enabled: false
-main_dttm_col: null
+main_dttm_col: emission_time
 metrics:
+- currency: null
+  d3format: null
+  description: null
+  expression: COUNT(*)
+  extra: null
+  metric_name: count
+  metric_type: count
+  verbose_name: COUNT(*)
+  warning_text: null
 - currency: null
   d3format: null
   description: null

--- a/tutoraspects/templates/aspects/build/aspects-superset/openedx-assets/assets/datasets/fact_enrollments.yaml
+++ b/tutoraspects/templates/aspects/build/aspects-superset/openedx-assets/assets/datasets/fact_enrollments.yaml
@@ -1,22 +1,11 @@
 _file_name: fact_enrollments.yaml
+always_filter_main_dttm: false
 cache_timeout: null
 columns:
 - advanced_data_type: null
-  column_name: enrollment_mode
-  description: null
-  expression: null
-  extra: {}
-  filterable: true
-  groupby: true
-  is_active: true
-  is_dttm: false
-  python_date_format: null
-  type: LowCardinality(String)
-  verbose_name: Enrollment Mode
-- advanced_data_type: null
   column_name: actor_id
   description: null
-  expression: null
+  expression: ''
   extra: {}
   filterable: true
   groupby: true
@@ -28,7 +17,7 @@ columns:
 - advanced_data_type: null
   column_name: course_key
   description: null
-  expression: null
+  expression: ''
   extra: {}
   filterable: true
   groupby: true
@@ -40,7 +29,7 @@ columns:
 - advanced_data_type: null
   column_name: course_name
   description: null
-  expression: null
+  expression: ''
   extra: {}
   filterable: true
   groupby: true
@@ -52,7 +41,7 @@ columns:
 - advanced_data_type: null
   column_name: course_run
   description: null
-  expression: null
+  expression: ''
   extra: {}
   filterable: true
   groupby: true
@@ -64,7 +53,7 @@ columns:
 - advanced_data_type: null
   column_name: emission_time
   description: null
-  expression: null
+  expression: ''
   extra: {}
   filterable: true
   groupby: true
@@ -74,9 +63,21 @@ columns:
   type: DateTime
   verbose_name: Emission Time
 - advanced_data_type: null
+  column_name: enrollment_mode
+  description: null
+  expression: ''
+  extra: {}
+  filterable: true
+  groupby: true
+  is_active: true
+  is_dttm: false
+  python_date_format: null
+  type: String
+  verbose_name: Enrollment Mode
+- advanced_data_type: null
   column_name: enrollment_status
   description: null
-  expression: null
+  expression: ''
   extra: {}
   filterable: true
   groupby: true
@@ -88,7 +89,7 @@ columns:
 - advanced_data_type: null
   column_name: org
   description: null
-  expression: null
+  expression: ''
   extra: {}
   filterable: true
   groupby: true
@@ -103,7 +104,7 @@ description: null
 extra: {}
 fetch_values_predicate: null
 filter_select_enabled: false
-main_dttm_col: null
+main_dttm_col: emission_time
 metrics:
 - currency: null
   d3format: null

--- a/tutoraspects/templates/aspects/build/aspects-superset/openedx-assets/assets/datasets/fact_enrollments_by_day.yaml
+++ b/tutoraspects/templates/aspects/build/aspects-superset/openedx-assets/assets/datasets/fact_enrollments_by_day.yaml
@@ -1,10 +1,11 @@
 _file_name: fact_enrollments_by_day.yaml
+always_filter_main_dttm: false
 cache_timeout: null
 columns:
 - advanced_data_type: null
   column_name: enrollment_status_date
   description: null
-  expression: null
+  expression: ''
   extra: {}
   filterable: true
   groupby: true
@@ -14,21 +15,9 @@ columns:
   type: Date
   verbose_name: Enrollment Status Date
 - advanced_data_type: null
-  column_name: enrollment_mode
-  description: null
-  expression: null
-  extra: {}
-  filterable: true
-  groupby: true
-  is_active: true
-  is_dttm: false
-  python_date_format: null
-  type: LowCardinality(String)
-  verbose_name: Enrollment Mode
-- advanced_data_type: null
   column_name: actor_id
   description: null
-  expression: null
+  expression: ''
   extra: {}
   filterable: true
   groupby: true
@@ -40,7 +29,7 @@ columns:
 - advanced_data_type: null
   column_name: course_key
   description: null
-  expression: null
+  expression: ''
   extra: {}
   filterable: true
   groupby: true
@@ -52,7 +41,7 @@ columns:
 - advanced_data_type: null
   column_name: course_name
   description: null
-  expression: null
+  expression: ''
   extra: {}
   filterable: true
   groupby: true
@@ -64,7 +53,7 @@ columns:
 - advanced_data_type: null
   column_name: course_run
   description: null
-  expression: null
+  expression: ''
   extra: {}
   filterable: true
   groupby: true
@@ -74,9 +63,21 @@ columns:
   type: String
   verbose_name: Course Run
 - advanced_data_type: null
+  column_name: enrollment_mode
+  description: null
+  expression: ''
+  extra: {}
+  filterable: true
+  groupby: true
+  is_active: true
+  is_dttm: false
+  python_date_format: null
+  type: String
+  verbose_name: Enrollment Mode
+- advanced_data_type: null
   column_name: enrollment_status
   description: null
-  expression: null
+  expression: ''
   extra: {}
   filterable: true
   groupby: true
@@ -88,7 +89,7 @@ columns:
 - advanced_data_type: null
   column_name: org
   description: null
-  expression: null
+  expression: ''
   extra: {}
   filterable: true
   groupby: true
@@ -103,7 +104,7 @@ description: null
 extra: {}
 fetch_values_predicate: null
 filter_select_enabled: false
-main_dttm_col: null
+main_dttm_col: enrollment_status_date
 metrics:
 - currency: null
   d3format: null

--- a/tutoraspects/templates/aspects/build/aspects-superset/openedx-assets/assets/datasets/fact_forum_interactions.yaml
+++ b/tutoraspects/templates/aspects/build/aspects-superset/openedx-assets/assets/datasets/fact_forum_interactions.yaml
@@ -1,10 +1,11 @@
 _file_name: fact_forum_interactions.yaml
+always_filter_main_dttm: false
 cache_timeout: null
 columns:
 - advanced_data_type: null
   column_name: actor_id
   description: null
-  expression: null
+  expression: ''
   extra: {}
   filterable: true
   groupby: true
@@ -16,7 +17,7 @@ columns:
 - advanced_data_type: null
   column_name: course_key
   description: null
-  expression: null
+  expression: ''
   extra: {}
   filterable: true
   groupby: true
@@ -28,7 +29,7 @@ columns:
 - advanced_data_type: null
   column_name: course_name
   description: null
-  expression: null
+  expression: ''
   extra: {}
   filterable: true
   groupby: true
@@ -40,7 +41,7 @@ columns:
 - advanced_data_type: null
   column_name: course_run
   description: null
-  expression: null
+  expression: ''
   extra: {}
   filterable: true
   groupby: true
@@ -52,7 +53,7 @@ columns:
 - advanced_data_type: null
   column_name: event_id
   description: null
-  expression: null
+  expression: ''
   extra: {}
   filterable: true
   groupby: true
@@ -64,7 +65,7 @@ columns:
 - advanced_data_type: null
   column_name: emission_time
   description: null
-  expression: null
+  expression: ''
   extra: {}
   filterable: true
   groupby: true
@@ -76,7 +77,7 @@ columns:
 - advanced_data_type: null
   column_name: object_id
   description: null
-  expression: null
+  expression: ''
   extra: {}
   filterable: true
   groupby: true
@@ -88,7 +89,7 @@ columns:
 - advanced_data_type: null
   column_name: verb_id
   description: null
-  expression: null
+  expression: ''
   extra: {}
   filterable: true
   groupby: true
@@ -100,7 +101,7 @@ columns:
 - advanced_data_type: null
   column_name: org
   description: null
-  expression: null
+  expression: ''
   extra: {}
   filterable: true
   groupby: true
@@ -115,7 +116,7 @@ description: null
 extra: {}
 fetch_values_predicate: null
 filter_select_enabled: false
-main_dttm_col: null
+main_dttm_col: emission_time
 metrics:
 - currency: null
   d3format: null

--- a/tutoraspects/templates/aspects/build/aspects-superset/openedx-assets/assets/datasets/fact_learner_problem_course_summary.yaml
+++ b/tutoraspects/templates/aspects/build/aspects-superset/openedx-assets/assets/datasets/fact_learner_problem_course_summary.yaml
@@ -1,10 +1,11 @@
 _file_name: fact_learner_problem_course_summary.yaml
+always_filter_main_dttm: false
 cache_timeout: null
 columns:
 - advanced_data_type: null
   column_name: num_answers_displayed
   description: null
-  expression: null
+  expression: ''
   extra: {}
   filterable: true
   groupby: true
@@ -16,7 +17,7 @@ columns:
 - advanced_data_type: null
   column_name: num_hints_displayed
   description: null
-  expression: null
+  expression: ''
   extra: {}
   filterable: true
   groupby: true
@@ -28,7 +29,7 @@ columns:
 - advanced_data_type: null
   column_name: problem_name_with_location
   description: null
-  expression: null
+  expression: ''
   extra: {}
   filterable: true
   groupby: true
@@ -40,7 +41,7 @@ columns:
 - advanced_data_type: null
   column_name: actor_id
   description: null
-  expression: null
+  expression: ''
   extra: {}
   filterable: true
   groupby: true
@@ -52,7 +53,7 @@ columns:
 - advanced_data_type: null
   column_name: course_key
   description: null
-  expression: null
+  expression: ''
   extra: {}
   filterable: true
   groupby: true
@@ -64,7 +65,7 @@ columns:
 - advanced_data_type: null
   column_name: course_name
   description: null
-  expression: null
+  expression: ''
   extra: {}
   filterable: true
   groupby: true
@@ -76,7 +77,7 @@ columns:
 - advanced_data_type: null
   column_name: course_run
   description: null
-  expression: null
+  expression: ''
   extra: {}
   filterable: true
   groupby: true
@@ -88,7 +89,7 @@ columns:
 - advanced_data_type: null
   column_name: problem_name
   description: null
-  expression: null
+  expression: ''
   extra: {}
   filterable: true
   groupby: true
@@ -100,7 +101,7 @@ columns:
 - advanced_data_type: null
   column_name: attempts
   description: null
-  expression: null
+  expression: ''
   extra: {}
   filterable: true
   groupby: true
@@ -112,7 +113,7 @@ columns:
 - advanced_data_type: null
   column_name: success
   description: null
-  expression: null
+  expression: ''
   extra: {}
   filterable: true
   groupby: true
@@ -124,7 +125,7 @@ columns:
 - advanced_data_type: null
   column_name: org
   description: null
-  expression: null
+  expression: ''
   extra: {}
   filterable: true
   groupby: true

--- a/tutoraspects/templates/aspects/build/aspects-superset/openedx-assets/assets/datasets/fact_learner_problem_summary.yaml
+++ b/tutoraspects/templates/aspects/build/aspects-superset/openedx-assets/assets/datasets/fact_learner_problem_summary.yaml
@@ -1,10 +1,11 @@
 _file_name: fact_learner_problem_summary.yaml
+always_filter_main_dttm: false
 cache_timeout: null
 columns:
 - advanced_data_type: null
   column_name: num_answers_displayed
   description: null
-  expression: null
+  expression: ''
   extra: {}
   filterable: true
   groupby: true
@@ -16,7 +17,7 @@ columns:
 - advanced_data_type: null
   column_name: num_hints_displayed
   description: null
-  expression: null
+  expression: ''
   extra: {}
   filterable: true
   groupby: true
@@ -28,7 +29,7 @@ columns:
 - advanced_data_type: null
   column_name: problem_name_with_location
   description: null
-  expression: null
+  expression: ''
   extra: {}
   filterable: true
   groupby: true
@@ -40,7 +41,7 @@ columns:
 - advanced_data_type: null
   column_name: actor_id
   description: null
-  expression: null
+  expression: ''
   extra: {}
   filterable: true
   groupby: true
@@ -52,7 +53,7 @@ columns:
 - advanced_data_type: null
   column_name: course_key
   description: null
-  expression: null
+  expression: ''
   extra: {}
   filterable: true
   groupby: true
@@ -64,7 +65,7 @@ columns:
 - advanced_data_type: null
   column_name: course_name
   description: null
-  expression: null
+  expression: ''
   extra: {}
   filterable: true
   groupby: true
@@ -76,7 +77,7 @@ columns:
 - advanced_data_type: null
   column_name: course_run
   description: null
-  expression: null
+  expression: ''
   extra: {}
   filterable: true
   groupby: true
@@ -88,7 +89,7 @@ columns:
 - advanced_data_type: null
   column_name: problem_name
   description: null
-  expression: null
+  expression: ''
   extra: {}
   filterable: true
   groupby: true
@@ -100,7 +101,7 @@ columns:
 - advanced_data_type: null
   column_name: attempts
   description: null
-  expression: null
+  expression: ''
   extra: {}
   filterable: true
   groupby: true
@@ -112,7 +113,7 @@ columns:
 - advanced_data_type: null
   column_name: success
   description: null
-  expression: null
+  expression: ''
   extra: {}
   filterable: true
   groupby: true
@@ -124,7 +125,7 @@ columns:
 - advanced_data_type: null
   column_name: org
   description: null
-  expression: null
+  expression: ''
   extra: {}
   filterable: true
   groupby: true
@@ -141,6 +142,15 @@ fetch_values_predicate: null
 filter_select_enabled: false
 main_dttm_col: null
 metrics:
+- currency: null
+  d3format: null
+  description: null
+  expression: COUNT(*)
+  extra: null
+  metric_name: count
+  metric_type: count
+  verbose_name: COUNT(*)
+  warning_text: null
 - currency: null
   d3format: null
   description: null

--- a/tutoraspects/templates/aspects/build/aspects-superset/openedx-assets/assets/datasets/fact_pageview_engagement.yaml
+++ b/tutoraspects/templates/aspects/build/aspects-superset/openedx-assets/assets/datasets/fact_pageview_engagement.yaml
@@ -5,7 +5,7 @@ columns:
 - advanced_data_type: null
   column_name: section/subsection page engagement
   description: null
-  expression: null
+  expression: ''
   extra: null
   filterable: true
   groupby: true
@@ -17,7 +17,7 @@ columns:
 - advanced_data_type: null
   column_name: section/subsection name
   description: null
-  expression: null
+  expression: ''
   extra: null
   filterable: true
   groupby: true
@@ -29,7 +29,7 @@ columns:
 - advanced_data_type: null
   column_name: content level
   description: null
-  expression: null
+  expression: ''
   extra: null
   filterable: true
   groupby: true
@@ -41,7 +41,7 @@ columns:
 - advanced_data_type: null
   column_name: actor_id
   description: null
-  expression: null
+  expression: ''
   extra: null
   filterable: true
   groupby: true
@@ -53,7 +53,7 @@ columns:
 - advanced_data_type: null
   column_name: course_key
   description: null
-  expression: null
+  expression: ''
   extra: null
   filterable: true
   groupby: true
@@ -65,7 +65,7 @@ columns:
 - advanced_data_type: null
   column_name: course_run
   description: null
-  expression: null
+  expression: ''
   extra: null
   filterable: true
   groupby: true
@@ -77,7 +77,7 @@ columns:
 - advanced_data_type: null
   column_name: org
   description: null
-  expression: null
+  expression: ''
   extra: null
   filterable: true
   groupby: true

--- a/tutoraspects/templates/aspects/build/aspects-superset/openedx-assets/assets/datasets/fact_pageview_engagement.yaml
+++ b/tutoraspects/templates/aspects/build/aspects-superset/openedx-assets/assets/datasets/fact_pageview_engagement.yaml
@@ -1,4 +1,5 @@
 _file_name: fact_pageview_engagement.yaml
+always_filter_main_dttm: false
 cache_timeout: null
 columns:
 - advanced_data_type: null

--- a/tutoraspects/templates/aspects/build/aspects-superset/openedx-assets/assets/datasets/fact_problem_grades.yaml
+++ b/tutoraspects/templates/aspects/build/aspects-superset/openedx-assets/assets/datasets/fact_problem_grades.yaml
@@ -3,6 +3,18 @@ always_filter_main_dttm: false
 cache_timeout: null
 columns:
 - advanced_data_type: null
+  column_name: entity_name_with_location
+  description: null
+  expression: ''
+  extra: null
+  filterable: true
+  groupby: true
+  is_active: true
+  is_dttm: false
+  python_date_format: null
+  type: Nullable(String)
+  verbose_name: Entity Name With Location
+- advanced_data_type: null
   column_name: grade_type
   description: null
   expression: ''
@@ -122,18 +134,6 @@ columns:
   python_date_format: null
   type: String
   verbose_name: Organization
-- advanced_data_type: null
-  column_name: entity_name_with_location
-  description: null
-  expression: null
-  extra: null
-  filterable: true
-  groupby: true
-  is_active: true
-  is_dttm: false
-  python_date_format: null
-  type: Nullable(String)
-  verbose_name: Entity Name With Location
 database_uuid: 21174b6c-4d40-4958-8161-d6c3cf5e77b6
 default_endpoint: null
 description: null

--- a/tutoraspects/templates/aspects/build/aspects-superset/openedx-assets/assets/datasets/fact_problem_grades.yaml
+++ b/tutoraspects/templates/aspects/build/aspects-superset/openedx-assets/assets/datasets/fact_problem_grades.yaml
@@ -1,10 +1,35 @@
 _file_name: fact_problem_grades.yaml
+always_filter_main_dttm: false
 cache_timeout: null
 columns:
 - advanced_data_type: null
+  column_name: grade_type
+  description: null
+  expression: ''
+  extra: {}
+  filterable: true
+  groupby: true
+  is_active: true
+  is_dttm: false
+  python_date_format: null
+  type: Nullable(String)
+  verbose_name: Grade Type
+- advanced_data_type: null
+  column_name: scaled_score
+  description: null
+  expression: ''
+  extra: {}
+  filterable: true
+  groupby: true
+  is_active: true
+  is_dttm: false
+  python_date_format: null
+  type: Float64
+  verbose_name: Scaled Score
+- advanced_data_type: null
   column_name: actor_id
   description: null
-  expression: null
+  expression: ''
   extra: {}
   filterable: true
   groupby: true
@@ -16,7 +41,7 @@ columns:
 - advanced_data_type: null
   column_name: grade_bucket
   description: null
-  expression: null
+  expression: ''
   extra: {}
   filterable: true
   groupby: true
@@ -28,7 +53,7 @@ columns:
 - advanced_data_type: null
   column_name: course_key
   description: null
-  expression: null
+  expression: ''
   extra: {}
   filterable: true
   groupby: true
@@ -40,7 +65,7 @@ columns:
 - advanced_data_type: null
   column_name: course_name
   description: null
-  expression: null
+  expression: ''
   extra: {}
   filterable: true
   groupby: true
@@ -52,7 +77,7 @@ columns:
 - advanced_data_type: null
   column_name: course_run
   description: null
-  expression: null
+  expression: ''
   extra: {}
   filterable: true
   groupby: true
@@ -64,7 +89,7 @@ columns:
 - advanced_data_type: null
   column_name: emission_time
   description: null
-  expression: null
+  expression: ''
   extra: {}
   filterable: true
   groupby: true
@@ -76,7 +101,7 @@ columns:
 - advanced_data_type: null
   column_name: entity_name
   description: null
-  expression: null
+  expression: ''
   extra: {}
   filterable: true
   groupby: true
@@ -86,33 +111,9 @@ columns:
   type: String
   verbose_name: Entity Name
 - advanced_data_type: null
-  column_name: scaled_score
-  description: null
-  expression: null
-  extra: {}
-  filterable: true
-  groupby: true
-  is_active: true
-  is_dttm: false
-  python_date_format: null
-  type: Float
-  verbose_name: Scaled Score
-- advanced_data_type: null
-  column_name: grade_type
-  description: null
-  expression: null
-  extra: {}
-  filterable: true
-  groupby: true
-  is_active: true
-  is_dttm: false
-  python_date_format: null
-  type: String
-  verbose_name: Grade Type
-- advanced_data_type: null
   column_name: org
   description: null
-  expression: null
+  expression: ''
   extra: {}
   filterable: true
   groupby: true
@@ -121,14 +122,35 @@ columns:
   python_date_format: null
   type: String
   verbose_name: Organization
+- advanced_data_type: null
+  column_name: entity_name_with_location
+  description: null
+  expression: null
+  extra: null
+  filterable: true
+  groupby: true
+  is_active: true
+  is_dttm: false
+  python_date_format: null
+  type: Nullable(String)
+  verbose_name: Entity Name With Location
 database_uuid: 21174b6c-4d40-4958-8161-d6c3cf5e77b6
 default_endpoint: null
 description: null
 extra: {}
 fetch_values_predicate: null
 filter_select_enabled: false
-main_dttm_col: null
+main_dttm_col: emission_time
 metrics:
+- currency: null
+  d3format: null
+  description: null
+  expression: COUNT(*)
+  extra: null
+  metric_name: count
+  metric_type: count
+  verbose_name: COUNT(*)
+  warning_text: null
 - currency: null
   d3format: null
   description: null

--- a/tutoraspects/templates/aspects/build/aspects-superset/openedx-assets/assets/datasets/fact_problem_responses.yaml
+++ b/tutoraspects/templates/aspects/build/aspects-superset/openedx-assets/assets/datasets/fact_problem_responses.yaml
@@ -1,10 +1,11 @@
 _file_name: fact_problem_responses.yaml
+always_filter_main_dttm: false
 cache_timeout: null
 columns:
 - advanced_data_type: null
   column_name: problem_name_with_location
   description: null
-  expression: null
+  expression: ''
   extra: {}
   filterable: true
   groupby: true
@@ -16,7 +17,7 @@ columns:
 - advanced_data_type: null
   column_name: actor_id
   description: null
-  expression: null
+  expression: ''
   extra: {}
   filterable: true
   groupby: true
@@ -28,7 +29,7 @@ columns:
 - advanced_data_type: null
   column_name: course_name
   description: null
-  expression: null
+  expression: ''
   extra: {}
   filterable: true
   groupby: true
@@ -40,7 +41,7 @@ columns:
 - advanced_data_type: null
   column_name: course_run
   description: null
-  expression: null
+  expression: ''
   extra: {}
   filterable: true
   groupby: true
@@ -52,7 +53,7 @@ columns:
 - advanced_data_type: null
   column_name: emission_time
   description: null
-  expression: null
+  expression: ''
   extra: {}
   filterable: true
   groupby: true
@@ -64,7 +65,7 @@ columns:
 - advanced_data_type: null
   column_name: problem_name
   description: null
-  expression: null
+  expression: ''
   extra: {}
   filterable: true
   groupby: true
@@ -76,7 +77,7 @@ columns:
 - advanced_data_type: null
   column_name: attempts
   description: null
-  expression: null
+  expression: ''
   extra: {}
   filterable: true
   groupby: true
@@ -88,7 +89,7 @@ columns:
 - advanced_data_type: null
   column_name: success
   description: null
-  expression: null
+  expression: ''
   extra: {}
   filterable: true
   groupby: true
@@ -100,7 +101,7 @@ columns:
 - advanced_data_type: null
   column_name: org
   description: null
-  expression: null
+  expression: ''
   extra: {}
   filterable: true
   groupby: true
@@ -112,7 +113,7 @@ columns:
 - advanced_data_type: null
   column_name: responses
   description: null
-  expression: null
+  expression: ''
   extra: {}
   filterable: true
   groupby: true
@@ -121,14 +122,47 @@ columns:
   python_date_format: null
   type: String
   verbose_name: Responses
+- advanced_data_type: null
+  column_name: problem_id
+  description: null
+  expression: null
+  extra: null
+  filterable: true
+  groupby: true
+  is_active: true
+  is_dttm: false
+  python_date_format: null
+  type: String
+  verbose_name: Problem ID
+- advanced_data_type: null
+  column_name: course_key
+  description: null
+  expression: null
+  extra: null
+  filterable: true
+  groupby: true
+  is_active: true
+  is_dttm: false
+  python_date_format: null
+  type: String
+  verbose_name: Course Key
 database_uuid: 21174b6c-4d40-4958-8161-d6c3cf5e77b6
 default_endpoint: null
 description: null
 extra: {}
 fetch_values_predicate: null
 filter_select_enabled: false
-main_dttm_col: null
+main_dttm_col: emission_time
 metrics:
+- currency: null
+  d3format: null
+  description: null
+  expression: COUNT(*)
+  extra: null
+  metric_name: count
+  metric_type: count
+  verbose_name: COUNT(*)
+  warning_text: null
 - currency: null
   d3format: null
   description: null

--- a/tutoraspects/templates/aspects/build/aspects-superset/openedx-assets/assets/datasets/fact_problem_responses.yaml
+++ b/tutoraspects/templates/aspects/build/aspects-superset/openedx-assets/assets/datasets/fact_problem_responses.yaml
@@ -75,6 +75,30 @@ columns:
   type: String
   verbose_name: Problem Name
 - advanced_data_type: null
+  column_name: course_key
+  description: null
+  expression: ''
+  extra: null
+  filterable: true
+  groupby: true
+  is_active: true
+  is_dttm: false
+  python_date_format: null
+  type: String
+  verbose_name: Course Key
+- advanced_data_type: null
+  column_name: problem_id
+  description: null
+  expression: ''
+  extra: null
+  filterable: true
+  groupby: true
+  is_active: true
+  is_dttm: false
+  python_date_format: null
+  type: String
+  verbose_name: Problem ID
+- advanced_data_type: null
   column_name: attempts
   description: null
   expression: ''
@@ -122,30 +146,6 @@ columns:
   python_date_format: null
   type: String
   verbose_name: Responses
-- advanced_data_type: null
-  column_name: problem_id
-  description: null
-  expression: null
-  extra: null
-  filterable: true
-  groupby: true
-  is_active: true
-  is_dttm: false
-  python_date_format: null
-  type: String
-  verbose_name: Problem ID
-- advanced_data_type: null
-  column_name: course_key
-  description: null
-  expression: null
-  extra: null
-  filterable: true
-  groupby: true
-  is_active: true
-  is_dttm: false
-  python_date_format: null
-  type: String
-  verbose_name: Course Key
 database_uuid: 21174b6c-4d40-4958-8161-d6c3cf5e77b6
 default_endpoint: null
 description: null

--- a/tutoraspects/templates/aspects/build/aspects-superset/openedx-assets/assets/datasets/fact_transcript_usage.yaml
+++ b/tutoraspects/templates/aspects/build/aspects-superset/openedx-assets/assets/datasets/fact_transcript_usage.yaml
@@ -1,10 +1,11 @@
 _file_name: fact_transcript_usage.yaml
+always_filter_main_dttm: false
 cache_timeout: null
 columns:
 - advanced_data_type: null
   column_name: video_name_with_location
   description: null
-  expression: null
+  expression: ''
   extra: {}
   filterable: true
   groupby: true
@@ -16,7 +17,7 @@ columns:
 - advanced_data_type: null
   column_name: actor_id
   description: null
-  expression: null
+  expression: ''
   extra: {}
   filterable: true
   groupby: true
@@ -28,7 +29,7 @@ columns:
 - advanced_data_type: null
   column_name: course_key
   description: null
-  expression: null
+  expression: ''
   extra: {}
   filterable: true
   groupby: true
@@ -40,7 +41,7 @@ columns:
 - advanced_data_type: null
   column_name: course_name
   description: null
-  expression: null
+  expression: ''
   extra: {}
   filterable: true
   groupby: true
@@ -52,7 +53,7 @@ columns:
 - advanced_data_type: null
   column_name: course_run
   description: null
-  expression: null
+  expression: ''
   extra: {}
   filterable: true
   groupby: true
@@ -64,7 +65,7 @@ columns:
 - advanced_data_type: null
   column_name: emission_time
   description: null
-  expression: null
+  expression: ''
   extra: {}
   filterable: true
   groupby: true
@@ -76,7 +77,7 @@ columns:
 - advanced_data_type: null
   column_name: video_name
   description: null
-  expression: null
+  expression: ''
   extra: {}
   filterable: true
   groupby: true
@@ -88,7 +89,7 @@ columns:
 - advanced_data_type: null
   column_name: org
   description: null
-  expression: null
+  expression: ''
   extra: {}
   filterable: true
   groupby: true
@@ -103,7 +104,7 @@ description: null
 extra: {}
 fetch_values_predicate: null
 filter_select_enabled: false
-main_dttm_col: null
+main_dttm_col: emission_time
 metrics:
 - currency: null
   d3format: null
@@ -124,6 +125,15 @@ metrics:
   metric_name: total_transcript_usage
   metric_type: null
   verbose_name: Total transcript usage
+  warning_text: null
+- currency: null
+  d3format: null
+  description: null
+  expression: COUNT(*)
+  extra: null
+  metric_name: count
+  metric_type: count
+  verbose_name: COUNT(*)
   warning_text: null
 normalize_columns: true
 offset: 0

--- a/tutoraspects/templates/aspects/build/aspects-superset/openedx-assets/assets/datasets/fact_video_engagement.yaml
+++ b/tutoraspects/templates/aspects/build/aspects-superset/openedx-assets/assets/datasets/fact_video_engagement.yaml
@@ -1,4 +1,5 @@
 _file_name: fact_video_engagement.yaml
+always_filter_main_dttm: false
 cache_timeout: null
 columns:
 - advanced_data_type: null

--- a/tutoraspects/templates/aspects/build/aspects-superset/openedx-assets/assets/datasets/fact_video_plays.yaml
+++ b/tutoraspects/templates/aspects/build/aspects-superset/openedx-assets/assets/datasets/fact_video_plays.yaml
@@ -87,6 +87,18 @@ columns:
   type: String
   verbose_name: Video Name
 - advanced_data_type: null
+  column_name: video_position
+  description: null
+  expression: null
+  extra: {}
+  filterable: true
+  groupby: true
+  is_active: true
+  is_dttm: false
+  python_date_format: null
+  type: Decimal(9, 2)
+  verbose_name: Video Position
+- advanced_data_type: null
   column_name: org
   description: null
   expression: ''
@@ -98,6 +110,54 @@ columns:
   python_date_format: null
   type: String
   verbose_name: Organization
+- advanced_data_type: null
+  column_name: video_duration
+  description: null
+  expression: null
+  extra: {}
+  filterable: true
+  groupby: true
+  is_active: true
+  is_dttm: false
+  python_date_format: null
+  type: Int64
+  verbose_name: Video Duration
+- advanced_data_type: null
+  column_name: graded
+  description: null
+  expression: null
+  extra: {}
+  filterable: true
+  groupby: true
+  is_active: true
+  is_dttm: false
+  python_date_format: null
+  type: Bool
+  verbose_name: Graded
+- advanced_data_type: null
+  column_name: visualization_bucket
+  description: null
+  expression: null
+  extra: {}
+  filterable: true
+  groupby: true
+  is_active: true
+  is_dttm: false
+  python_date_format: null
+  type: String
+  verbose_name: Visualization Bucket
+- advanced_data_type: null
+  column_name: video_id
+  description: null
+  expression: null
+  extra: {}
+  filterable: true
+  groupby: true
+  is_active: true
+  is_dttm: false
+  python_date_format: null
+  type: String
+  verbose_name: Video ID
 database_uuid: 21174b6c-4d40-4958-8161-d6c3cf5e77b6
 default_endpoint: null
 description: null
@@ -130,7 +190,8 @@ metrics:
   d3format: null
   description: null
   expression: COUNT(*)
-  extra: null
+  extra:
+    warning_markdown: ''
   metric_name: count
   metric_type: count
   verbose_name: COUNT(*)

--- a/tutoraspects/templates/aspects/build/aspects-superset/openedx-assets/assets/datasets/fact_video_plays.yaml
+++ b/tutoraspects/templates/aspects/build/aspects-superset/openedx-assets/assets/datasets/fact_video_plays.yaml
@@ -15,6 +15,30 @@ columns:
   type: String
   verbose_name: Video Name With Location
 - advanced_data_type: null
+  column_name: video_position
+  description: null
+  expression: ''
+  extra: {}
+  filterable: true
+  groupby: true
+  is_active: true
+  is_dttm: false
+  python_date_format: null
+  type: Decimal(9, 2)
+  verbose_name: Video Position
+- advanced_data_type: null
+  column_name: video_duration
+  description: null
+  expression: ''
+  extra: {}
+  filterable: true
+  groupby: true
+  is_active: true
+  is_dttm: false
+  python_date_format: null
+  type: Int64
+  verbose_name: Video Duration
+- advanced_data_type: null
   column_name: actor_id
   description: null
   expression: ''
@@ -26,6 +50,18 @@ columns:
   python_date_format: null
   type: String
   verbose_name: Actor ID
+- advanced_data_type: null
+  column_name: visualization_bucket
+  description: null
+  expression: ''
+  extra: {}
+  filterable: true
+  groupby: true
+  is_active: true
+  is_dttm: false
+  python_date_format: null
+  type: String
+  verbose_name: Visualization Bucket
 - advanced_data_type: null
   column_name: course_key
   description: null
@@ -75,6 +111,18 @@ columns:
   type: DateTime
   verbose_name: Emission Time
 - advanced_data_type: null
+  column_name: video_id
+  description: null
+  expression: ''
+  extra: {}
+  filterable: true
+  groupby: true
+  is_active: true
+  is_dttm: false
+  python_date_format: null
+  type: String
+  verbose_name: Video ID
+- advanced_data_type: null
   column_name: video_name
   description: null
   expression: ''
@@ -87,17 +135,17 @@ columns:
   type: String
   verbose_name: Video Name
 - advanced_data_type: null
-  column_name: video_position
+  column_name: graded
   description: null
-  expression: null
+  expression: ''
   extra: {}
   filterable: true
   groupby: true
   is_active: true
   is_dttm: false
   python_date_format: null
-  type: Decimal(9, 2)
-  verbose_name: Video Position
+  type: Bool
+  verbose_name: Graded
 - advanced_data_type: null
   column_name: org
   description: null
@@ -110,54 +158,6 @@ columns:
   python_date_format: null
   type: String
   verbose_name: Organization
-- advanced_data_type: null
-  column_name: video_duration
-  description: null
-  expression: null
-  extra: {}
-  filterable: true
-  groupby: true
-  is_active: true
-  is_dttm: false
-  python_date_format: null
-  type: Int64
-  verbose_name: Video Duration
-- advanced_data_type: null
-  column_name: graded
-  description: null
-  expression: null
-  extra: {}
-  filterable: true
-  groupby: true
-  is_active: true
-  is_dttm: false
-  python_date_format: null
-  type: Bool
-  verbose_name: Graded
-- advanced_data_type: null
-  column_name: visualization_bucket
-  description: null
-  expression: null
-  extra: {}
-  filterable: true
-  groupby: true
-  is_active: true
-  is_dttm: false
-  python_date_format: null
-  type: String
-  verbose_name: Visualization Bucket
-- advanced_data_type: null
-  column_name: video_id
-  description: null
-  expression: null
-  extra: {}
-  filterable: true
-  groupby: true
-  is_active: true
-  is_dttm: false
-  python_date_format: null
-  type: String
-  verbose_name: Video ID
 database_uuid: 21174b6c-4d40-4958-8161-d6c3cf5e77b6
 default_endpoint: null
 description: null

--- a/tutoraspects/templates/aspects/build/aspects-superset/openedx-assets/assets/datasets/fact_video_plays.yaml
+++ b/tutoraspects/templates/aspects/build/aspects-superset/openedx-assets/assets/datasets/fact_video_plays.yaml
@@ -1,10 +1,11 @@
 _file_name: fact_video_plays.yaml
+always_filter_main_dttm: false
 cache_timeout: null
 columns:
 - advanced_data_type: null
   column_name: video_name_with_location
   description: null
-  expression: null
+  expression: ''
   extra: {}
   filterable: true
   groupby: true
@@ -16,7 +17,7 @@ columns:
 - advanced_data_type: null
   column_name: actor_id
   description: null
-  expression: null
+  expression: ''
   extra: {}
   filterable: true
   groupby: true
@@ -28,7 +29,7 @@ columns:
 - advanced_data_type: null
   column_name: course_key
   description: null
-  expression: null
+  expression: ''
   extra: {}
   filterable: true
   groupby: true
@@ -40,7 +41,7 @@ columns:
 - advanced_data_type: null
   column_name: course_name
   description: null
-  expression: null
+  expression: ''
   extra: {}
   filterable: true
   groupby: true
@@ -52,7 +53,7 @@ columns:
 - advanced_data_type: null
   column_name: course_run
   description: null
-  expression: null
+  expression: ''
   extra: {}
   filterable: true
   groupby: true
@@ -64,7 +65,7 @@ columns:
 - advanced_data_type: null
   column_name: emission_time
   description: null
-  expression: null
+  expression: ''
   extra: {}
   filterable: true
   groupby: true
@@ -76,7 +77,7 @@ columns:
 - advanced_data_type: null
   column_name: video_name
   description: null
-  expression: null
+  expression: ''
   extra: {}
   filterable: true
   groupby: true
@@ -88,7 +89,7 @@ columns:
 - advanced_data_type: null
   column_name: org
   description: null
-  expression: null
+  expression: ''
   extra: {}
   filterable: true
   groupby: true
@@ -103,7 +104,7 @@ description: null
 extra: {}
 fetch_values_predicate: null
 filter_select_enabled: false
-main_dttm_col: null
+main_dttm_col: emission_time
 metrics:
 - currency: null
   d3format: null
@@ -124,6 +125,15 @@ metrics:
   metric_name: total_plays
   metric_type: null
   verbose_name: Total plays
+  warning_text: null
+- currency: null
+  d3format: null
+  description: null
+  expression: COUNT(*)
+  extra: null
+  metric_name: count
+  metric_type: count
+  verbose_name: COUNT(*)
   warning_text: null
 normalize_columns: true
 offset: 0

--- a/tutoraspects/templates/aspects/build/aspects-superset/openedx-assets/assets/datasets/fact_watched_video_segments.yaml
+++ b/tutoraspects/templates/aspects/build/aspects-superset/openedx-assets/assets/datasets/fact_watched_video_segments.yaml
@@ -1,10 +1,11 @@
 _file_name: fact_watched_video_segments.yaml
+always_filter_main_dttm: false
 cache_timeout: null
 columns:
 - advanced_data_type: null
   column_name: video_name_with_location
   description: null
-  expression: null
+  expression: ''
   extra: {}
   filterable: true
   groupby: true
@@ -16,19 +17,19 @@ columns:
 - advanced_data_type: null
   column_name: segment_start
   description: null
-  expression: null
+  expression: ''
   extra: {}
   filterable: true
   groupby: true
   is_active: true
   is_dttm: false
   python_date_format: null
-  type: Int32
+  type: Int64
   verbose_name: Segment Start
 - advanced_data_type: null
   column_name: actor_id
   description: null
-  expression: null
+  expression: ''
   extra: {}
   filterable: true
   groupby: true
@@ -40,7 +41,7 @@ columns:
 - advanced_data_type: null
   column_name: started_at
   description: null
-  expression: null
+  expression: ''
   extra: {}
   filterable: true
   groupby: true
@@ -52,7 +53,7 @@ columns:
 - advanced_data_type: null
   column_name: course_key
   description: null
-  expression: null
+  expression: ''
   extra: {}
   filterable: true
   groupby: true
@@ -64,7 +65,7 @@ columns:
 - advanced_data_type: null
   column_name: course_name
   description: null
-  expression: null
+  expression: ''
   extra: {}
   filterable: true
   groupby: true
@@ -76,7 +77,7 @@ columns:
 - advanced_data_type: null
   column_name: course_run
   description: null
-  expression: null
+  expression: ''
   extra: {}
   filterable: true
   groupby: true
@@ -88,7 +89,7 @@ columns:
 - advanced_data_type: null
   column_name: video_name
   description: null
-  expression: null
+  expression: ''
   extra: {}
   filterable: true
   groupby: true
@@ -100,7 +101,7 @@ columns:
 - advanced_data_type: null
   column_name: org
   description: null
-  expression: null
+  expression: ''
   extra: {}
   filterable: true
   groupby: true
@@ -115,7 +116,7 @@ description: null
 extra: {}
 fetch_values_predicate: null
 filter_select_enabled: false
-main_dttm_col: null
+main_dttm_col: started_at
 metrics:
 - currency: null
   d3format: null

--- a/tutoraspects/templates/aspects/build/aspects-superset/openedx-assets/assets/datasets/hints_per_success.yaml
+++ b/tutoraspects/templates/aspects/build/aspects-superset/openedx-assets/assets/datasets/hints_per_success.yaml
@@ -1,10 +1,11 @@
 _file_name: hints_per_success.yaml
+always_filter_main_dttm: false
 cache_timeout: null
 columns:
 - advanced_data_type: null
   column_name: problem_name_with_location
   description: null
-  expression: null
+  expression: ''
   extra: {}
   filterable: true
   groupby: true
@@ -16,7 +17,7 @@ columns:
 - advanced_data_type: null
   column_name: total_hints
   description: null
-  expression: null
+  expression: ''
   extra: {}
   filterable: true
   groupby: true
@@ -28,7 +29,7 @@ columns:
 - advanced_data_type: null
   column_name: actor_id
   description: null
-  expression: null
+  expression: ''
   extra: {}
   filterable: true
   groupby: true
@@ -40,7 +41,7 @@ columns:
 - advanced_data_type: null
   column_name: course_key
   description: null
-  expression: null
+  expression: ''
   extra: {}
   filterable: true
   groupby: true
@@ -52,7 +53,7 @@ columns:
 - advanced_data_type: null
   column_name: course_name
   description: null
-  expression: null
+  expression: ''
   extra: {}
   filterable: true
   groupby: true
@@ -64,7 +65,7 @@ columns:
 - advanced_data_type: null
   column_name: course_run
   description: null
-  expression: null
+  expression: ''
   extra: {}
   filterable: true
   groupby: true
@@ -76,7 +77,7 @@ columns:
 - advanced_data_type: null
   column_name: problem_name
   description: null
-  expression: null
+  expression: ''
   extra: {}
   filterable: true
   groupby: true
@@ -88,7 +89,7 @@ columns:
 - advanced_data_type: null
   column_name: org
   description: null
-  expression: null
+  expression: ''
   extra: {}
   filterable: true
   groupby: true
@@ -105,6 +106,15 @@ fetch_values_predicate: null
 filter_select_enabled: false
 main_dttm_col: null
 metrics:
+- currency: null
+  d3format: null
+  description: null
+  expression: COUNT(*)
+  extra: null
+  metric_name: count
+  metric_type: count
+  verbose_name: COUNT(*)
+  warning_text: null
 - currency: null
   d3format: null
   description: null

--- a/tutoraspects/templates/aspects/build/aspects-superset/openedx-assets/assets/datasets/posts_per_user.yaml
+++ b/tutoraspects/templates/aspects/build/aspects-superset/openedx-assets/assets/datasets/posts_per_user.yaml
@@ -1,10 +1,11 @@
 _file_name: posts_per_user.yaml
+always_filter_main_dttm: false
 cache_timeout: null
 columns:
 - advanced_data_type: null
   column_name: num_posts
   description: null
-  expression: null
+  expression: ''
   extra: {}
   filterable: true
   groupby: true
@@ -16,7 +17,7 @@ columns:
 - advanced_data_type: null
   column_name: actor_id
   description: null
-  expression: null
+  expression: ''
   extra: {}
   filterable: true
   groupby: true
@@ -28,7 +29,7 @@ columns:
 - advanced_data_type: null
   column_name: course_key
   description: null
-  expression: null
+  expression: ''
   extra: {}
   filterable: true
   groupby: true
@@ -40,7 +41,7 @@ columns:
 - advanced_data_type: null
   column_name: course_name
   description: null
-  expression: null
+  expression: ''
   extra: {}
   filterable: true
   groupby: true
@@ -52,7 +53,7 @@ columns:
 - advanced_data_type: null
   column_name: course_run
   description: null
-  expression: null
+  expression: ''
   extra: {}
   filterable: true
   groupby: true
@@ -64,7 +65,7 @@ columns:
 - advanced_data_type: null
   column_name: org
   description: null
-  expression: null
+  expression: ''
   extra: {}
   filterable: true
   groupby: true
@@ -89,6 +90,15 @@ metrics:
   metric_name: users
   metric_type: null
   verbose_name: Number Of Users
+  warning_text: null
+- currency: null
+  d3format: null
+  description: null
+  expression: COUNT(*)
+  extra: null
+  metric_name: count
+  metric_type: count
+  verbose_name: COUNT(*)
   warning_text: null
 normalize_columns: true
 offset: 0

--- a/tutoraspects/templates/aspects/build/aspects-superset/openedx-assets/assets/datasets/superset_action_log.yaml
+++ b/tutoraspects/templates/aspects/build/aspects-superset/openedx-assets/assets/datasets/superset_action_log.yaml
@@ -190,7 +190,7 @@ metrics:
 normalize_columns: false
 offset: 0
 params: null
-schema: main
+schema: superset
 sql: |-
   {% filter indent(width=2) %}{% include 'openedx-assets/queries/superset_action_log.sql' %}{% endfilter %}
 table_name: superset_action_log

--- a/tutoraspects/templates/aspects/build/aspects-superset/requirements.txt
+++ b/tutoraspects/templates/aspects/build/aspects-superset/requirements.txt
@@ -1,4 +1,4 @@
 authlib  # OAuth2
-clickhouse-connect>0.5,<0.6
+clickhouse-connect>0.5,<1.0
 sentry-sdk[flask]
 urllib3>=1.26.15,<2

--- a/tutoraspects/templates/openedx-assets/queries/fact_learner_problem_course_summary.sql
+++ b/tutoraspects/templates/openedx-assets/queries/fact_learner_problem_course_summary.sql
@@ -86,10 +86,10 @@ WITH problem_responses AS (
     FROM int_problem_results
     WHERE 1=1
     {% raw %}
-    {% if from_dttm is not none %}
+    {% if from_dttm %}
     and emission_time > '{{ from_dttm }}'
     {% endif %}
-    {% if to_dttm is not none %}
+    {% if to_dttm %}
     and emission_time < '{{ to_dttm }}'
     {% endif %}
     {% endraw %}
@@ -109,10 +109,10 @@ WITH problem_responses AS (
     FROM {{ DBT_PROFILE_TARGET_DATABASE }}.int_problem_hints
     WHERE 1=1
     {% raw %}
-    {% if from_dttm is not none %}
+    {% if from_dttm %}
     and emission_time > '{{ from_dttm }}'
     {% endif %}
-    {% if to_dttm is not none %}
+    {% if to_dttm %}
     and emission_time < '{{ to_dttm }}'
     {% endif %}
     {% endraw %}

--- a/tutoraspects/templates/openedx-assets/queries/fact_pageview_engagement.sql
+++ b/tutoraspects/templates/openedx-assets/queries/fact_pageview_engagement.sql
@@ -20,10 +20,10 @@ with
         where
             1 = 1
             {% raw %}
-            {% if from_dttm is not none %}
+            {% if from_dttm %}
                 and visited_on > date('{{ from_dttm }}')
             {% endif %}
-            {% if to_dttm is not none %}
+            {% if to_dttm %}
                 and visited_on < date('{{ to_dttm }}')
             {% endif %}
             {% endraw %}

--- a/tutoraspects/templates/openedx-assets/queries/fact_problem_engagement.sql
+++ b/tutoraspects/templates/openedx-assets/queries/fact_problem_engagement.sql
@@ -20,10 +20,10 @@ with
         where
             1 = 1
             {% raw %}
-            {% if from_dttm is not none %}
+            {% if from_dttm %}
                 and attempted_on > date('{{ from_dttm }}')
             {% endif %}
-            {% if to_dttm is not none %}
+            {% if to_dttm %}
                 and attempted_on < date('{{ to_dttm }}')
             {% endif %}
             {% endraw %}

--- a/tutoraspects/templates/openedx-assets/queries/fact_video_engagement.sql
+++ b/tutoraspects/templates/openedx-assets/queries/fact_video_engagement.sql
@@ -19,10 +19,10 @@ with
         where
             1 = 1
             {% raw %}
-            {% if from_dttm is not none %}
+            {% if from_dttm %}
                 and viewed_on > date('{{ from_dttm }}')
             {% endif %}
-            {% if to_dttm is not none %}
+            {% if to_dttm %}
                 and viewed_on < date('{{ to_dttm }}')
             {% endif %}
             {% endraw %}

--- a/tutoraspects/templates/openedx-assets/queries/fact_video_plays.sql
+++ b/tutoraspects/templates/openedx-assets/queries/fact_video_plays.sql
@@ -15,12 +15,5 @@ where
 )
 
 select
-    emission_time,
-    org,
-    course_key,
-    course_name,
-    course_run,
-    video_name,
-    video_name_with_location,
-    actor_id
+    *
 from plays

--- a/tutoraspects/templates/openedx-assets/queries/posts_per_user.sql
+++ b/tutoraspects/templates/openedx-assets/queries/posts_per_user.sql
@@ -10,10 +10,10 @@ from
 where
     1=1
     {% raw %}
-    {% if from_dttm is not none %}
+    {% if from_dttm %}
     and emission_time > '{{ from_dttm }}'
     {% endif %}
-    {% if to_dttm is not none %}
+    {% if to_dttm %}
     and emission_time < '{{ to_dttm }}'
     {% endif %}
     {% endraw %}


### PR DESCRIPTION
### Description

This PR upgrades the superset version to v4.0.0.
This PR also:
- Automatically refresh datasets on import which will load the most recent columns (and remove old ones) on datasets
- fixes an issue with the `from_dttm` SQL template