### PR TITLE
feat: import new course dashboard V1

### DIFF
--- a/tutoraspects/templates/aspects/apps/superset/pythonpath/create_assets.py
+++ b/tutoraspects/templates/aspects/apps/superset/pythonpath/create_assets.py
@@ -19,7 +19,7 @@ from superset.connectors.sqla.models import SqlaTable
 from superset.utils.database import get_or_create_db
 from superset.models.embedded_dashboard import EmbeddedDashboard
 from pythonpath.localization import get_translation
-
+from pythonpath.create_row_level_security import create_rls_filters
 BASE_DIR = "/app/assets/superset"
 
 ASSET_FOLDER_MAPPING = {
@@ -93,6 +93,7 @@ def create_assets():
     update_dashboard_roles(roles)
     update_embeddable_uuids()
     update_datasets()
+    create_rls_filters()
 
 
 def import_databases():

--- a/tutoraspects/templates/aspects/apps/superset/pythonpath/create_row_level_security.py
+++ b/tutoraspects/templates/aspects/apps/superset/pythonpath/create_row_level_security.py
@@ -1,8 +1,3 @@
-from superset.app import create_app
-
-app = create_app()
-app.app_context().push()
-
 from superset.connectors.sqla.models import (
     RLSFilterRoles,
     RowLevelSecurityFilter,
@@ -15,100 +10,34 @@ session = security_manager.get_session()
 
 ## https://docs.preset.io/docs/row-level-security-rls
 
-VIRTUAL_TABLE_SCHEMA = "main"
+XAPI_SCHEMA = "{{ ASPECTS_XAPI_DATABASE }}"
+DBT_SCHEMA = "{{ DBT_PROFILE_TARGET_DATABASE }}"
+EVENT_SINK_SCHEMA = "{{ ASPECTS_EVENT_SINK_DATABASE }}"
+
 
 SECURITY_FILTERS = [
     {
-        "schema": VIRTUAL_TABLE_SCHEMA,
-        "table_name": "{{ASPECTS_XAPI_TABLE}}",
+        "name": f"can_view_courses_{XAPI_SCHEMA}",
+        "schema": XAPI_SCHEMA,
+        "exclude": [],
         "role_name": "{{SUPERSET_ROLES_MAPPING.instructor}}",
         "group_key": "{{SUPERSET_ROW_LEVEL_SECURITY_XAPI_GROUP_KEY}}",
         "clause": '{% raw %}{{can_view_courses(current_username(), "splitByChar(\'/\', course_id)[-1]")}}{% endraw %}',
-        "filter_type": "Regular",
+        "filter_type": "Regular"
     },
     {
-        "schema": VIRTUAL_TABLE_SCHEMA,
-        "table_name": "fact_enrollments_by_day",
+        "name": f"can_view_courses_{EVENT_SINK_SCHEMA}",
+        "schema": EVENT_SINK_SCHEMA,
+        "exclude": ["user_pii"],
         "role_name": "{{SUPERSET_ROLES_MAPPING.instructor}}",
         "group_key": "{{SUPERSET_ROW_LEVEL_SECURITY_XAPI_GROUP_KEY}}",
         "clause": '{% raw %}{{can_view_courses(current_username(), "course_key")}}{% endraw %}',
         "filter_type": "Regular"
     },
     {
-        "schema": VIRTUAL_TABLE_SCHEMA,
-        "table_name": "fact_enrollments",
-        "role_name": "{{SUPERSET_ROLES_MAPPING.instructor}}",
-        "group_key": "{{SUPERSET_ROW_LEVEL_SECURITY_XAPI_GROUP_KEY}}",
-        "clause": '{% raw %}{{can_view_courses(current_username(), "course_key")}}{% endraw %}',
-        "filter_type": "Regular"
-    },
-    {
-        "schema": VIRTUAL_TABLE_SCHEMA,
-        "table_name": "fact_learner_problem_summary",
-        "role_name": "{{SUPERSET_ROLES_MAPPING.instructor}}",
-        "group_key": "{{SUPERSET_ROW_LEVEL_SECURITY_XAPI_GROUP_KEY}}",
-        "clause": '{% raw %}{{can_view_courses(current_username(), "course_key")}}{% endraw %}',
-        "filter_type": "Regular"
-    },
-    {
-        "schema": VIRTUAL_TABLE_SCHEMA,
-        "table_name": "fact_problem_responses",
-        "role_name": "{{SUPERSET_ROLES_MAPPING.instructor}}",
-        "group_key": "{{SUPERSET_ROW_LEVEL_SECURITY_XAPI_GROUP_KEY}}",
-        "clause": '{% raw %}{{can_view_courses(current_username(), "course_key")}}{% endraw %}',
-        "filter_type": "Regular"
-    },
-    {
-        "schema": VIRTUAL_TABLE_SCHEMA,
-        "table_name": "fact_transcript_usage",
-        "role_name": "{{SUPERSET_ROLES_MAPPING.instructor}}",
-        "group_key": "{{SUPERSET_ROW_LEVEL_SECURITY_XAPI_GROUP_KEY}}",
-        "clause": '{% raw %}{{can_view_courses(current_username(), "course_key")}}{% endraw %}',
-        "filter_type": "Regular"
-    },
-    {
-        "schema": VIRTUAL_TABLE_SCHEMA,
-        "table_name": "fact_video_plays",
-        "role_name": "{{SUPERSET_ROLES_MAPPING.instructor}}",
-        "group_key": "{{SUPERSET_ROW_LEVEL_SECURITY_XAPI_GROUP_KEY}}",
-        "clause": '{% raw %}{{can_view_courses(current_username(), "course_key")}}{% endraw %}',
-        "filter_type": "Regular"
-    },
-    {
-        "schema": VIRTUAL_TABLE_SCHEMA,
-        "table_name": "fact_watched_video_segments",
-        "role_name": "{{SUPERSET_ROLES_MAPPING.instructor}}",
-        "group_key": "{{SUPERSET_ROW_LEVEL_SECURITY_XAPI_GROUP_KEY}}",
-        "clause": '{% raw %}{{can_view_courses(current_username(), "course_key")}}{% endraw %}',
-        "filter_type": "Regular"
-    },
-    {
-        "schema": VIRTUAL_TABLE_SCHEMA,
-        "table_name": "hints_per_success",
-        "role_name": "{{SUPERSET_ROLES_MAPPING.instructor}}",
-        "group_key": "{{SUPERSET_ROW_LEVEL_SECURITY_XAPI_GROUP_KEY}}",
-        "clause": '{% raw %}{{can_view_courses(current_username(), "course_key")}}{% endraw %}',
-        "filter_type": "Regular"
-    },
-    {
-        "schema": VIRTUAL_TABLE_SCHEMA,
-        "table_name": "course_names",
-        "role_name": "{{SUPERSET_ROLES_MAPPING.instructor}}",
-        "group_key": "{{SUPERSET_ROW_LEVEL_SECURITY_XAPI_GROUP_KEY}}",
-        "clause": '{% raw %}{{can_view_courses(current_username(), "course_key")}}{% endraw %}',
-        "filter_type": "Regular"
-    },
-    {
-        "schema": VIRTUAL_TABLE_SCHEMA,
-        "table_name": "course_overviews",
-        "role_name": "{{SUPERSET_ROLES_MAPPING.instructor}}",
-        "group_key": "{{SUPERSET_ROW_LEVEL_SECURITY_XAPI_GROUP_KEY}}",
-        "clause": '{% raw %}{{can_view_courses(current_username(), "course_key")}}{% endraw %}',
-        "filter_type": "Regular"
-    },
-    {
-        "schema": VIRTUAL_TABLE_SCHEMA,
-        "table_name": "course_blocks",
+        "name": f"can_view_courses_{DBT_SCHEMA}",
+        "schema": DBT_SCHEMA,
+        "exclude": [],
         "role_name": "{{SUPERSET_ROLES_MAPPING.instructor}}",
         "group_key": "{{SUPERSET_ROW_LEVEL_SECURITY_XAPI_GROUP_KEY}}",
         "clause": '{% raw %}{{can_view_courses(current_username(), "course_key")}}{% endraw %}',
@@ -118,67 +47,57 @@ SECURITY_FILTERS = [
 
 {{patch("superset-row-level-security") | indent(4)}}
 
-
-for security_filter in SECURITY_FILTERS:
-    # Fetch the table we want to restrict access to
-    (
-        schema,
-        table_name,
-        role_name,
-        group_key,
-        clause,
-        filter_type,
-    ) = security_filter.values()
-    table = (
-        session.query(SqlaTable)
-        .filter(SqlaTable.schema == schema)
-        .filter(SqlaTable.table_name == table_name)
-        .first()
-    )
-
-    assert table, (f"{schema}.{table_name} table doesn't exist. If you have changed "
-                   "your database (schema) name, you will need to update the database "
-                   "connection and dataset schema entries in the Superset UI or "
-                   "database. You may also need to rebuild your aspects-superset "
-                   "image after changes.")
-
-    role = session.query(Role).filter(Role.name == role_name).first()
-    assert role, f"{role_name} role doesn't exist yet?"
-    # See if the Row Level Security Filter already exists
-    rlsf = (
-        session.query(RowLevelSecurityFilter)
-        .filter(RLSFilterRoles.c.role_id.in_((role.id,)))
-        .filter(RowLevelSecurityFilter.group_key == group_key)
-        .filter(RowLevelSecurityFilter.tables.any(id=table.id))
-    ).first()
-    # If it doesn't already exist, create one
-    if rlsf:
-        create = False
-    else:
-        create = True
-        rlsf = RowLevelSecurityFilter()
-    # Sync the fields to our expectations
-    rlsf.filter_type = filter_type
-    rlsf.group_key = group_key
-    rlsf.tables = [table]
-    rlsf.clause = clause
-    rlsf.name = f"{table.table_name} - {role.name}"
-    # Create if needed
-    if create:
-        session.add(rlsf)
-        # ...and commit, so we are sure to have an rlsf.id
-        session.commit()
-    # Add the filter role if needed
-    rls_filter_roles = (
-        session.query(RLSFilterRoles)
-        .filter(RLSFilterRoles.c.role_id == role.id)
-        .filter(RLSFilterRoles.c.rls_filter_id == rlsf.id)
-    )
-
-    if not rls_filter_roles.count():
-        session.execute(
-            RLSFilterRoles.insert(), [dict(role_id=role.id, rls_filter_id=rlsf.id)]
+def create_rls_filters():
+    for security_filter in SECURITY_FILTERS:
+        # Fetch the table we want to restrict access to
+        (
+            name,
+            schema,
+            exclude,
+            role_name,
+            group_key,
+            clause,
+            filter_type,
+        ) = security_filter.values()
+        tables = (
+            session.query(SqlaTable)
+            .filter(SqlaTable.schema == schema)
+            .filter(SqlaTable.table_name.not_in(exclude))
+            .all()
         )
-        session.commit()
+        print(f"Creating RLS filter {name} for {schema} schema")
 
-print("Successfully create row-level security filters.")
+        role = session.query(Role).filter(Role.name == role_name).first()
+        assert role, f"{role_name} role doesn't exist yet?"
+        # See if the Row Level Security Filter already exists
+        rlsf = (
+            session.query(RowLevelSecurityFilter)
+            .filter(RowLevelSecurityFilter.group_key == group_key)
+            .filter(RowLevelSecurityFilter.name == name)
+        ).first()
+        # If it doesn't already exist, create one
+        if not rlsf:
+            rlsf = RowLevelSecurityFilter()
+        # Sync the fields to our expectations
+        rlsf.filter_type = filter_type
+        rlsf.group_key = group_key
+        rlsf.tables = tables
+        rlsf.clause = clause
+        rlsf.name = name
+
+        session.add(rlsf)
+        session.commit()
+        # Add the filter role if needed
+        rls_filter_roles = (
+            session.query(RLSFilterRoles)
+            .filter(RLSFilterRoles.c.role_id == role.id)
+            .filter(RLSFilterRoles.c.rls_filter_id == rlsf.id)
+        )
+
+        if not rls_filter_roles.count():
+            session.execute(
+                RLSFilterRoles.insert(), [dict(role_id=role.id, rls_filter_id=rlsf.id)]
+            )
+            session.commit()
+
+    print("Successfully create row-level security filters.")

--- a/tutoraspects/templates/aspects/build/aspects-superset/openedx-assets/assets/charts/Active_Users_Over_Time_v2.yaml
+++ b/tutoraspects/templates/aspects/build/aspects-superset/openedx-assets/assets/charts/Active_Users_Over_Time_v2.yaml
@@ -11,6 +11,7 @@ params:
     expressionType: SIMPLE
     operator: TEMPORAL_RANGE
     subject: emission_time
+  annotation_layers: []
   color_picker:
     a: 1
     b: 135
@@ -36,6 +37,7 @@ params:
   viz_type: big_number
   x_axis: emission_time
   y_axis_format: SMART_NUMBER
+query_context: null
 slice_name: Active Users Over Time v2
 uuid: e1d619a2-6238-4264-a000-6b6856027edd
 version: 1.0.0

--- a/tutoraspects/templates/aspects/build/aspects-superset/openedx-assets/assets/charts/Active_Users_Per_Organization.yaml
+++ b/tutoraspects/templates/aspects/build/aspects-superset/openedx-assets/assets/charts/Active_Users_Per_Organization.yaml
@@ -11,6 +11,7 @@ params:
     expressionType: SIMPLE
     operator: TEMPORAL_RANGE
     subject: emission_time
+  annotation_layers: []
   color_scheme: supersetColors
   date_format: smart_date
   extra_form_data: {}
@@ -54,6 +55,7 @@ params:
   show_legend: true
   sort_by_metric: true
   viz_type: pie
+query_context: null
 slice_name: Active Users Per Organization
 uuid: 02af00f5-6539-428f-b3ab-632997de7528
 version: 1.0.0

--- a/tutoraspects/templates/aspects/build/aspects-superset/openedx-assets/assets/charts/Chart_Count.yaml
+++ b/tutoraspects/templates/aspects/build/aspects-superset/openedx-assets/assets/charts/Chart_Count.yaml
@@ -6,6 +6,7 @@ dataset_uuid: aaf1ae12-73c1-4b88-b07d-7a8988333018
 description: Count of charts created in Superset over the selected time period.
 params:
   adhoc_filters: []
+  annotation_layers: []
   color_picker:
     a: 1
     b: 150
@@ -30,6 +31,7 @@ params:
   url_params: {}
   viz_type: big_number
   y_axis_format: SMART_NUMBER
+query_context: null
 slice_name: Chart Count
 uuid: a5e0f18b-fb83-4d65-81e0-5f0e620fa05b
 version: 1.0.0

--- a/tutoraspects/templates/aspects/build/aspects-superset/openedx-assets/assets/charts/Charts_by_Type.yaml
+++ b/tutoraspects/templates/aspects/build/aspects-superset/openedx-assets/assets/charts/Charts_by_Type.yaml
@@ -7,6 +7,7 @@ description: Count of the various types of charts created in Superset over the s
   time period.
 params:
   adhoc_filters: []
+  annotation_layers: []
   color_scheme: htg_color_scheme
   date_format: smart_date
   extra_form_data: {}
@@ -25,6 +26,7 @@ params:
   - exclusive
   url_params: {}
   viz_type: treemap_v2
+query_context: null
 slice_name: Charts by Type
 uuid: 84393abe-04ab-4084-a195-116ad568badd
 version: 1.0.0

--- a/tutoraspects/templates/aspects/build/aspects-superset/openedx-assets/assets/charts/ClickHouse_metrics.yaml
+++ b/tutoraspects/templates/aspects/build/aspects-superset/openedx-assets/assets/charts/ClickHouse_metrics.yaml
@@ -10,6 +10,7 @@ params:
   - name
   - value
   - description
+  annotation_layers: []
   color_pn: true
   extra_form_data: {}
   groupby: []
@@ -24,6 +25,7 @@ params:
   temporal_columns_lookup: {}
   time_grain_sqla: P1D
   viz_type: table
+query_context: null
 slice_name: ClickHouse metrics
 uuid: 2f84cbc3-4068-4d4d-bd40-ae348e4be95d
 version: 1.0.0

--- a/tutoraspects/templates/aspects/build/aspects-superset/openedx-assets/assets/charts/Course_Enrollments_Over_Time.yaml
+++ b/tutoraspects/templates/aspects/build/aspects-superset/openedx-assets/assets/charts/Course_Enrollments_Over_Time.yaml
@@ -83,6 +83,7 @@ params:
   y_axis_title: Registrations
   y_axis_title_margin: 15
   y_axis_title_position: Left
+query_context: null
 slice_name: Course Enrollments Over Time
 uuid: bf4f4671-c276-4185-9b9a-b10864efea6c
 version: 1.0.0

--- a/tutoraspects/templates/aspects/build/aspects-superset/openedx-assets/assets/charts/Course_Information.yaml
+++ b/tutoraspects/templates/aspects/build/aspects-superset/openedx-assets/assets/charts/Course_Information.yaml
@@ -1,0 +1,184 @@
+_file_name: Course_Information.yaml
+cache_timeout: null
+certification_details: null
+certified_by: null
+dataset_uuid: 633a1d4e-cd40-482f-a5dc-d5901c2181c2
+description: null
+params:
+  adhoc_filters: []
+  all_columns: []
+  color_pn: true
+  conditional_formatting:
+  - colorScheme: '#ACE1C4'
+    column: Graded Learners
+    operator: '>'
+    targetValue: 0
+  - colorScheme: '#FDE380'
+    column: Avg Course Grade
+    operator: "\u2264 x \u2264"
+    targetValueLeft: '0.5'
+    targetValueRight: '0.7'
+  - colorScheme: '#EFA1AA'
+    column: Avg Course Grade
+    operator: <
+    targetValue: 0.5
+  - colorScheme: '#ACE1C4'
+    column: Avg Course Grade
+    operator: "\u2265"
+    targetValue: 0.7
+  - colorScheme: '#ACE1C4'
+    column: Median Course Grade
+    operator: "\u2265"
+    targetValue: 0.7
+  - colorScheme: '#FDE380'
+    column: Median Course Grade
+    operator: "\u2264 x \u2264"
+    targetValueLeft: '0.5'
+    targetValueRight: '0.7'
+  - colorScheme: '#EFA1AA'
+    column: Median Course Grade
+    operator: <
+    targetValue: 0.5
+  extra_form_data: {}
+  groupby:
+  - org
+  - course_key
+  - course_name
+  - course_run
+  metrics:
+  - aggregate: COUNT_DISTINCT
+    column:
+      advanced_data_type: null
+      certification_details: null
+      certified_by: null
+      column_name: actor_id
+      description: null
+      expression: null
+      filterable: true
+      groupby: true
+      id: 457
+      is_certified: false
+      is_dttm: false
+      python_date_format: null
+      type: STRING
+      type_generic: 1
+      verbose_name: null
+      warning_markdown: null
+    datasourceWarning: false
+    expressionType: SIMPLE
+    hasCustomLabel: true
+    label: Graded Learners
+    optionName: metric_25t7qgbwxu5_a9fbiaboytw
+    sqlExpression: null
+  - aggregate: AVG
+    column:
+      advanced_data_type: null
+      certification_details: null
+      certified_by: null
+      column_name: course_grade
+      description: null
+      expression: null
+      filterable: true
+      groupby: true
+      id: 461
+      is_certified: false
+      is_dttm: false
+      python_date_format: null
+      type: FLOAT64
+      type_generic: 0
+      verbose_name: null
+      warning_markdown: null
+    datasourceWarning: false
+    expressionType: SIMPLE
+    hasCustomLabel: true
+    label: Avg Course Grade
+    optionName: metric_i5mlkxng7kb_5auir2yzvnx
+    sqlExpression: null
+  - aggregate: null
+    column: null
+    datasourceWarning: false
+    expressionType: SQL
+    hasCustomLabel: true
+    label: Median Course Grade
+    optionName: metric_prd604bf33n_j3zxzos2g5
+    sqlExpression: 'quantile(0.5)(course_grade) '
+  order_by_cols: []
+  order_desc: true
+  percent_metrics: []
+  query_mode: aggregate
+  row_limit: 1000
+  server_page_length: 10
+  show_cell_bars: true
+  table_timestamp_format: smart_date
+  temporal_columns_lookup: {}
+  time_grain_sqla: P1D
+  viz_type: table
+query_context: "{\"datasource\":{\"id\":70,\"type\":\"table\"},\"force\":false,\"\
+  queries\":[{\"filters\":[],\"extras\":{\"time_grain_sqla\":\"P1D\",\"having\":\"\
+  \",\"where\":\"\"},\"applied_time_extras\":{},\"columns\":[\"org\",\"course_key\"\
+  ,\"course_name\",\"course_run\"],\"metrics\":[{\"aggregate\":\"COUNT_DISTINCT\"\
+  ,\"column\":{\"advanced_data_type\":null,\"certification_details\":null,\"certified_by\"\
+  :null,\"column_name\":\"actor_id\",\"description\":null,\"expression\":null,\"filterable\"\
+  :true,\"groupby\":true,\"id\":457,\"is_certified\":false,\"is_dttm\":false,\"python_date_format\"\
+  :null,\"type\":\"STRING\",\"type_generic\":1,\"verbose_name\":null,\"warning_markdown\"\
+  :null},\"datasourceWarning\":false,\"expressionType\":\"SIMPLE\",\"hasCustomLabel\"\
+  :true,\"label\":\"Graded Learners\",\"optionName\":\"metric_25t7qgbwxu5_a9fbiaboytw\"\
+  ,\"sqlExpression\":null},{\"aggregate\":\"AVG\",\"column\":{\"advanced_data_type\"\
+  :null,\"certification_details\":null,\"certified_by\":null,\"column_name\":\"course_grade\"\
+  ,\"description\":null,\"expression\":null,\"filterable\":true,\"groupby\":true,\"\
+  id\":461,\"is_certified\":false,\"is_dttm\":false,\"python_date_format\":null,\"\
+  type\":\"FLOAT64\",\"type_generic\":0,\"verbose_name\":null,\"warning_markdown\"\
+  :null},\"datasourceWarning\":false,\"expressionType\":\"SIMPLE\",\"hasCustomLabel\"\
+  :true,\"label\":\"Avg Course Grade\",\"optionName\":\"metric_i5mlkxng7kb_5auir2yzvnx\"\
+  ,\"sqlExpression\":null},{\"aggregate\":null,\"column\":null,\"datasourceWarning\"\
+  :false,\"expressionType\":\"SQL\",\"hasCustomLabel\":true,\"label\":\"Median Course\
+  \ Grade\",\"optionName\":\"metric_prd604bf33n_j3zxzos2g5\",\"sqlExpression\":\"\
+  quantile(0.5)(course_grade) \"}],\"orderby\":[[{\"aggregate\":\"COUNT_DISTINCT\"\
+  ,\"column\":{\"advanced_data_type\":null,\"certification_details\":null,\"certified_by\"\
+  :null,\"column_name\":\"actor_id\",\"description\":null,\"expression\":null,\"filterable\"\
+  :true,\"groupby\":true,\"id\":457,\"is_certified\":false,\"is_dttm\":false,\"python_date_format\"\
+  :null,\"type\":\"STRING\",\"type_generic\":1,\"verbose_name\":null,\"warning_markdown\"\
+  :null},\"datasourceWarning\":false,\"expressionType\":\"SIMPLE\",\"hasCustomLabel\"\
+  :true,\"label\":\"Graded Learners\",\"optionName\":\"metric_25t7qgbwxu5_a9fbiaboytw\"\
+  ,\"sqlExpression\":null},false]],\"annotation_layers\":[],\"row_limit\":1000,\"\
+  series_limit\":0,\"order_desc\":true,\"url_params\":{},\"custom_params\":{},\"custom_form_data\"\
+  :{},\"post_processing\":[]}],\"form_data\":{\"datasource\":\"70__table\",\"viz_type\"\
+  :\"table\",\"slice_id\":186,\"query_mode\":\"aggregate\",\"groupby\":[\"org\",\"\
+  course_key\",\"course_name\",\"course_run\"],\"time_grain_sqla\":\"P1D\",\"temporal_columns_lookup\"\
+  :{},\"metrics\":[{\"aggregate\":\"COUNT_DISTINCT\",\"column\":{\"advanced_data_type\"\
+  :null,\"certification_details\":null,\"certified_by\":null,\"column_name\":\"actor_id\"\
+  ,\"description\":null,\"expression\":null,\"filterable\":true,\"groupby\":true,\"\
+  id\":457,\"is_certified\":false,\"is_dttm\":false,\"python_date_format\":null,\"\
+  type\":\"STRING\",\"type_generic\":1,\"verbose_name\":null,\"warning_markdown\"\
+  :null},\"datasourceWarning\":false,\"expressionType\":\"SIMPLE\",\"hasCustomLabel\"\
+  :true,\"label\":\"Graded Learners\",\"optionName\":\"metric_25t7qgbwxu5_a9fbiaboytw\"\
+  ,\"sqlExpression\":null},{\"aggregate\":\"AVG\",\"column\":{\"advanced_data_type\"\
+  :null,\"certification_details\":null,\"certified_by\":null,\"column_name\":\"course_grade\"\
+  ,\"description\":null,\"expression\":null,\"filterable\":true,\"groupby\":true,\"\
+  id\":461,\"is_certified\":false,\"is_dttm\":false,\"python_date_format\":null,\"\
+  type\":\"FLOAT64\",\"type_generic\":0,\"verbose_name\":null,\"warning_markdown\"\
+  :null},\"datasourceWarning\":false,\"expressionType\":\"SIMPLE\",\"hasCustomLabel\"\
+  :true,\"label\":\"Avg Course Grade\",\"optionName\":\"metric_i5mlkxng7kb_5auir2yzvnx\"\
+  ,\"sqlExpression\":null},{\"aggregate\":null,\"column\":null,\"datasourceWarning\"\
+  :false,\"expressionType\":\"SQL\",\"hasCustomLabel\":true,\"label\":\"Median Course\
+  \ Grade\",\"optionName\":\"metric_prd604bf33n_j3zxzos2g5\",\"sqlExpression\":\"\
+  quantile(0.5)(course_grade) \"}],\"all_columns\":[],\"percent_metrics\":[],\"adhoc_filters\"\
+  :[],\"order_by_cols\":[],\"row_limit\":1000,\"server_page_length\":10,\"order_desc\"\
+  :true,\"table_timestamp_format\":\"smart_date\",\"show_cell_bars\":true,\"color_pn\"\
+  :true,\"conditional_formatting\":[{\"colorScheme\":\"#ACE1C4\",\"column\":\"Graded\
+  \ Learners\",\"operator\":\">\",\"targetValue\":0},{\"colorScheme\":\"#FDE380\"\
+  ,\"column\":\"Avg Course Grade\",\"operator\":\"\u2264 x \u2264\",\"targetValueLeft\"\
+  :\"0.5\",\"targetValueRight\":\"0.7\"},{\"colorScheme\":\"#EFA1AA\",\"column\":\"\
+  Avg Course Grade\",\"operator\":\"<\",\"targetValue\":0.5},{\"colorScheme\":\"#ACE1C4\"\
+  ,\"column\":\"Avg Course Grade\",\"operator\":\"\u2265\",\"targetValue\":0.7},{\"\
+  colorScheme\":\"#ACE1C4\",\"column\":\"Median Course Grade\",\"operator\":\"\u2265\
+  \",\"targetValue\":0.7},{\"colorScheme\":\"#FDE380\",\"column\":\"Median Course\
+  \ Grade\",\"operator\":\"\u2264 x \u2264\",\"targetValueLeft\":\"0.5\",\"targetValueRight\"\
+  :\"0.7\"},{\"colorScheme\":\"#EFA1AA\",\"column\":\"Median Course Grade\",\"operator\"\
+  :\"<\",\"targetValue\":0.5}],\"extra_form_data\":{},\"dashboards\":[16],\"force\"\
+  :false,\"result_format\":\"json\",\"result_type\":\"full\"},\"result_format\":\"\
+  json\",\"result_type\":\"full\"}"
+slice_name: Course Information
+uuid: fa249dda-78da-4ccc-9ef3-39177e6aae0c
+version: 1.0.0
+viz_type: table

--- a/tutoraspects/templates/aspects/build/aspects-superset/openedx-assets/assets/charts/Course_Information.yaml
+++ b/tutoraspects/templates/aspects/build/aspects-superset/openedx-assets/assets/charts/Course_Information.yaml
@@ -7,6 +7,7 @@ description: null
 params:
   adhoc_filters: []
   all_columns: []
+  annotation_layers: []
   color_pn: true
   conditional_formatting:
   - colorScheme: '#ACE1C4'

--- a/tutoraspects/templates/aspects/build/aspects-superset/openedx-assets/assets/charts/Courses.yaml
+++ b/tutoraspects/templates/aspects/build/aspects-superset/openedx-assets/assets/charts/Courses.yaml
@@ -6,6 +6,7 @@ dataset_uuid: 41278a97-d0ff-4645-9514-d79f80d275df
 description: null
 params:
   adhoc_filters: []
+  annotation_layers: []
   extra_form_data: {}
   granularity_sqla: emission_time
   header_font_size: 0.4
@@ -40,6 +41,7 @@ params:
   time_range: No filter
   viz_type: big_number_total
   y_axis_format: SMART_NUMBER
+query_context: null
 slice_name: Courses
 uuid: 63f86926-3325-43cf-b075-ef37f5f60413
 version: 1.0.0

--- a/tutoraspects/templates/aspects/build/aspects-superset/openedx-assets/assets/charts/Courses_Per_Organization.yaml
+++ b/tutoraspects/templates/aspects/build/aspects-superset/openedx-assets/assets/charts/Courses_Per_Organization.yaml
@@ -6,6 +6,7 @@ dataset_uuid: 41278a97-d0ff-4645-9514-d79f80d275df
 description: null
 params:
   adhoc_filters: []
+  annotation_layers: []
   color_scheme: supersetColors
   date_format: smart_date
   extra_form_data: {}
@@ -49,6 +50,7 @@ params:
   show_legend: true
   sort_by_metric: true
   viz_type: pie
+query_context: null
 slice_name: Courses Per Organization
 uuid: 12fc799d-5d02-4861-892c-4e04cbc1f87a
 version: 1.0.0

--- a/tutoraspects/templates/aspects/build/aspects-superset/openedx-assets/assets/charts/Cumulative_Enrollments_by_Track.yaml
+++ b/tutoraspects/templates/aspects/build/aspects-superset/openedx-assets/assets/charts/Cumulative_Enrollments_by_Track.yaml
@@ -1,0 +1,98 @@
+_file_name: Cumulative_Enrollments_by_Track.yaml
+cache_timeout: null
+certification_details: null
+certified_by: null
+dataset_uuid: a234545d-08ff-480d-8361-961c3d15f14f
+description: null
+params:
+  adhoc_filters:
+  - clause: WHERE
+    comparator: No filter
+    datasourceWarning: false
+    expressionType: SIMPLE
+    filterOptionName: filter_utjjqw9427d_5p5ur7mob2
+    isExtra: false
+    isNew: false
+    operator: TEMPORAL_RANGE
+    sqlExpression: null
+    subject: emission_time
+  annotation_layers: []
+  color_scheme: supersetColors
+  comparison_type: values
+  extra_form_data: {}
+  forecastInterval: 0.8
+  forecastPeriods: 10
+  groupby:
+  - enrollment_mode
+  legendMargin: null
+  legendOrientation: top
+  legendType: scroll
+  markerEnabled: true
+  markerSize: 6
+  metrics:
+  - aggregate: COUNT_DISTINCT
+    column:
+      advanced_data_type: null
+      certification_details: null
+      certified_by: null
+      column_name: actor_id
+      description: null
+      expression: null
+      filterable: true
+      groupby: true
+      id: 138
+      is_certified: false
+      is_dttm: false
+      python_date_format: null
+      type: String
+      type_generic: 1
+      verbose_name: null
+      warning_markdown: null
+    datasourceWarning: false
+    expressionType: SIMPLE
+    hasCustomLabel: true
+    label: Number of Learners
+    optionName: metric_tpdu0kpjpka_gsgo2so3eld
+    sqlExpression: null
+  only_total: true
+  opacity: 0.2
+  order_desc: true
+  rich_tooltip: true
+  rolling_type: cumsum
+  row_limit: 10000
+  seriesType: line
+  show_empty_columns: true
+  show_extra_controls: false
+  show_legend: true
+  show_value: false
+  sort_series_type: sum
+  time_grain_sqla: P1M
+  tooltipTimeFormat: smart_date
+  truncate_metric: true
+  viz_type: echarts_area
+  x_axis: emission_time
+  x_axis_sort_asc: true
+  x_axis_sort_series: name
+  x_axis_sort_series_ascending: true
+  x_axis_time_format: smart_date
+  x_axis_title_margin: 15
+  y_axis_bounds:
+  - null
+  - null
+  y_axis_format: ~g
+  y_axis_title_margin: 15
+  y_axis_title_position: Left
+  zoomable: true
+query_context: '{"datasource":{"id":12,"type":"table"},"force":false,"queries":[{"filters":[{"col":"emission_time","op":"TEMPORAL_RANGE","val":"No
+  filter"}],"extras":{"having":"","where":""},"applied_time_extras":{},"columns":[{"timeGrain":"P1M","columnType":"BASE_AXIS","sqlExpression":"emission_time","label":"emission_time","expressionType":"SQL"},"enrollment_mode"],"metrics":[{"aggregate":"COUNT_DISTINCT","column":{"advanced_data_type":null,"certification_details":null,"certified_by":null,"column_name":"actor_id","description":null,"expression":null,"filterable":true,"groupby":true,"id":138,"is_certified":false,"is_dttm":false,"python_date_format":null,"type":"String","type_generic":1,"verbose_name":null,"warning_markdown":null},"datasourceWarning":false,"expressionType":"SIMPLE","hasCustomLabel":true,"label":"Number
+  of Learners","optionName":"metric_tpdu0kpjpka_gsgo2so3eld","sqlExpression":null}],"orderby":[[{"aggregate":"COUNT_DISTINCT","column":{"advanced_data_type":null,"certification_details":null,"certified_by":null,"column_name":"actor_id","description":null,"expression":null,"filterable":true,"groupby":true,"id":138,"is_certified":false,"is_dttm":false,"python_date_format":null,"type":"String","type_generic":1,"verbose_name":null,"warning_markdown":null},"datasourceWarning":false,"expressionType":"SIMPLE","hasCustomLabel":true,"label":"Number
+  of Learners","optionName":"metric_tpdu0kpjpka_gsgo2so3eld","sqlExpression":null},false]],"annotation_layers":[],"row_limit":10000,"series_columns":["enrollment_mode"],"series_limit":0,"order_desc":true,"url_params":{},"custom_params":{},"custom_form_data":{},"time_offsets":[],"post_processing":[{"operation":"pivot","options":{"index":["emission_time"],"columns":["enrollment_mode"],"aggregates":{"Number
+  of Learners":{"operator":"mean"}},"drop_missing_columns":false}},{"operation":"cum","options":{"operator":"sum","columns":{"Number
+  of Learners":"Number of Learners"}}},{"operation":"rename","options":{"columns":{"Number
+  of Learners":null},"level":0,"inplace":true}},{"operation":"flatten"}]}],"form_data":{"datasource":"12__table","viz_type":"echarts_area","slice_id":189,"x_axis":"emission_time","time_grain_sqla":"P1M","x_axis_sort_asc":true,"x_axis_sort_series":"name","x_axis_sort_series_ascending":true,"metrics":[{"aggregate":"COUNT_DISTINCT","column":{"advanced_data_type":null,"certification_details":null,"certified_by":null,"column_name":"actor_id","description":null,"expression":null,"filterable":true,"groupby":true,"id":138,"is_certified":false,"is_dttm":false,"python_date_format":null,"type":"String","type_generic":1,"verbose_name":null,"warning_markdown":null},"datasourceWarning":false,"expressionType":"SIMPLE","hasCustomLabel":true,"label":"Number
+  of Learners","optionName":"metric_tpdu0kpjpka_gsgo2so3eld","sqlExpression":null}],"groupby":["enrollment_mode"],"adhoc_filters":[{"expressionType":"SIMPLE","subject":"emission_time","operator":"TEMPORAL_RANGE","comparator":"No
+  filter","clause":"WHERE","sqlExpression":null,"isExtra":false,"isNew":false,"datasourceWarning":false,"filterOptionName":"filter_utjjqw9427d_5p5ur7mob2"}],"order_desc":true,"row_limit":10000,"truncate_metric":true,"show_empty_columns":true,"rolling_type":"cumsum","comparison_type":"values","annotation_layers":[],"forecastPeriods":10,"forecastInterval":0.8,"x_axis_title_margin":15,"y_axis_title_margin":15,"y_axis_title_position":"Left","sort_series_type":"sum","color_scheme":"supersetColors","seriesType":"line","opacity":0.2,"show_value":false,"only_total":true,"show_extra_controls":false,"markerEnabled":true,"markerSize":6,"zoomable":true,"show_legend":true,"legendType":"scroll","legendOrientation":"top","legendMargin":null,"x_axis_time_format":"smart_date","rich_tooltip":true,"tooltipTimeFormat":"smart_date","y_axis_format":"~g","y_axis_bounds":[null,null],"extra_form_data":{},"dashboards":[16],"force":false,"result_format":"json","result_type":"full"},"result_format":"json","result_type":"full"}'
+slice_name: Cumulative Enrollments by Track
+uuid: f207c896-030a-462b-b69f-6416230d50b6
+version: 1.0.0
+viz_type: echarts_area

--- a/tutoraspects/templates/aspects/build/aspects-superset/openedx-assets/assets/charts/Cumulative_Interactions.yaml
+++ b/tutoraspects/templates/aspects/build/aspects-superset/openedx-assets/assets/charts/Cumulative_Interactions.yaml
@@ -1,0 +1,118 @@
+_file_name: Cumulative_Interactions.yaml
+cache_timeout: null
+certification_details: null
+certified_by: null
+dataset_uuid: 1b1cbf0a-1193-4251-ad52-724c2f0190ae
+description: null
+params:
+  adhoc_filters:
+  - clause: WHERE
+    comparator: No filter
+    expressionType: SIMPLE
+    operator: TEMPORAL_RANGE
+    subject: visited_on
+  annotation_layers: []
+  color_scheme: supersetColors
+  comparison_type: values
+  extra_form_data: {}
+  forecastInterval: 0.8
+  forecastPeriods: 10
+  groupby: []
+  legendMargin: null
+  legendOrientation: top
+  legendType: scroll
+  markerEnabled: true
+  markerSize: 7
+  metrics:
+  - aggregate: SUM
+    column:
+      advanced_data_type: null
+      certification_details: null
+      certified_by: null
+      column_name: page_count
+      description: null
+      expression: null
+      filterable: true
+      groupby: true
+      id: 468
+      is_certified: false
+      is_dttm: false
+      python_date_format: null
+      type: UINT64
+      type_generic: 0
+      verbose_name: null
+      warning_markdown: null
+    datasourceWarning: false
+    expressionType: SIMPLE
+    hasCustomLabel: true
+    label: Total Views
+    optionName: metric_42el42svy4d_vtnwv1k58f
+    sqlExpression: null
+  - aggregate: COUNT_DISTINCT
+    column:
+      advanced_data_type: null
+      certification_details: null
+      certified_by: null
+      column_name: actor_id
+      description: null
+      expression: null
+      filterable: true
+      groupby: true
+      id: 469
+      is_certified: false
+      is_dttm: false
+      python_date_format: null
+      type: STRING
+      type_generic: 1
+      verbose_name: null
+      warning_markdown: null
+    datasourceWarning: false
+    expressionType: SIMPLE
+    hasCustomLabel: true
+    label: Total Learners
+    optionName: metric_f5k0vtt5bm_na5cjsf1ax
+    sqlExpression: null
+  only_total: true
+  opacity: 0.2
+  order_desc: true
+  rich_tooltip: true
+  rolling_type: cumsum
+  row_limit: 1000
+  seriesType: line
+  show_empty_columns: true
+  show_legend: true
+  show_value: false
+  sort_series_ascending: true
+  sort_series_type: sum
+  time_grain_sqla: P1M
+  tooltipTimeFormat: smart_date
+  truncate_metric: true
+  viz_type: echarts_timeseries_line
+  x_axis: visited_on
+  x_axis_sort: Views
+  x_axis_sort_asc: true
+  x_axis_sort_series: name
+  x_axis_sort_series_ascending: true
+  x_axis_time_format: smart_date
+  x_axis_title_margin: 15
+  y_axis_bounds:
+  - null
+  - null
+  y_axis_format: ',d'
+  y_axis_title_margin: 15
+  y_axis_title_position: Left
+  zoomable: true
+query_context: '{"datasource":{"id":42,"type":"table"},"force":false,"queries":[{"filters":[{"col":"visited_on","op":"TEMPORAL_RANGE","val":"No
+  filter"}],"extras":{"having":"","where":""},"applied_time_extras":{},"columns":[{"timeGrain":"P1M","columnType":"BASE_AXIS","sqlExpression":"visited_on","label":"visited_on","expressionType":"SQL"}],"metrics":[{"aggregate":"SUM","column":{"advanced_data_type":null,"certification_details":null,"certified_by":null,"column_name":"page_count","description":null,"expression":null,"filterable":true,"groupby":true,"id":468,"is_certified":false,"is_dttm":false,"python_date_format":null,"type":"UINT64","type_generic":0,"verbose_name":null,"warning_markdown":null},"datasourceWarning":false,"expressionType":"SIMPLE","hasCustomLabel":true,"label":"Total
+  Views","optionName":"metric_42el42svy4d_vtnwv1k58f","sqlExpression":null},{"aggregate":"COUNT_DISTINCT","column":{"advanced_data_type":null,"certification_details":null,"certified_by":null,"column_name":"actor_id","description":null,"expression":null,"filterable":true,"groupby":true,"id":469,"is_certified":false,"is_dttm":false,"python_date_format":null,"type":"STRING","type_generic":1,"verbose_name":null,"warning_markdown":null},"datasourceWarning":false,"expressionType":"SIMPLE","hasCustomLabel":true,"label":"Total
+  Learners","optionName":"metric_f5k0vtt5bm_na5cjsf1ax","sqlExpression":null}],"orderby":[[{"aggregate":"SUM","column":{"advanced_data_type":null,"certification_details":null,"certified_by":null,"column_name":"page_count","description":null,"expression":null,"filterable":true,"groupby":true,"id":468,"is_certified":false,"is_dttm":false,"python_date_format":null,"type":"UINT64","type_generic":0,"verbose_name":null,"warning_markdown":null},"datasourceWarning":false,"expressionType":"SIMPLE","hasCustomLabel":true,"label":"Total
+  Views","optionName":"metric_42el42svy4d_vtnwv1k58f","sqlExpression":null},false]],"annotation_layers":[],"row_limit":1000,"series_columns":[],"series_limit":0,"order_desc":true,"url_params":{},"custom_params":{},"custom_form_data":{},"time_offsets":[],"post_processing":[{"operation":"pivot","options":{"index":["visited_on"],"columns":[],"aggregates":{"Total
+  Views":{"operator":"mean"},"Total Learners":{"operator":"mean"}},"drop_missing_columns":false}},{"operation":"cum","options":{"operator":"sum","columns":{"Total
+  Views":"Total Views","Total Learners":"Total Learners"}}},{"operation":"flatten"}]}],"form_data":{"datasource":"42__table","viz_type":"echarts_timeseries_line","slice_id":195,"x_axis":"visited_on","time_grain_sqla":"P1M","x_axis_sort":"Views","x_axis_sort_asc":true,"x_axis_sort_series":"name","x_axis_sort_series_ascending":true,"metrics":[{"aggregate":"SUM","column":{"advanced_data_type":null,"certification_details":null,"certified_by":null,"column_name":"page_count","description":null,"expression":null,"filterable":true,"groupby":true,"id":468,"is_certified":false,"is_dttm":false,"python_date_format":null,"type":"UINT64","type_generic":0,"verbose_name":null,"warning_markdown":null},"datasourceWarning":false,"expressionType":"SIMPLE","hasCustomLabel":true,"label":"Total
+  Views","optionName":"metric_42el42svy4d_vtnwv1k58f","sqlExpression":null},{"aggregate":"COUNT_DISTINCT","column":{"advanced_data_type":null,"certification_details":null,"certified_by":null,"column_name":"actor_id","description":null,"expression":null,"filterable":true,"groupby":true,"id":469,"is_certified":false,"is_dttm":false,"python_date_format":null,"type":"STRING","type_generic":1,"verbose_name":null,"warning_markdown":null},"datasourceWarning":false,"expressionType":"SIMPLE","hasCustomLabel":true,"label":"Total
+  Learners","optionName":"metric_f5k0vtt5bm_na5cjsf1ax","sqlExpression":null}],"groupby":[],"adhoc_filters":[{"clause":"WHERE","comparator":"No
+  filter","expressionType":"SIMPLE","operator":"TEMPORAL_RANGE","subject":"visited_on"}],"order_desc":true,"row_limit":1000,"truncate_metric":true,"show_empty_columns":true,"rolling_type":"cumsum","comparison_type":"values","annotation_layers":[],"forecastPeriods":10,"forecastInterval":0.8,"x_axis_title_margin":15,"y_axis_title_margin":15,"y_axis_title_position":"Left","sort_series_type":"sum","sort_series_ascending":true,"color_scheme":"supersetColors","seriesType":"line","show_value":false,"only_total":true,"opacity":0.2,"markerEnabled":true,"markerSize":7,"zoomable":true,"show_legend":true,"legendType":"scroll","legendOrientation":"top","legendMargin":null,"x_axis_time_format":"smart_date","rich_tooltip":true,"tooltipTimeFormat":"smart_date","y_axis_format":",d","y_axis_bounds":[null,null],"extra_form_data":{},"dashboards":[16],"force":false,"result_format":"json","result_type":"full"},"result_format":"json","result_type":"full"}'
+slice_name: Cumulative Interactions
+uuid: c44e43b5-ba69-4805-8d01-3b04dcbf2cb6
+version: 1.0.0
+viz_type: echarts_timeseries_line

--- a/tutoraspects/templates/aspects/build/aspects-superset/openedx-assets/assets/charts/Current_Enrollees.yaml
+++ b/tutoraspects/templates/aspects/build/aspects-superset/openedx-assets/assets/charts/Current_Enrollees.yaml
@@ -1,0 +1,71 @@
+_file_name: Current_Enrollees.yaml
+cache_timeout: null
+certification_details: null
+certified_by: null
+dataset_uuid: a234545d-08ff-480d-8361-961c3d15f14f
+description: null
+params:
+  adhoc_filters:
+  - clause: WHERE
+    comparator: No filter
+    datasourceWarning: false
+    expressionType: SIMPLE
+    filterOptionName: filter_w289d0y7sjh_5e8k4qfsgou
+    isExtra: false
+    isNew: false
+    operator: TEMPORAL_RANGE
+    sqlExpression: null
+    subject: emission_time
+  - clause: WHERE
+    comparator:
+    - registered
+    datasourceWarning: false
+    expressionType: SIMPLE
+    filterOptionName: filter_ft5qci1uk74_ejjj76o6scl
+    isExtra: false
+    isNew: false
+    operator: IN
+    operatorId: IN
+    sqlExpression: null
+    subject: enrollment_status
+  conditional_formatting: []
+  extra_form_data: {}
+  header_font_size: 0.4
+  metric:
+    aggregate: COUNT_DISTINCT
+    column:
+      advanced_data_type: null
+      certification_details: null
+      certified_by: null
+      column_name: actor_id
+      description: null
+      expression: null
+      filterable: true
+      groupby: true
+      id: 138
+      is_certified: false
+      is_dttm: false
+      python_date_format: null
+      type: String
+      type_generic: 1
+      verbose_name: null
+      warning_markdown: null
+    datasourceWarning: false
+    expressionType: SIMPLE
+    hasCustomLabel: true
+    label: Number of Learners
+    optionName: metric_aw0btdmzbxf_6vx2yp23yt4
+    sqlExpression: null
+  subheader_font_size: 0.2
+  time_format: smart_date
+  viz_type: big_number_total
+  y_axis_format: ',d'
+query_context: '{"datasource":{"id":12,"type":"table"},"force":false,"queries":[{"filters":[{"col":"emission_time","op":"TEMPORAL_RANGE","val":"No
+  filter"},{"col":"enrollment_status","op":"IN","val":["registered"]}],"extras":{"having":"","where":""},"applied_time_extras":{},"columns":[],"metrics":[{"aggregate":"COUNT_DISTINCT","column":{"advanced_data_type":null,"certification_details":null,"certified_by":null,"column_name":"actor_id","description":null,"expression":null,"filterable":true,"groupby":true,"id":138,"is_certified":false,"is_dttm":false,"python_date_format":null,"type":"String","type_generic":1,"verbose_name":null,"warning_markdown":null},"datasourceWarning":false,"expressionType":"SIMPLE","hasCustomLabel":true,"label":"Number
+  of Learners","optionName":"metric_aw0btdmzbxf_6vx2yp23yt4","sqlExpression":null}],"annotation_layers":[],"series_limit":0,"order_desc":true,"url_params":{},"custom_params":{},"custom_form_data":{}}],"form_data":{"datasource":"12__table","viz_type":"big_number_total","slice_id":185,"metric":{"aggregate":"COUNT_DISTINCT","column":{"advanced_data_type":null,"certification_details":null,"certified_by":null,"column_name":"actor_id","description":null,"expression":null,"filterable":true,"groupby":true,"id":138,"is_certified":false,"is_dttm":false,"python_date_format":null,"type":"String","type_generic":1,"verbose_name":null,"warning_markdown":null},"datasourceWarning":false,"expressionType":"SIMPLE","hasCustomLabel":true,"label":"Number
+  of Learners","optionName":"metric_aw0btdmzbxf_6vx2yp23yt4","sqlExpression":null},"adhoc_filters":[{"clause":"WHERE","comparator":"No
+  filter","datasourceWarning":false,"expressionType":"SIMPLE","filterOptionName":"filter_w289d0y7sjh_5e8k4qfsgou","isExtra":false,"isNew":false,"operator":"TEMPORAL_RANGE","sqlExpression":null,"subject":"emission_time"},{"clause":"WHERE","comparator":["registered"],"datasourceWarning":false,"expressionType":"SIMPLE","filterOptionName":"filter_ft5qci1uk74_ejjj76o6scl","isExtra":false,"isNew":false,"operator":"IN","operatorId":"IN","sqlExpression":null,"subject":"enrollment_status"}],"header_font_size":0.4,"subheader_font_size":0.2,"y_axis_format":",d","time_format":"smart_date","conditional_formatting":[],"extra_form_data":{},"dashboards":[16],"force":false,"result_format":"json","result_type":"full"},"result_format":"json","result_type":"full"}'
+slice_name: Current Enrollees
+uuid: 00de2f72-b3ed-4994-b231-fd3cf29d758d
+version: 1.0.0
+viz_type: big_number_total

--- a/tutoraspects/templates/aspects/build/aspects-superset/openedx-assets/assets/charts/Current_Enrollees.yaml
+++ b/tutoraspects/templates/aspects/build/aspects-superset/openedx-assets/assets/charts/Current_Enrollees.yaml
@@ -28,6 +28,7 @@ params:
     operatorId: IN
     sqlExpression: null
     subject: enrollment_status
+  annotation_layers: []
   conditional_formatting: []
   extra_form_data: {}
   header_font_size: 0.4

--- a/tutoraspects/templates/aspects/build/aspects-superset/openedx-assets/assets/charts/Dashboard_Count.yaml
+++ b/tutoraspects/templates/aspects/build/aspects-superset/openedx-assets/assets/charts/Dashboard_Count.yaml
@@ -6,6 +6,7 @@ dataset_uuid: 3dee777a-3dd4-4fcb-a749-4d13651b3444
 description: Count of dashboards created in Superset over the selected time period.
 params:
   adhoc_filters: []
+  annotation_layers: []
   color_picker:
     a: 1
     b: 150
@@ -29,6 +30,7 @@ params:
   url_params: {}
   viz_type: big_number
   y_axis_format: SMART_NUMBER
+query_context: null
 slice_name: Dashboard Count
 uuid: 8368fe0b-5e64-4ad5-b93b-93f8a6f848af
 version: 1.0.0

--- a/tutoraspects/templates/aspects/build/aspects-superset/openedx-assets/assets/charts/Distribution_of_Current_Course_Grade.yaml
+++ b/tutoraspects/templates/aspects/build/aspects-superset/openedx-assets/assets/charts/Distribution_of_Current_Course_Grade.yaml
@@ -1,0 +1,28 @@
+_file_name: Distribution_of_Current_Course_Grade.yaml
+cache_timeout: null
+certification_details: null
+certified_by: null
+dataset_uuid: 633a1d4e-cd40-482f-a5dc-d5901c2181c2
+description: null
+params:
+  adhoc_filters: []
+  all_columns_x:
+  - Course Grade
+  color_scheme: supersetColors
+  cumulative: false
+  extra_form_data: {}
+  groupby: []
+  link_length: '10'
+  normalized: true
+  row_limit: 10000
+  show_legend: true
+  viz_type: histogram
+  x_axis_label: Grade
+  y_axis_label: Number of Learners
+query_context: '{"datasource":{"id":70,"type":"table"},"force":false,"queries":[{"filters":[],"extras":{"having":"","where":""},"applied_time_extras":{},"columns":[],"metrics":[],"annotation_layers":[],"row_limit":10000,"series_limit":0,"order_desc":true,"url_params":{},"custom_params":{},"custom_form_data":{}}],"form_data":{"datasource":"70__table","viz_type":"histogram","slice_id":197,"all_columns_x":["Course
+  Grade"],"adhoc_filters":[],"row_limit":10000,"groupby":[],"color_scheme":"supersetColors","link_length":"10","x_axis_label":"Grade","y_axis_label":"Number
+  of Learners","show_legend":true,"normalized":true,"cumulative":false,"extra_form_data":{},"dashboards":[16],"force":false,"result_format":"json","result_type":"full"},"result_format":"json","result_type":"full"}'
+slice_name: Distribution of Current Course Grade
+uuid: ea565658-6796-40e8-9d1e-01ffd0778bc9
+version: 1.0.0
+viz_type: histogram

--- a/tutoraspects/templates/aspects/build/aspects-superset/openedx-assets/assets/charts/Distribution_of_Current_Course_Grade.yaml
+++ b/tutoraspects/templates/aspects/build/aspects-superset/openedx-assets/assets/charts/Distribution_of_Current_Course_Grade.yaml
@@ -8,6 +8,7 @@ params:
   adhoc_filters: []
   all_columns_x:
   - Course Grade
+  annotation_layers: []
   color_scheme: supersetColors
   cumulative: false
   extra_form_data: {}

--- a/tutoraspects/templates/aspects/build/aspects-superset/openedx-assets/assets/charts/Enrollees_per_Enrollment_Track.yaml
+++ b/tutoraspects/templates/aspects/build/aspects-superset/openedx-assets/assets/charts/Enrollees_per_Enrollment_Track.yaml
@@ -1,0 +1,100 @@
+_file_name: Enrollees_per_Enrollment_Track.yaml
+cache_timeout: null
+certification_details: null
+certified_by: null
+dataset_uuid: 3dde421d-c0d0-43ab-8087-ca470985e88e
+description: null
+params:
+  adhoc_filters:
+  - clause: WHERE
+    comparator: No filter
+    datasourceWarning: false
+    expressionType: SIMPLE
+    filterOptionName: filter_3lacmmheoza_5bcm089g49o
+    isExtra: false
+    isNew: false
+    operator: TEMPORAL_RANGE
+    sqlExpression: null
+    subject: emission_time
+  - clause: WHERE
+    comparator:
+    - registered
+    datasourceWarning: false
+    expressionType: SIMPLE
+    filterOptionName: filter_qttcfymcil_aplt776mxl
+    isExtra: false
+    isNew: false
+    operator: IN
+    operatorId: IN
+    sqlExpression: null
+    subject: enrollment_status
+  annotation_layers: []
+  color_scheme: supersetColors
+  comparison_type: values
+  extra_form_data: {}
+  forecastInterval: 0.8
+  forecastPeriods: 10
+  groupby: []
+  legendMargin: null
+  legendOrientation: top
+  legendType: scroll
+  metrics:
+  - aggregate: COUNT_DISTINCT
+    column:
+      advanced_data_type: null
+      certification_details: null
+      certified_by: null
+      column_name: actor_id
+      description: null
+      expression: null
+      filterable: true
+      groupby: true
+      id: 138
+      is_certified: false
+      is_dttm: false
+      python_date_format: null
+      type: String
+      type_generic: 1
+      verbose_name: null
+      warning_markdown: null
+    datasourceWarning: false
+    expressionType: SIMPLE
+    hasCustomLabel: true
+    label: Number of Learners
+    optionName: metric_1toulfn6uev_crrzwxqvjvj
+    sqlExpression: null
+  only_total: true
+  order_desc: true
+  orientation: vertical
+  rich_tooltip: true
+  row_limit: 100
+  show_empty_columns: true
+  show_legend: true
+  show_value: true
+  sort_series_type: sum
+  tooltipTimeFormat: smart_date
+  truncate_metric: true
+  viz_type: echarts_timeseries_bar
+  x_axis: enrollment_mode
+  x_axis_sort_asc: true
+  x_axis_sort_series: name
+  x_axis_sort_series_ascending: true
+  x_axis_time_format: smart_date
+  x_axis_title_margin: 15
+  y_axis_bounds:
+  - null
+  - null
+  y_axis_format: ',d'
+  y_axis_title_margin: 15
+  y_axis_title_position: Left
+query_context: '{"datasource":{"id":71,"type":"table"},"force":false,"queries":[{"filters":[{"col":"emission_time","op":"TEMPORAL_RANGE","val":"No
+  filter"},{"col":"enrollment_status","op":"IN","val":["registered"]}],"extras":{"having":"","where":""},"applied_time_extras":{},"columns":[{"columnType":"BASE_AXIS","sqlExpression":"enrollment_mode","label":"enrollment_mode","expressionType":"SQL"}],"metrics":[{"aggregate":"COUNT_DISTINCT","column":{"advanced_data_type":null,"certification_details":null,"certified_by":null,"column_name":"actor_id","description":null,"expression":null,"filterable":true,"groupby":true,"id":138,"is_certified":false,"is_dttm":false,"python_date_format":null,"type":"String","type_generic":1,"verbose_name":null,"warning_markdown":null},"datasourceWarning":false,"expressionType":"SIMPLE","hasCustomLabel":true,"label":"Number
+  of Learners","optionName":"metric_1toulfn6uev_crrzwxqvjvj","sqlExpression":null}],"orderby":[[{"aggregate":"COUNT_DISTINCT","column":{"advanced_data_type":null,"certification_details":null,"certified_by":null,"column_name":"actor_id","description":null,"expression":null,"filterable":true,"groupby":true,"id":138,"is_certified":false,"is_dttm":false,"python_date_format":null,"type":"String","type_generic":1,"verbose_name":null,"warning_markdown":null},"datasourceWarning":false,"expressionType":"SIMPLE","hasCustomLabel":true,"label":"Number
+  of Learners","optionName":"metric_1toulfn6uev_crrzwxqvjvj","sqlExpression":null},false]],"annotation_layers":[],"row_limit":100,"series_columns":[],"series_limit":0,"order_desc":true,"url_params":{},"custom_params":{},"custom_form_data":{},"time_offsets":[],"post_processing":[{"operation":"pivot","options":{"index":["enrollment_mode"],"columns":[],"aggregates":{"Number
+  of Learners":{"operator":"mean"}},"drop_missing_columns":false}},{"operation":"flatten"}]}],"form_data":{"datasource":"71__table","viz_type":"echarts_timeseries_bar","slice_id":188,"x_axis":"enrollment_mode","x_axis_sort_asc":true,"x_axis_sort_series":"name","x_axis_sort_series_ascending":true,"metrics":[{"aggregate":"COUNT_DISTINCT","column":{"advanced_data_type":null,"certification_details":null,"certified_by":null,"column_name":"actor_id","description":null,"expression":null,"filterable":true,"groupby":true,"id":138,"is_certified":false,"is_dttm":false,"python_date_format":null,"type":"String","type_generic":1,"verbose_name":null,"warning_markdown":null},"datasourceWarning":false,"expressionType":"SIMPLE","hasCustomLabel":true,"label":"Number
+  of Learners","optionName":"metric_1toulfn6uev_crrzwxqvjvj","sqlExpression":null}],"groupby":[],"adhoc_filters":[{"expressionType":"SIMPLE","subject":"emission_time","operator":"TEMPORAL_RANGE","comparator":"No
+  filter","clause":"WHERE","sqlExpression":null,"isExtra":false,"isNew":false,"datasourceWarning":false,"filterOptionName":"filter_3lacmmheoza_5bcm089g49o"},{"expressionType":"SIMPLE","subject":"enrollment_status","operator":"IN","operatorId":"IN","comparator":["registered"],"clause":"WHERE","sqlExpression":null,"isExtra":false,"isNew":false,"datasourceWarning":false,"filterOptionName":"filter_qttcfymcil_aplt776mxl"}],"order_desc":true,"row_limit":100,"truncate_metric":true,"show_empty_columns":true,"comparison_type":"values","annotation_layers":[],"forecastPeriods":10,"forecastInterval":0.8,"orientation":"vertical","x_axis_title_margin":15,"y_axis_title_margin":15,"y_axis_title_position":"Left","sort_series_type":"sum","color_scheme":"supersetColors","show_value":true,"only_total":true,"show_legend":true,"legendType":"scroll","legendOrientation":"top","legendMargin":null,"x_axis_time_format":"smart_date","y_axis_format":",d","y_axis_bounds":[null,null],"rich_tooltip":true,"tooltipTimeFormat":"smart_date","extra_form_data":{},"dashboards":[16],"force":false,"result_format":"json","result_type":"full"},"result_format":"json","result_type":"full"}'
+slice_name: Enrollees per Enrollment Track
+uuid: e584199e-0ed6-42bf-afb9-db3b9fe4132b
+version: 1.0.0
+viz_type: echarts_timeseries_bar

--- a/tutoraspects/templates/aspects/build/aspects-superset/openedx-assets/assets/charts/Enrollments_By_Type.yaml
+++ b/tutoraspects/templates/aspects/build/aspects-superset/openedx-assets/assets/charts/Enrollments_By_Type.yaml
@@ -25,6 +25,7 @@ params:
     operator: null
     sqlExpression: enrollment_status_date = today()
     subject: null
+  annotation_layers: []
   color_scheme: supersetColors
   date_format: smart_date
   extra_form_data: {}
@@ -46,6 +47,7 @@ params:
   sort_by_metric: true
   time_range: No filter
   viz_type: pie
+query_context: null
 slice_name: Enrollments By Type
 uuid: 6c473b09-6a1a-4531-b71d-ab82e09721ef
 version: 1.0.0

--- a/tutoraspects/templates/aspects/build/aspects-superset/openedx-assets/assets/charts/Events_per_course.yaml
+++ b/tutoraspects/templates/aspects/build/aspects-superset/openedx-assets/assets/charts/Events_per_course.yaml
@@ -11,6 +11,7 @@ params:
     expressionType: SIMPLE
     operator: TEMPORAL_RANGE
     subject: emission_time
+  annotation_layers: []
   color_scheme: supersetColors
   date_format: smart_date
   extra_form_data: {}
@@ -31,6 +32,7 @@ params:
   show_legend: true
   sort_by_metric: true
   viz_type: pie
+query_context: null
 slice_name: Events per course
 uuid: 269c5919-2d2e-493d-8c29-14e7b8222ee4
 version: 1.0.0

--- a/tutoraspects/templates/aspects/build/aspects-superset/openedx-assets/assets/charts/Evolution_of_engagement.yaml
+++ b/tutoraspects/templates/aspects/build/aspects-superset/openedx-assets/assets/charts/Evolution_of_engagement.yaml
@@ -1,0 +1,115 @@
+_file_name: Evolution_of_engagement.yaml
+cache_timeout: null
+certification_details: null
+certified_by: null
+dataset_uuid: 1b1cbf0a-1193-4251-ad52-724c2f0190ae
+description: null
+params:
+  adhoc_filters:
+  - clause: WHERE
+    comparator: No filter
+    expressionType: SIMPLE
+    operator: TEMPORAL_RANGE
+    subject: visited_on
+  annotation_layers: []
+  color_scheme: supersetColors
+  comparison_type: values
+  extra_form_data: {}
+  forecastInterval: 0.8
+  forecastPeriods: 10
+  groupby: []
+  legendOrientation: top
+  legendType: scroll
+  markerEnabled: true
+  markerSize: 6
+  metrics:
+  - aggregate: SUM
+    column:
+      advanced_data_type: null
+      certification_details: null
+      certified_by: null
+      column_name: page_count
+      description: null
+      expression: null
+      filterable: true
+      groupby: true
+      id: 468
+      is_certified: false
+      is_dttm: false
+      python_date_format: null
+      type: UINT64
+      type_generic: 0
+      verbose_name: null
+      warning_markdown: null
+    datasourceWarning: false
+    expressionType: SIMPLE
+    hasCustomLabel: true
+    label: Total Views
+    optionName: metric_42el42svy4d_vtnwv1k58f
+    sqlExpression: null
+  - aggregate: COUNT_DISTINCT
+    column:
+      advanced_data_type: null
+      certification_details: null
+      certified_by: null
+      column_name: actor_id
+      description: null
+      expression: null
+      filterable: true
+      groupby: true
+      id: 469
+      is_certified: false
+      is_dttm: false
+      python_date_format: null
+      type: STRING
+      type_generic: 1
+      verbose_name: null
+      warning_markdown: null
+    datasourceWarning: false
+    expressionType: SIMPLE
+    hasCustomLabel: true
+    label: Total Learners
+    optionName: metric_f5k0vtt5bm_na5cjsf1ax
+    sqlExpression: null
+  only_total: true
+  opacity: 0.2
+  order_desc: true
+  rich_tooltip: true
+  row_limit: 1000
+  seriesType: line
+  show_empty_columns: true
+  show_legend: true
+  show_value: false
+  sort_series_ascending: true
+  sort_series_type: sum
+  time_grain_sqla: P1M
+  tooltipTimeFormat: smart_date
+  truncate_metric: true
+  viz_type: echarts_timeseries_line
+  x_axis: visited_on
+  x_axis_sort: Views
+  x_axis_sort_asc: true
+  x_axis_sort_series: name
+  x_axis_sort_series_ascending: true
+  x_axis_time_format: smart_date
+  x_axis_title_margin: 15
+  y_axis_bounds:
+  - null
+  - null
+  y_axis_format: ',d'
+  y_axis_title_margin: 15
+  y_axis_title_position: Left
+  zoomable: true
+query_context: '{"datasource":{"id":42,"type":"table"},"force":false,"queries":[{"filters":[{"col":"visited_on","op":"TEMPORAL_RANGE","val":"No
+  filter"}],"extras":{"having":"","where":""},"applied_time_extras":{},"columns":[{"timeGrain":"P1M","columnType":"BASE_AXIS","sqlExpression":"visited_on","label":"visited_on","expressionType":"SQL"}],"metrics":[{"aggregate":"SUM","column":{"advanced_data_type":null,"certification_details":null,"certified_by":null,"column_name":"page_count","description":null,"expression":null,"filterable":true,"groupby":true,"id":468,"is_certified":false,"is_dttm":false,"python_date_format":null,"type":"UINT64","type_generic":0,"verbose_name":null,"warning_markdown":null},"datasourceWarning":false,"expressionType":"SIMPLE","hasCustomLabel":true,"label":"Total
+  Views","optionName":"metric_42el42svy4d_vtnwv1k58f","sqlExpression":null},{"aggregate":"COUNT_DISTINCT","column":{"advanced_data_type":null,"certification_details":null,"certified_by":null,"column_name":"actor_id","description":null,"expression":null,"filterable":true,"groupby":true,"id":469,"is_certified":false,"is_dttm":false,"python_date_format":null,"type":"STRING","type_generic":1,"verbose_name":null,"warning_markdown":null},"datasourceWarning":false,"expressionType":"SIMPLE","hasCustomLabel":true,"label":"Total
+  Learners","optionName":"metric_f5k0vtt5bm_na5cjsf1ax","sqlExpression":null}],"orderby":[[{"aggregate":"SUM","column":{"advanced_data_type":null,"certification_details":null,"certified_by":null,"column_name":"page_count","description":null,"expression":null,"filterable":true,"groupby":true,"id":468,"is_certified":false,"is_dttm":false,"python_date_format":null,"type":"UINT64","type_generic":0,"verbose_name":null,"warning_markdown":null},"datasourceWarning":false,"expressionType":"SIMPLE","hasCustomLabel":true,"label":"Total
+  Views","optionName":"metric_42el42svy4d_vtnwv1k58f","sqlExpression":null},false]],"annotation_layers":[],"row_limit":1000,"series_columns":[],"series_limit":0,"order_desc":true,"url_params":{},"custom_params":{},"custom_form_data":{},"time_offsets":[],"post_processing":[{"operation":"pivot","options":{"index":["visited_on"],"columns":[],"aggregates":{"Total
+  Views":{"operator":"mean"},"Total Learners":{"operator":"mean"}},"drop_missing_columns":false}},{"operation":"flatten"}]}],"form_data":{"datasource":"42__table","viz_type":"echarts_timeseries_line","slice_id":194,"x_axis":"visited_on","time_grain_sqla":"P1M","x_axis_sort":"Views","x_axis_sort_asc":true,"x_axis_sort_series":"name","x_axis_sort_series_ascending":true,"metrics":[{"aggregate":"SUM","column":{"advanced_data_type":null,"certification_details":null,"certified_by":null,"column_name":"page_count","description":null,"expression":null,"filterable":true,"groupby":true,"id":468,"is_certified":false,"is_dttm":false,"python_date_format":null,"type":"UINT64","type_generic":0,"verbose_name":null,"warning_markdown":null},"datasourceWarning":false,"expressionType":"SIMPLE","hasCustomLabel":true,"label":"Total
+  Views","optionName":"metric_42el42svy4d_vtnwv1k58f","sqlExpression":null},{"aggregate":"COUNT_DISTINCT","column":{"advanced_data_type":null,"certification_details":null,"certified_by":null,"column_name":"actor_id","description":null,"expression":null,"filterable":true,"groupby":true,"id":469,"is_certified":false,"is_dttm":false,"python_date_format":null,"type":"STRING","type_generic":1,"verbose_name":null,"warning_markdown":null},"datasourceWarning":false,"expressionType":"SIMPLE","hasCustomLabel":true,"label":"Total
+  Learners","optionName":"metric_f5k0vtt5bm_na5cjsf1ax","sqlExpression":null}],"groupby":[],"adhoc_filters":[{"clause":"WHERE","comparator":"No
+  filter","expressionType":"SIMPLE","operator":"TEMPORAL_RANGE","subject":"visited_on"}],"order_desc":true,"row_limit":1000,"truncate_metric":true,"show_empty_columns":true,"comparison_type":"values","annotation_layers":[],"forecastPeriods":10,"forecastInterval":0.8,"x_axis_title_margin":15,"y_axis_title_margin":15,"y_axis_title_position":"Left","sort_series_type":"sum","sort_series_ascending":true,"color_scheme":"supersetColors","seriesType":"line","show_value":false,"only_total":true,"opacity":0.2,"markerEnabled":true,"markerSize":6,"zoomable":true,"show_legend":true,"legendType":"scroll","legendOrientation":"top","x_axis_time_format":"smart_date","rich_tooltip":true,"tooltipTimeFormat":"smart_date","y_axis_format":",d","y_axis_bounds":[null,null],"extra_form_data":{},"dashboards":[16],"force":false,"result_format":"json","result_type":"full"},"result_format":"json","result_type":"full"}'
+slice_name: Evolution of engagement
+uuid: d3ae0546-37a8-4841-a57b-8087a6c33049
+version: 1.0.0
+viz_type: echarts_timeseries_line

--- a/tutoraspects/templates/aspects/build/aspects-superset/openedx-assets/assets/charts/Last_Received_Event.yaml
+++ b/tutoraspects/templates/aspects/build/aspects-superset/openedx-assets/assets/charts/Last_Received_Event.yaml
@@ -6,6 +6,7 @@ dataset_uuid: 2a2498dc-03ce-41a0-b798-d84f808f7da6
 description: null
 params:
   adhoc_filters: []
+  annotation_layers: []
   extra_form_data: {}
   granularity_sqla: emission_time
   header_font_size: 0.4
@@ -24,6 +25,7 @@ params:
   time_range: No filter
   viz_type: big_number_total
   y_axis_format: ~g
+query_context: null
 slice_name: Last Received Event
 uuid: ffdaabc5-8d01-47d7-8f29-66efa643befb
 version: 1.0.0

--- a/tutoraspects/templates/aspects/build/aspects-superset/openedx-assets/assets/charts/Last_course_syncronized.yaml
+++ b/tutoraspects/templates/aspects/build/aspects-superset/openedx-assets/assets/charts/Last_course_syncronized.yaml
@@ -6,6 +6,7 @@ dataset_uuid: 46183302-6fa6-41a3-b6a7-79ff6c1c8402
 description: null
 params:
   adhoc_filters: []
+  annotation_layers: []
   extra_form_data: {}
   header_font_size: 0.4
   metric:
@@ -39,6 +40,7 @@ params:
   time_range: No filter
   viz_type: big_number_total
   y_axis_format: SMART_NUMBER
+query_context: null
 slice_name: Last course syncronized
 uuid: ca93f427-d021-476e-9a36-6ea0d99d30ea
 version: 1.0.0

--- a/tutoraspects/templates/aspects/build/aspects-superset/openedx-assets/assets/charts/Learners_with_Passing_Grade.yaml
+++ b/tutoraspects/templates/aspects/build/aspects-superset/openedx-assets/assets/charts/Learners_with_Passing_Grade.yaml
@@ -6,6 +6,7 @@ dataset_uuid: 633a1d4e-cd40-482f-a5dc-d5901c2181c2
 description: null
 params:
   adhoc_filters: []
+  annotation_layers: []
   conditional_formatting:
   - colorScheme: '#ACE1C4'
     column: Number of Learners

--- a/tutoraspects/templates/aspects/build/aspects-superset/openedx-assets/assets/charts/Learners_with_Passing_Grade.yaml
+++ b/tutoraspects/templates/aspects/build/aspects-superset/openedx-assets/assets/charts/Learners_with_Passing_Grade.yaml
@@ -1,0 +1,73 @@
+_file_name: Learners_with_Passing_Grade.yaml
+cache_timeout: null
+certification_details: null
+certified_by: null
+dataset_uuid: 633a1d4e-cd40-482f-a5dc-d5901c2181c2
+description: null
+params:
+  adhoc_filters: []
+  conditional_formatting:
+  - colorScheme: '#ACE1C4'
+    column: Number of Learners
+    operator: "\u2265"
+    targetValue: 0
+  extra_form_data: {}
+  header_font_size: 0.6
+  metric:
+    aggregate: COUNT_DISTINCT
+    column:
+      advanced_data_type: null
+      certification_details: null
+      certified_by: null
+      column_name: actor_id
+      description: null
+      expression: null
+      filterable: true
+      groupby: true
+      id: 457
+      is_certified: false
+      is_dttm: false
+      python_date_format: null
+      type: STRING
+      type_generic: 1
+      verbose_name: null
+      warning_markdown: null
+    datasourceWarning: false
+    expressionType: SIMPLE
+    hasCustomLabel: true
+    label: Number of Learners
+    optionName: metric_edlf1m0plr_j1zup9r1ixl
+    sqlExpression: null
+  subheader_font_size: 0.4
+  time_format: smart_date
+  viz_type: big_number_total
+  y_axis_format: SMART_NUMBER
+query_context: "{\"datasource\":{\"id\":70,\"type\":\"table\"},\"force\":false,\"\
+  queries\":[{\"filters\":[],\"extras\":{\"having\":\"\",\"where\":\"\"},\"applied_time_extras\"\
+  :{},\"columns\":[],\"metrics\":[{\"aggregate\":\"COUNT_DISTINCT\",\"column\":{\"\
+  advanced_data_type\":null,\"certification_details\":null,\"certified_by\":null,\"\
+  column_name\":\"actor_id\",\"description\":null,\"expression\":null,\"filterable\"\
+  :true,\"groupby\":true,\"id\":457,\"is_certified\":false,\"is_dttm\":false,\"python_date_format\"\
+  :null,\"type\":\"STRING\",\"type_generic\":1,\"verbose_name\":null,\"warning_markdown\"\
+  :null},\"datasourceWarning\":false,\"expressionType\":\"SIMPLE\",\"hasCustomLabel\"\
+  :true,\"label\":\"Number of Learners\",\"optionName\":\"metric_edlf1m0plr_j1zup9r1ixl\"\
+  ,\"sqlExpression\":null}],\"annotation_layers\":[],\"series_limit\":0,\"order_desc\"\
+  :true,\"url_params\":{},\"custom_params\":{},\"custom_form_data\":{}}],\"form_data\"\
+  :{\"datasource\":\"70__table\",\"viz_type\":\"big_number_total\",\"slice_id\":196,\"\
+  metric\":{\"aggregate\":\"COUNT_DISTINCT\",\"column\":{\"advanced_data_type\":null,\"\
+  certification_details\":null,\"certified_by\":null,\"column_name\":\"actor_id\"\
+  ,\"description\":null,\"expression\":null,\"filterable\":true,\"groupby\":true,\"\
+  id\":457,\"is_certified\":false,\"is_dttm\":false,\"python_date_format\":null,\"\
+  type\":\"STRING\",\"type_generic\":1,\"verbose_name\":null,\"warning_markdown\"\
+  :null},\"datasourceWarning\":false,\"expressionType\":\"SIMPLE\",\"hasCustomLabel\"\
+  :true,\"label\":\"Number of Learners\",\"optionName\":\"metric_edlf1m0plr_j1zup9r1ixl\"\
+  ,\"sqlExpression\":null},\"adhoc_filters\":[],\"header_font_size\":0.6,\"subheader_font_size\"\
+  :0.4,\"y_axis_format\":\"SMART_NUMBER\",\"time_format\":\"smart_date\",\"conditional_formatting\"\
+  :[{\"colorScheme\":\"#ACE1C4\",\"column\":\"Number of Learners\",\"operator\":\"\
+  \u2265\",\"targetValue\":0}],\"extra_form_data\":{},\"dashboards\":[16],\"force\"\
+  :false,\"result_format\":\"json\",\"result_type\":\"full\"},\"result_format\":\"\
+  json\",\"result_type\":\"full\"}"
+slice_name: Learners with Passing Grade
+uuid: b40cdabc-b265-48d2-913d-a9dfee0b6ab1
+version: 1.0.0
+viz_type: big_number_total

--- a/tutoraspects/templates/aspects/build/aspects-superset/openedx-assets/assets/charts/Most-used_Charts.yaml
+++ b/tutoraspects/templates/aspects/build/aspects-superset/openedx-assets/assets/charts/Most-used_Charts.yaml
@@ -18,6 +18,7 @@ params:
     sqlExpression: null
     subject: slice_id
   all_columns: []
+  annotation_layers: []
   color_pn: false
   conditional_formatting: []
   extra_form_data: {}
@@ -65,6 +66,7 @@ params:
   - exclusive
   url_params: {}
   viz_type: table
+query_context: null
 slice_name: Most-used Charts
 uuid: 9d5f69e8-f335-42a0-bbfa-272f43d74ad0
 version: 1.0.0

--- a/tutoraspects/templates/aspects/build/aspects-superset/openedx-assets/assets/charts/Most-used_Dashboards.yaml
+++ b/tutoraspects/templates/aspects/build/aspects-superset/openedx-assets/assets/charts/Most-used_Dashboards.yaml
@@ -18,6 +18,7 @@ params:
     sqlExpression: null
     subject: dashboard_id
   all_columns: []
+  annotation_layers: []
   color_pn: false
   conditional_formatting: []
   extra_form_data: {}
@@ -65,6 +66,7 @@ params:
   - exclusive
   url_params: {}
   viz_type: table
+query_context: null
 slice_name: Most-used Dashboards
 uuid: 36842ef1-d4e9-4cb6-83f7-cb9b34eaab77
 version: 1.0.0

--- a/tutoraspects/templates/aspects/build/aspects-superset/openedx-assets/assets/charts/Most_Active_Courses_Per_Day.yaml
+++ b/tutoraspects/templates/aspects/build/aspects-superset/openedx-assets/assets/charts/Most_Active_Courses_Per_Day.yaml
@@ -74,6 +74,7 @@ params:
   y_axis_format: SMART_NUMBER
   y_axis_title_margin: 15
   y_axis_title_position: Left
+query_context: null
 slice_name: Most Active Courses Per Day
 uuid: 0c377fa6-6a0b-4b07-8de4-c828915d4aa6
 version: 1.0.0

--- a/tutoraspects/templates/aspects/build/aspects-superset/openedx-assets/assets/charts/Page_views_per_section_subsection.yaml
+++ b/tutoraspects/templates/aspects/build/aspects-superset/openedx-assets/assets/charts/Page_views_per_section_subsection.yaml
@@ -1,0 +1,84 @@
+_file_name: Page_views_per_section_subsection.yaml
+cache_timeout: null
+certification_details: null
+certified_by: null
+dataset_uuid: 1c443466-300e-4f01-a690-3d9d1b934d9a
+description: null
+params:
+  adhoc_filters:
+  - clause: WHERE
+    comparator: No filter
+    expressionType: SIMPLE
+    operator: TEMPORAL_RANGE
+    subject: emission_time
+  annotation_layers: []
+  color_scheme: supersetColors
+  comparison_type: values
+  extra_form_data: {}
+  forecastInterval: 0.8
+  forecastPeriods: 10
+  groupby: []
+  legendOrientation: top
+  legendType: scroll
+  metrics:
+  - aggregate: null
+    column: null
+    datasourceWarning: false
+    expressionType: SQL
+    hasCustomLabel: true
+    label: All pages viewed
+    optionName: metric_79weo5uoij_22vrzytsx8v
+    sqlExpression: rand() % 10
+  - aggregate: null
+    column: null
+    datasourceWarning: false
+    expressionType: SQL
+    hasCustomLabel: true
+    label: At least one page viewed
+    optionName: metric_oijxyr99vkc_bvobo3jivn
+    sqlExpression: rand() % 20
+  only_total: true
+  order_desc: true
+  orientation: vertical
+  rich_tooltip: true
+  row_limit: 10000
+  show_empty_columns: true
+  show_legend: true
+  sort_series_type: sum
+  time_grain_sqla: P1M
+  tooltipTimeFormat: smart_date
+  truncate_metric: true
+  viz_type: echarts_timeseries_bar
+  xAxisLabelRotation: 45
+  x_axis: block_name_with_location
+  x_axis_sort_asc: true
+  x_axis_sort_series: name
+  x_axis_sort_series_ascending: true
+  x_axis_time_format: smart_date
+  x_axis_title_margin: 15
+  y_axis_bounds:
+  - null
+  - null
+  y_axis_format: SMART_NUMBER
+  y_axis_title: Number of learners
+  y_axis_title_margin: 30
+  y_axis_title_position: Left
+  zoomable: true
+query_context: '{"datasource":{"id":69,"type":"table"},"force":false,"queries":[{"filters":[{"col":"emission_time","op":"TEMPORAL_RANGE","val":"No
+  filter"}],"extras":{"having":"","where":""},"applied_time_extras":{},"columns":[{"timeGrain":"P1M","columnType":"BASE_AXIS","sqlExpression":"block_name_with_location","label":"block_name_with_location","expressionType":"SQL"}],"metrics":[{"aggregate":null,"column":null,"datasourceWarning":false,"expressionType":"SQL","hasCustomLabel":true,"label":"All
+  pages viewed","optionName":"metric_79weo5uoij_22vrzytsx8v","sqlExpression":"rand()
+  % 10"},{"aggregate":null,"column":null,"datasourceWarning":false,"expressionType":"SQL","hasCustomLabel":true,"label":"At
+  least one page viewed","optionName":"metric_oijxyr99vkc_bvobo3jivn","sqlExpression":"rand()
+  % 20"}],"orderby":[[{"aggregate":null,"column":null,"datasourceWarning":false,"expressionType":"SQL","hasCustomLabel":true,"label":"All
+  pages viewed","optionName":"metric_79weo5uoij_22vrzytsx8v","sqlExpression":"rand()
+  % 10"},false]],"annotation_layers":[],"row_limit":10000,"series_columns":[],"series_limit":0,"order_desc":true,"url_params":{},"custom_params":{},"custom_form_data":{},"time_offsets":[],"post_processing":[{"operation":"pivot","options":{"index":["block_name_with_location"],"columns":[],"aggregates":{"All
+  pages viewed":{"operator":"mean"},"At least one page viewed":{"operator":"mean"}},"drop_missing_columns":false}},{"operation":"flatten"}]}],"form_data":{"datasource":"69__table","viz_type":"echarts_timeseries_bar","slice_id":201,"x_axis":"block_name_with_location","time_grain_sqla":"P1M","x_axis_sort_asc":true,"x_axis_sort_series":"name","x_axis_sort_series_ascending":true,"metrics":[{"aggregate":null,"column":null,"datasourceWarning":false,"expressionType":"SQL","hasCustomLabel":true,"label":"All
+  pages viewed","optionName":"metric_79weo5uoij_22vrzytsx8v","sqlExpression":"rand()
+  % 10"},{"aggregate":null,"column":null,"datasourceWarning":false,"expressionType":"SQL","hasCustomLabel":true,"label":"At
+  least one page viewed","optionName":"metric_oijxyr99vkc_bvobo3jivn","sqlExpression":"rand()
+  % 20"}],"groupby":[],"adhoc_filters":[{"clause":"WHERE","comparator":"No filter","expressionType":"SIMPLE","operator":"TEMPORAL_RANGE","subject":"emission_time"}],"order_desc":true,"row_limit":10000,"truncate_metric":true,"show_empty_columns":true,"comparison_type":"values","annotation_layers":[],"forecastPeriods":10,"forecastInterval":0.8,"orientation":"vertical","x_axis_title_margin":15,"y_axis_title":"Number
+  of learners","y_axis_title_margin":30,"y_axis_title_position":"Left","sort_series_type":"sum","color_scheme":"supersetColors","only_total":true,"zoomable":true,"show_legend":true,"legendType":"scroll","legendOrientation":"top","x_axis_time_format":"smart_date","xAxisLabelRotation":45,"y_axis_format":"SMART_NUMBER","y_axis_bounds":[null,null],"rich_tooltip":true,"tooltipTimeFormat":"smart_date","extra_form_data":{},"dashboards":[16],"force":false,"result_format":"json","result_type":"full"},"result_format":"json","result_type":"full"}'
+slice_name: Page views per section/subsection
+uuid: 0538470d-0328-4f15-9e48-ffc9e84c4c06
+version: 1.0.0
+viz_type: echarts_timeseries_bar

--- a/tutoraspects/templates/aspects/build/aspects-superset/openedx-assets/assets/charts/Problem_Interactions.yaml
+++ b/tutoraspects/templates/aspects/build/aspects-superset/openedx-assets/assets/charts/Problem_Interactions.yaml
@@ -17,6 +17,7 @@ params:
     sqlExpression: null
     subject: emission_time
   all_columns: []
+  annotation_layers: []
   color_pn: true
   conditional_formatting:
   - colorScheme: '#ACE1C4'

--- a/tutoraspects/templates/aspects/build/aspects-superset/openedx-assets/assets/charts/Problem_Interactions.yaml
+++ b/tutoraspects/templates/aspects/build/aspects-superset/openedx-assets/assets/charts/Problem_Interactions.yaml
@@ -1,0 +1,173 @@
+_file_name: Problem_Interactions.yaml
+cache_timeout: null
+certification_details: null
+certified_by: null
+dataset_uuid: c0c8b8a3-b18a-4c17-a69b-e6befea0159d
+description: null
+params:
+  adhoc_filters:
+  - clause: WHERE
+    comparator: No filter
+    datasourceWarning: false
+    expressionType: SIMPLE
+    filterOptionName: filter_qqnzi3klvaa_mtbj67olly
+    isExtra: false
+    isNew: false
+    operator: TEMPORAL_RANGE
+    sqlExpression: null
+    subject: emission_time
+  all_columns: []
+  color_pn: true
+  conditional_formatting:
+  - colorScheme: '#ACE1C4'
+    column: Avg Attempts
+    operator: '='
+    targetValue: 1
+  - colorScheme: '#FDE380'
+    column: Avg Attempts
+    operator: "\u2264 x \u2264"
+    targetValueLeft: '2'
+    targetValueRight: '4'
+  - colorScheme: '#EFA1AA'
+    column: Avg Attempts
+    operator: '>'
+    targetValue: 4
+  extra_form_data: {}
+  groupby:
+  - problem_name_with_location
+  metrics:
+  - aggregate: COUNT_DISTINCT
+    column:
+      advanced_data_type: null
+      certification_details: null
+      certified_by: null
+      column_name: actor_id
+      description: null
+      expression: null
+      filterable: true
+      groupby: true
+      id: 698
+      is_certified: false
+      is_dttm: false
+      python_date_format: null
+      type: STRING
+      type_generic: 1
+      verbose_name: null
+      warning_markdown: null
+    datasourceWarning: false
+    expressionType: SIMPLE
+    hasCustomLabel: true
+    label: Number of Learners who attemped the problem
+    optionName: metric_zboha5uydk_auondva1ju5
+    sqlExpression: null
+  - aggregate: SUM
+    column:
+      advanced_data_type: null
+      certification_details: null
+      certified_by: null
+      column_name: attempts
+      description: null
+      expression: null
+      filterable: true
+      groupby: true
+      id: 701
+      is_certified: false
+      is_dttm: false
+      python_date_format: null
+      type: INT16
+      type_generic: 0
+      verbose_name: null
+      warning_markdown: null
+    datasourceWarning: false
+    expressionType: SIMPLE
+    hasCustomLabel: true
+    label: Number of Attempts
+    optionName: metric_v4jssil92q_9ajhtgt7xwt
+    sqlExpression: null
+  - aggregate: null
+    column: null
+    datasourceWarning: false
+    expressionType: SQL
+    hasCustomLabel: true
+    label: Avg Attempts
+    optionName: metric_qqr85xkaahh_5e6q3lf3a0w
+    sqlExpression: SUM(attempts)/COUNT(actor_id)
+  order_by_cols: []
+  order_desc: true
+  percent_metrics: []
+  query_mode: aggregate
+  row_limit: 1000
+  server_page_length: 10
+  show_cell_bars: true
+  table_timestamp_format: smart_date
+  temporal_columns_lookup:
+    emission_time: true
+  time_grain_sqla: P1D
+  viz_type: table
+query_context: "{\"datasource\":{\"id\":66,\"type\":\"table\"},\"force\":false,\"\
+  queries\":[{\"filters\":[{\"col\":\"emission_time\",\"op\":\"TEMPORAL_RANGE\",\"\
+  val\":\"No filter\"}],\"extras\":{\"time_grain_sqla\":\"P1D\",\"having\":\"\",\"\
+  where\":\"\"},\"applied_time_extras\":{},\"columns\":[\"problem_name_with_location\"\
+  ],\"metrics\":[{\"expressionType\":\"SIMPLE\",\"column\":{\"advanced_data_type\"\
+  :null,\"certification_details\":null,\"certified_by\":null,\"column_name\":\"actor_id\"\
+  ,\"description\":null,\"expression\":null,\"filterable\":true,\"groupby\":true,\"\
+  id\":698,\"is_certified\":false,\"is_dttm\":false,\"python_date_format\":null,\"\
+  type\":\"STRING\",\"type_generic\":1,\"verbose_name\":null,\"warning_markdown\"\
+  :null},\"aggregate\":\"COUNT_DISTINCT\",\"sqlExpression\":null,\"datasourceWarning\"\
+  :false,\"hasCustomLabel\":true,\"label\":\"Number of Learners who attemped the problem\"\
+  ,\"optionName\":\"metric_zboha5uydk_auondva1ju5\"},{\"expressionType\":\"SIMPLE\"\
+  ,\"column\":{\"advanced_data_type\":null,\"certification_details\":null,\"certified_by\"\
+  :null,\"column_name\":\"attempts\",\"description\":null,\"expression\":null,\"filterable\"\
+  :true,\"groupby\":true,\"id\":701,\"is_certified\":false,\"is_dttm\":false,\"python_date_format\"\
+  :null,\"type\":\"INT16\",\"type_generic\":0,\"verbose_name\":null,\"warning_markdown\"\
+  :null},\"aggregate\":\"SUM\",\"sqlExpression\":null,\"datasourceWarning\":false,\"\
+  hasCustomLabel\":true,\"label\":\"Number of Attempts\",\"optionName\":\"metric_v4jssil92q_9ajhtgt7xwt\"\
+  },{\"expressionType\":\"SQL\",\"sqlExpression\":\"SUM(attempts)/COUNT(actor_id)\"\
+  ,\"column\":null,\"aggregate\":null,\"datasourceWarning\":false,\"hasCustomLabel\"\
+  :true,\"label\":\"Avg Attempts\",\"optionName\":\"metric_qqr85xkaahh_5e6q3lf3a0w\"\
+  }],\"orderby\":[[{\"expressionType\":\"SIMPLE\",\"column\":{\"advanced_data_type\"\
+  :null,\"certification_details\":null,\"certified_by\":null,\"column_name\":\"actor_id\"\
+  ,\"description\":null,\"expression\":null,\"filterable\":true,\"groupby\":true,\"\
+  id\":698,\"is_certified\":false,\"is_dttm\":false,\"python_date_format\":null,\"\
+  type\":\"STRING\",\"type_generic\":1,\"verbose_name\":null,\"warning_markdown\"\
+  :null},\"aggregate\":\"COUNT_DISTINCT\",\"sqlExpression\":null,\"datasourceWarning\"\
+  :false,\"hasCustomLabel\":true,\"label\":\"Number of Learners who attemped the problem\"\
+  ,\"optionName\":\"metric_zboha5uydk_auondva1ju5\"},false]],\"annotation_layers\"\
+  :[],\"row_limit\":1000,\"series_limit\":0,\"order_desc\":true,\"url_params\":{},\"\
+  custom_params\":{},\"custom_form_data\":{},\"post_processing\":[]}],\"form_data\"\
+  :{\"datasource\":\"66__table\",\"viz_type\":\"table\",\"slice_id\":198,\"query_mode\"\
+  :\"aggregate\",\"groupby\":[\"problem_name_with_location\"],\"time_grain_sqla\"\
+  :\"P1D\",\"temporal_columns_lookup\":{\"emission_time\":true},\"metrics\":[{\"expressionType\"\
+  :\"SIMPLE\",\"column\":{\"advanced_data_type\":null,\"certification_details\":null,\"\
+  certified_by\":null,\"column_name\":\"actor_id\",\"description\":null,\"expression\"\
+  :null,\"filterable\":true,\"groupby\":true,\"id\":698,\"is_certified\":false,\"\
+  is_dttm\":false,\"python_date_format\":null,\"type\":\"STRING\",\"type_generic\"\
+  :1,\"verbose_name\":null,\"warning_markdown\":null},\"aggregate\":\"COUNT_DISTINCT\"\
+  ,\"sqlExpression\":null,\"datasourceWarning\":false,\"hasCustomLabel\":true,\"label\"\
+  :\"Number of Learners who attemped the problem\",\"optionName\":\"metric_zboha5uydk_auondva1ju5\"\
+  },{\"expressionType\":\"SIMPLE\",\"column\":{\"advanced_data_type\":null,\"certification_details\"\
+  :null,\"certified_by\":null,\"column_name\":\"attempts\",\"description\":null,\"\
+  expression\":null,\"filterable\":true,\"groupby\":true,\"id\":701,\"is_certified\"\
+  :false,\"is_dttm\":false,\"python_date_format\":null,\"type\":\"INT16\",\"type_generic\"\
+  :0,\"verbose_name\":null,\"warning_markdown\":null},\"aggregate\":\"SUM\",\"sqlExpression\"\
+  :null,\"datasourceWarning\":false,\"hasCustomLabel\":true,\"label\":\"Number of\
+  \ Attempts\",\"optionName\":\"metric_v4jssil92q_9ajhtgt7xwt\"},{\"expressionType\"\
+  :\"SQL\",\"sqlExpression\":\"SUM(attempts)/COUNT(actor_id)\",\"column\":null,\"\
+  aggregate\":null,\"datasourceWarning\":false,\"hasCustomLabel\":true,\"label\":\"\
+  Avg Attempts\",\"optionName\":\"metric_qqr85xkaahh_5e6q3lf3a0w\"}],\"all_columns\"\
+  :[],\"percent_metrics\":[],\"adhoc_filters\":[{\"clause\":\"WHERE\",\"comparator\"\
+  :\"No filter\",\"datasourceWarning\":false,\"expressionType\":\"SIMPLE\",\"filterOptionName\"\
+  :\"filter_qqnzi3klvaa_mtbj67olly\",\"isExtra\":false,\"isNew\":false,\"operator\"\
+  :\"TEMPORAL_RANGE\",\"sqlExpression\":null,\"subject\":\"emission_time\"}],\"order_by_cols\"\
+  :[],\"row_limit\":1000,\"server_page_length\":10,\"order_desc\":true,\"table_timestamp_format\"\
+  :\"smart_date\",\"show_cell_bars\":true,\"color_pn\":true,\"conditional_formatting\"\
+  :[{\"colorScheme\":\"#ACE1C4\",\"column\":\"Avg Attempts\",\"operator\":\"=\",\"\
+  targetValue\":1},{\"colorScheme\":\"#FDE380\",\"column\":\"Avg Attempts\",\"operator\"\
+  :\"\u2264 x \u2264\",\"targetValueLeft\":\"2\",\"targetValueRight\":\"4\"},{\"colorScheme\"\
+  :\"#EFA1AA\",\"column\":\"Avg Attempts\",\"operator\":\">\",\"targetValue\":4}],\"\
+  extra_form_data\":{},\"dashboards\":[16],\"force\":false,\"result_format\":\"json\"\
+  ,\"result_type\":\"full\"},\"result_format\":\"json\",\"result_type\":\"full\"}"
+slice_name: Problem Interactions
+uuid: ba14d2ea-8c53-4f79-aa1b-434011f3c725
+version: 1.0.0
+viz_type: table

--- a/tutoraspects/templates/aspects/build/aspects-superset/openedx-assets/assets/charts/Problem_Results.yaml
+++ b/tutoraspects/templates/aspects/build/aspects-superset/openedx-assets/assets/charts/Problem_Results.yaml
@@ -1,0 +1,76 @@
+_file_name: Problem_Results.yaml
+cache_timeout: null
+certification_details: null
+certified_by: null
+dataset_uuid: c0c8b8a3-b18a-4c17-a69b-e6befea0159d
+description: null
+params:
+  adhoc_filters:
+  - clause: WHERE
+    comparator: No filter
+    expressionType: SIMPLE
+    operator: TEMPORAL_RANGE
+    subject: emission_time
+  aggregateFunction: Sum
+  colOrder: key_a_to_z
+  conditional_formatting: []
+  date_format: smart_date
+  extra_form_data: {}
+  groupbyColumns:
+  - success
+  groupbyRows:
+  - problem_name_with_location
+  metrics:
+  - aggregate: SUM
+    column:
+      advanced_data_type: null
+      certification_details: null
+      certified_by: null
+      column_name: attempts
+      description: null
+      expression: null
+      filterable: true
+      groupby: true
+      id: 701
+      is_certified: false
+      is_dttm: false
+      python_date_format: null
+      type: INT16
+      type_generic: 0
+      verbose_name: null
+      warning_markdown: null
+    datasourceWarning: false
+    expressionType: SIMPLE
+    hasCustomLabel: true
+    label: Number of Attempts
+    optionName: metric_v4jssil92q_9ajhtgt7xwt
+    sqlExpression: null
+  - aggregate: null
+    column: null
+    datasourceWarning: false
+    expressionType: SQL
+    hasCustomLabel: true
+    label: Avg Attempts
+    optionName: metric_vv08p5p9y98_ydc7swlypm
+    sqlExpression: SUM(attempts)/COUNT(actor_id)
+  metricsLayout: COLUMNS
+  order_desc: true
+  rowOrder: key_a_to_z
+  row_limit: 1000
+  temporal_columns_lookup:
+    emission_time: true
+  time_grain_sqla: P1D
+  valueFormat: SMART_NUMBER
+  viz_type: pivot_table_v2
+query_context: '{"datasource":{"id":66,"type":"table"},"force":false,"queries":[{"filters":[{"col":"emission_time","op":"TEMPORAL_RANGE","val":"No
+  filter"}],"extras":{"having":"","where":""},"applied_time_extras":{},"columns":["success","problem_name_with_location"],"metrics":[{"expressionType":"SIMPLE","column":{"advanced_data_type":null,"certification_details":null,"certified_by":null,"column_name":"attempts","description":null,"expression":null,"filterable":true,"groupby":true,"id":701,"is_certified":false,"is_dttm":false,"python_date_format":null,"type":"INT16","type_generic":0,"verbose_name":null,"warning_markdown":null},"aggregate":"SUM","sqlExpression":null,"datasourceWarning":false,"hasCustomLabel":true,"label":"Number
+  of Attempts","optionName":"metric_v4jssil92q_9ajhtgt7xwt"},{"expressionType":"SQL","sqlExpression":"SUM(attempts)/COUNT(actor_id)","column":null,"aggregate":null,"datasourceWarning":false,"hasCustomLabel":true,"label":"Avg
+  Attempts","optionName":"metric_vv08p5p9y98_ydc7swlypm"}],"orderby":[[{"expressionType":"SIMPLE","column":{"advanced_data_type":null,"certification_details":null,"certified_by":null,"column_name":"attempts","description":null,"expression":null,"filterable":true,"groupby":true,"id":701,"is_certified":false,"is_dttm":false,"python_date_format":null,"type":"INT16","type_generic":0,"verbose_name":null,"warning_markdown":null},"aggregate":"SUM","sqlExpression":null,"datasourceWarning":false,"hasCustomLabel":true,"label":"Number
+  of Attempts","optionName":"metric_v4jssil92q_9ajhtgt7xwt"},false]],"annotation_layers":[],"row_limit":1000,"series_limit":0,"order_desc":true,"url_params":{},"custom_params":{},"custom_form_data":{}}],"form_data":{"datasource":"66__table","viz_type":"pivot_table_v2","slice_id":199,"groupbyColumns":["success"],"groupbyRows":["problem_name_with_location"],"time_grain_sqla":"P1D","temporal_columns_lookup":{"emission_time":true},"metrics":[{"expressionType":"SIMPLE","column":{"advanced_data_type":null,"certification_details":null,"certified_by":null,"column_name":"attempts","description":null,"expression":null,"filterable":true,"groupby":true,"id":701,"is_certified":false,"is_dttm":false,"python_date_format":null,"type":"INT16","type_generic":0,"verbose_name":null,"warning_markdown":null},"aggregate":"SUM","sqlExpression":null,"datasourceWarning":false,"hasCustomLabel":true,"label":"Number
+  of Attempts","optionName":"metric_v4jssil92q_9ajhtgt7xwt"},{"expressionType":"SQL","sqlExpression":"SUM(attempts)/COUNT(actor_id)","column":null,"aggregate":null,"datasourceWarning":false,"hasCustomLabel":true,"label":"Avg
+  Attempts","optionName":"metric_vv08p5p9y98_ydc7swlypm"}],"metricsLayout":"COLUMNS","adhoc_filters":[{"clause":"WHERE","comparator":"No
+  filter","expressionType":"SIMPLE","operator":"TEMPORAL_RANGE","subject":"emission_time"}],"row_limit":1000,"order_desc":true,"aggregateFunction":"Sum","valueFormat":"SMART_NUMBER","date_format":"smart_date","rowOrder":"key_a_to_z","colOrder":"key_a_to_z","conditional_formatting":[],"extra_form_data":{},"dashboards":[16],"force":false,"result_format":"json","result_type":"full"},"result_format":"json","result_type":"full"}'
+slice_name: Problem Results
+uuid: 2d7e5995-922e-44f4-be34-18f553dbcd21
+version: 1.0.0
+viz_type: pivot_table_v2

--- a/tutoraspects/templates/aspects/build/aspects-superset/openedx-assets/assets/charts/Problem_Results.yaml
+++ b/tutoraspects/templates/aspects/build/aspects-superset/openedx-assets/assets/charts/Problem_Results.yaml
@@ -12,6 +12,7 @@ params:
     operator: TEMPORAL_RANGE
     subject: emission_time
   aggregateFunction: Sum
+  annotation_layers: []
   colOrder: key_a_to_z
   conditional_formatting: []
   date_format: smart_date

--- a/tutoraspects/templates/aspects/build/aspects-superset/openedx-assets/assets/charts/Problems_attempted_per_section_subsection.yaml
+++ b/tutoraspects/templates/aspects/build/aspects-superset/openedx-assets/assets/charts/Problems_attempted_per_section_subsection.yaml
@@ -1,0 +1,84 @@
+_file_name: Problems_attempted_per_section_subsection.yaml
+cache_timeout: null
+certification_details: null
+certified_by: null
+dataset_uuid: 1c443466-300e-4f01-a690-3d9d1b934d9a
+description: null
+params:
+  adhoc_filters:
+  - clause: WHERE
+    comparator: No filter
+    expressionType: SIMPLE
+    operator: TEMPORAL_RANGE
+    subject: emission_time
+  annotation_layers: []
+  color_scheme: supersetColors
+  comparison_type: values
+  extra_form_data: {}
+  forecastInterval: 0.8
+  forecastPeriods: 10
+  groupby: []
+  legendOrientation: top
+  legendType: scroll
+  metrics:
+  - aggregate: null
+    column: null
+    datasourceWarning: false
+    expressionType: SQL
+    hasCustomLabel: true
+    label: Attempted at least one problem
+    optionName: metric_0gasd9pjc5y_44f8wzc1g3q
+    sqlExpression: rand() % 20
+  - aggregate: null
+    column: null
+    datasourceWarning: false
+    expressionType: SQL
+    hasCustomLabel: true
+    label: Attempted all problems
+    optionName: metric_6ibge21tuod_k3hhlneae8f
+    sqlExpression: rand() % 10
+  only_total: true
+  order_desc: true
+  orientation: vertical
+  rich_tooltip: true
+  row_limit: 10000
+  show_empty_columns: true
+  show_legend: true
+  sort_series_type: sum
+  time_grain_sqla: P1M
+  tooltipTimeFormat: smart_date
+  truncate_metric: true
+  viz_type: echarts_timeseries_bar
+  xAxisLabelRotation: 45
+  x_axis: block_name_with_location
+  x_axis_sort_asc: true
+  x_axis_sort_series: name
+  x_axis_sort_series_ascending: true
+  x_axis_time_format: smart_date
+  x_axis_title_margin: 15
+  y_axis_bounds:
+  - null
+  - null
+  y_axis_format: SMART_NUMBER
+  y_axis_title: Number of learners
+  y_axis_title_margin: 30
+  y_axis_title_position: Left
+  zoomable: true
+query_context: '{"datasource":{"id":69,"type":"table"},"force":false,"queries":[{"filters":[{"col":"emission_time","op":"TEMPORAL_RANGE","val":"No
+  filter"}],"extras":{"having":"","where":""},"applied_time_extras":{},"columns":[{"timeGrain":"P1M","columnType":"BASE_AXIS","sqlExpression":"block_name_with_location","label":"block_name_with_location","expressionType":"SQL"}],"metrics":[{"aggregate":null,"column":null,"datasourceWarning":false,"expressionType":"SQL","hasCustomLabel":true,"label":"Attempted
+  at least one problem","optionName":"metric_0gasd9pjc5y_44f8wzc1g3q","sqlExpression":"rand()
+  % 20"},{"aggregate":null,"column":null,"datasourceWarning":false,"expressionType":"SQL","hasCustomLabel":true,"label":"Attempted
+  all problems","optionName":"metric_6ibge21tuod_k3hhlneae8f","sqlExpression":"rand()
+  % 10"}],"orderby":[[{"aggregate":null,"column":null,"datasourceWarning":false,"expressionType":"SQL","hasCustomLabel":true,"label":"Attempted
+  at least one problem","optionName":"metric_0gasd9pjc5y_44f8wzc1g3q","sqlExpression":"rand()
+  % 20"},false]],"annotation_layers":[],"row_limit":10000,"series_columns":[],"series_limit":0,"order_desc":true,"url_params":{},"custom_params":{},"custom_form_data":{},"time_offsets":[],"post_processing":[{"operation":"pivot","options":{"index":["block_name_with_location"],"columns":[],"aggregates":{"Attempted
+  at least one problem":{"operator":"mean"},"Attempted all problems":{"operator":"mean"}},"drop_missing_columns":false}},{"operation":"flatten"}]}],"form_data":{"datasource":"69__table","viz_type":"echarts_timeseries_bar","slice_id":202,"x_axis":"block_name_with_location","time_grain_sqla":"P1M","x_axis_sort_asc":true,"x_axis_sort_series":"name","x_axis_sort_series_ascending":true,"metrics":[{"aggregate":null,"column":null,"datasourceWarning":false,"expressionType":"SQL","hasCustomLabel":true,"label":"Attempted
+  at least one problem","optionName":"metric_0gasd9pjc5y_44f8wzc1g3q","sqlExpression":"rand()
+  % 20"},{"aggregate":null,"column":null,"datasourceWarning":false,"expressionType":"SQL","hasCustomLabel":true,"label":"Attempted
+  all problems","optionName":"metric_6ibge21tuod_k3hhlneae8f","sqlExpression":"rand()
+  % 10"}],"groupby":[],"adhoc_filters":[{"clause":"WHERE","comparator":"No filter","expressionType":"SIMPLE","operator":"TEMPORAL_RANGE","subject":"emission_time"}],"order_desc":true,"row_limit":10000,"truncate_metric":true,"show_empty_columns":true,"comparison_type":"values","annotation_layers":[],"forecastPeriods":10,"forecastInterval":0.8,"orientation":"vertical","x_axis_title_margin":15,"y_axis_title":"Number
+  of learners","y_axis_title_margin":30,"y_axis_title_position":"Left","sort_series_type":"sum","color_scheme":"supersetColors","only_total":true,"zoomable":true,"show_legend":true,"legendType":"scroll","legendOrientation":"top","x_axis_time_format":"smart_date","xAxisLabelRotation":45,"y_axis_format":"SMART_NUMBER","y_axis_bounds":[null,null],"rich_tooltip":true,"tooltipTimeFormat":"smart_date","extra_form_data":{},"dashboards":[16],"force":false,"result_format":"json","result_type":"full"},"result_format":"json","result_type":"full"}'
+slice_name: Problems attempted per section/subsection
+uuid: 869edaf6-f911-4ca7-9e4b-28435bba2e82
+version: 1.0.0
+viz_type: echarts_timeseries_bar

--- a/tutoraspects/templates/aspects/build/aspects-superset/openedx-assets/assets/charts/Section_Summary.yaml
+++ b/tutoraspects/templates/aspects/build/aspects-superset/openedx-assets/assets/charts/Section_Summary.yaml
@@ -1,0 +1,145 @@
+_file_name: Section_Summary.yaml
+cache_timeout: null
+certification_details: null
+certified_by: null
+dataset_uuid: 1b1cbf0a-1193-4251-ad52-724c2f0190ae
+description: null
+params:
+  adhoc_filters:
+  - clause: WHERE
+    comparator: No filter
+    expressionType: SIMPLE
+    operator: TEMPORAL_RANGE
+    subject: visited_on
+  all_columns: []
+  color_pn: true
+  conditional_formatting:
+  - colorScheme: '#ACE1C4'
+    column: Number of Learners
+    operator: "\u2265"
+    targetValue: 1
+  - colorScheme: '#ACE1C4'
+    column: Views
+    operator: "\u2265"
+    targetValue: 1
+  extra_form_data: {}
+  groupby:
+  - section_with_name
+  metrics:
+  - aggregate: COUNT_DISTINCT
+    column:
+      advanced_data_type: null
+      certification_details: null
+      certified_by: null
+      column_name: actor_id
+      description: null
+      expression: null
+      filterable: true
+      groupby: true
+      id: 469
+      is_certified: false
+      is_dttm: false
+      python_date_format: null
+      type: STRING
+      type_generic: 1
+      verbose_name: null
+      warning_markdown: null
+    datasourceWarning: false
+    expressionType: SIMPLE
+    hasCustomLabel: true
+    label: Number of Learners
+    optionName: metric_irehgr64yc_a873p00dn94
+    sqlExpression: null
+  - aggregate: SUM
+    column:
+      advanced_data_type: null
+      certification_details: null
+      certified_by: null
+      column_name: page_count
+      description: null
+      expression: null
+      filterable: true
+      groupby: true
+      id: 468
+      is_certified: false
+      is_dttm: false
+      python_date_format: null
+      type: UINT64
+      type_generic: 0
+      verbose_name: null
+      warning_markdown: null
+    datasourceWarning: false
+    expressionType: SIMPLE
+    hasCustomLabel: true
+    label: Views
+    optionName: metric_lmuvjt8ora9_y80kswm8xuo
+    sqlExpression: null
+  order_by_cols: []
+  order_desc: true
+  percent_metrics: []
+  query_mode: aggregate
+  row_limit: 1000
+  server_page_length: 10
+  show_cell_bars: true
+  table_timestamp_format: smart_date
+  temporal_columns_lookup:
+    visited_on: true
+  time_grain_sqla: P1D
+  viz_type: table
+query_context: "{\"datasource\":{\"id\":42,\"type\":\"table\"},\"force\":false,\"\
+  queries\":[{\"filters\":[{\"col\":\"visited_on\",\"op\":\"TEMPORAL_RANGE\",\"val\"\
+  :\"No filter\"}],\"extras\":{\"time_grain_sqla\":\"P1D\",\"having\":\"\",\"where\"\
+  :\"\"},\"applied_time_extras\":{},\"columns\":[\"section_with_name\"],\"metrics\"\
+  :[{\"aggregate\":\"COUNT_DISTINCT\",\"column\":{\"advanced_data_type\":null,\"certification_details\"\
+  :null,\"certified_by\":null,\"column_name\":\"actor_id\",\"description\":null,\"\
+  expression\":null,\"filterable\":true,\"groupby\":true,\"id\":469,\"is_certified\"\
+  :false,\"is_dttm\":false,\"python_date_format\":null,\"type\":\"STRING\",\"type_generic\"\
+  :1,\"verbose_name\":null,\"warning_markdown\":null},\"datasourceWarning\":false,\"\
+  expressionType\":\"SIMPLE\",\"hasCustomLabel\":true,\"label\":\"Number of Learners\"\
+  ,\"optionName\":\"metric_irehgr64yc_a873p00dn94\",\"sqlExpression\":null},{\"aggregate\"\
+  :\"SUM\",\"column\":{\"advanced_data_type\":null,\"certification_details\":null,\"\
+  certified_by\":null,\"column_name\":\"page_count\",\"description\":null,\"expression\"\
+  :null,\"filterable\":true,\"groupby\":true,\"id\":468,\"is_certified\":false,\"\
+  is_dttm\":false,\"python_date_format\":null,\"type\":\"UINT64\",\"type_generic\"\
+  :0,\"verbose_name\":null,\"warning_markdown\":null},\"datasourceWarning\":false,\"\
+  expressionType\":\"SIMPLE\",\"hasCustomLabel\":true,\"label\":\"Views\",\"optionName\"\
+  :\"metric_lmuvjt8ora9_y80kswm8xuo\",\"sqlExpression\":null}],\"orderby\":[[{\"aggregate\"\
+  :\"COUNT_DISTINCT\",\"column\":{\"advanced_data_type\":null,\"certification_details\"\
+  :null,\"certified_by\":null,\"column_name\":\"actor_id\",\"description\":null,\"\
+  expression\":null,\"filterable\":true,\"groupby\":true,\"id\":469,\"is_certified\"\
+  :false,\"is_dttm\":false,\"python_date_format\":null,\"type\":\"STRING\",\"type_generic\"\
+  :1,\"verbose_name\":null,\"warning_markdown\":null},\"datasourceWarning\":false,\"\
+  expressionType\":\"SIMPLE\",\"hasCustomLabel\":true,\"label\":\"Number of Learners\"\
+  ,\"optionName\":\"metric_irehgr64yc_a873p00dn94\",\"sqlExpression\":null},false]],\"\
+  annotation_layers\":[],\"row_limit\":1000,\"series_limit\":0,\"order_desc\":true,\"\
+  url_params\":{},\"custom_params\":{},\"custom_form_data\":{},\"post_processing\"\
+  :[]}],\"form_data\":{\"datasource\":\"42__table\",\"viz_type\":\"table\",\"slice_id\"\
+  :191,\"query_mode\":\"aggregate\",\"groupby\":[\"section_with_name\"],\"time_grain_sqla\"\
+  :\"P1D\",\"temporal_columns_lookup\":{\"visited_on\":true},\"metrics\":[{\"aggregate\"\
+  :\"COUNT_DISTINCT\",\"column\":{\"advanced_data_type\":null,\"certification_details\"\
+  :null,\"certified_by\":null,\"column_name\":\"actor_id\",\"description\":null,\"\
+  expression\":null,\"filterable\":true,\"groupby\":true,\"id\":469,\"is_certified\"\
+  :false,\"is_dttm\":false,\"python_date_format\":null,\"type\":\"STRING\",\"type_generic\"\
+  :1,\"verbose_name\":null,\"warning_markdown\":null},\"datasourceWarning\":false,\"\
+  expressionType\":\"SIMPLE\",\"hasCustomLabel\":true,\"label\":\"Number of Learners\"\
+  ,\"optionName\":\"metric_irehgr64yc_a873p00dn94\",\"sqlExpression\":null},{\"aggregate\"\
+  :\"SUM\",\"column\":{\"advanced_data_type\":null,\"certification_details\":null,\"\
+  certified_by\":null,\"column_name\":\"page_count\",\"description\":null,\"expression\"\
+  :null,\"filterable\":true,\"groupby\":true,\"id\":468,\"is_certified\":false,\"\
+  is_dttm\":false,\"python_date_format\":null,\"type\":\"UINT64\",\"type_generic\"\
+  :0,\"verbose_name\":null,\"warning_markdown\":null},\"datasourceWarning\":false,\"\
+  expressionType\":\"SIMPLE\",\"hasCustomLabel\":true,\"label\":\"Views\",\"optionName\"\
+  :\"metric_lmuvjt8ora9_y80kswm8xuo\",\"sqlExpression\":null}],\"all_columns\":[],\"\
+  percent_metrics\":[],\"adhoc_filters\":[{\"clause\":\"WHERE\",\"comparator\":\"\
+  No filter\",\"expressionType\":\"SIMPLE\",\"operator\":\"TEMPORAL_RANGE\",\"subject\"\
+  :\"visited_on\"}],\"order_by_cols\":[],\"row_limit\":1000,\"server_page_length\"\
+  :10,\"order_desc\":true,\"table_timestamp_format\":\"smart_date\",\"show_cell_bars\"\
+  :true,\"color_pn\":true,\"conditional_formatting\":[{\"column\":\"Number of Learners\"\
+  ,\"colorScheme\":\"#ACE1C4\",\"operator\":\"\u2265\",\"targetValue\":1},{\"colorScheme\"\
+  :\"#ACE1C4\",\"column\":\"Views\",\"operator\":\"\u2265\",\"targetValue\":1}],\"\
+  extra_form_data\":{},\"dashboards\":[16],\"force\":false,\"result_format\":\"json\"\
+  ,\"result_type\":\"full\"},\"result_format\":\"json\",\"result_type\":\"full\"}"
+slice_name: Section Summary
+uuid: 47417136-acd1-44a1-b41e-644eb2c237c3
+version: 1.0.0
+viz_type: table

--- a/tutoraspects/templates/aspects/build/aspects-superset/openedx-assets/assets/charts/Section_Summary.yaml
+++ b/tutoraspects/templates/aspects/build/aspects-superset/openedx-assets/assets/charts/Section_Summary.yaml
@@ -12,6 +12,7 @@ params:
     operator: TEMPORAL_RANGE
     subject: visited_on
   all_columns: []
+  annotation_layers: []
   color_pn: true
   conditional_formatting:
   - colorScheme: '#ACE1C4'

--- a/tutoraspects/templates/aspects/build/aspects-superset/openedx-assets/assets/charts/Slowest_ClickHouse_Queries.yaml
+++ b/tutoraspects/templates/aspects/build/aspects-superset/openedx-assets/assets/charts/Slowest_ClickHouse_Queries.yaml
@@ -17,6 +17,7 @@ params:
   - read_rows
   - memory_usage_kb
   - query
+  annotation_layers: []
   color_pn: true
   extra_form_data: {}
   groupby: []
@@ -34,6 +35,7 @@ params:
     event_time: true
   time_grain_sqla: P1D
   viz_type: table
+query_context: null
 slice_name: Slowest ClickHouse Queries
 uuid: 953af3e5-8fc6-441e-bff1-22987735edf0
 version: 1.0.0

--- a/tutoraspects/templates/aspects/build/aspects-superset/openedx-assets/assets/charts/Subsection_Summary.yaml
+++ b/tutoraspects/templates/aspects/build/aspects-superset/openedx-assets/assets/charts/Subsection_Summary.yaml
@@ -1,0 +1,147 @@
+_file_name: Subsection_Summary.yaml
+cache_timeout: null
+certification_details: null
+certified_by: null
+dataset_uuid: 1b1cbf0a-1193-4251-ad52-724c2f0190ae
+description: null
+params:
+  adhoc_filters:
+  - clause: WHERE
+    comparator: No filter
+    expressionType: SIMPLE
+    operator: TEMPORAL_RANGE
+    subject: visited_on
+  all_columns: []
+  color_pn: true
+  conditional_formatting:
+  - colorScheme: '#ACE1C4'
+    column: Number of Learners
+    operator: "\u2265"
+    targetValue: 1
+  - colorScheme: '#ACE1C4'
+    column: Views
+    operator: "\u2265"
+    targetValue: 1
+  extra_form_data: {}
+  groupby:
+  - section_with_name
+  - subsection_with_name
+  metrics:
+  - aggregate: COUNT_DISTINCT
+    column:
+      advanced_data_type: null
+      certification_details: null
+      certified_by: null
+      column_name: actor_id
+      description: null
+      expression: null
+      filterable: true
+      groupby: true
+      id: 469
+      is_certified: false
+      is_dttm: false
+      python_date_format: null
+      type: STRING
+      type_generic: 1
+      verbose_name: null
+      warning_markdown: null
+    datasourceWarning: false
+    expressionType: SIMPLE
+    hasCustomLabel: true
+    label: Number of Learners
+    optionName: metric_irehgr64yc_a873p00dn94
+    sqlExpression: null
+  - aggregate: SUM
+    column:
+      advanced_data_type: null
+      certification_details: null
+      certified_by: null
+      column_name: page_count
+      description: null
+      expression: null
+      filterable: true
+      groupby: true
+      id: 468
+      is_certified: false
+      is_dttm: false
+      python_date_format: null
+      type: UINT64
+      type_generic: 0
+      verbose_name: null
+      warning_markdown: null
+    datasourceWarning: false
+    expressionType: SIMPLE
+    hasCustomLabel: true
+    label: Views
+    optionName: metric_lmuvjt8ora9_y80kswm8xuo
+    sqlExpression: null
+  order_by_cols: []
+  order_desc: true
+  percent_metrics: []
+  query_mode: aggregate
+  row_limit: 1000
+  server_page_length: 10
+  show_cell_bars: true
+  table_timestamp_format: smart_date
+  temporal_columns_lookup:
+    visited_on: true
+  time_grain_sqla: P1D
+  viz_type: table
+query_context: "{\"datasource\":{\"id\":42,\"type\":\"table\"},\"force\":false,\"\
+  queries\":[{\"filters\":[{\"col\":\"visited_on\",\"op\":\"TEMPORAL_RANGE\",\"val\"\
+  :\"No filter\"}],\"extras\":{\"time_grain_sqla\":\"P1D\",\"having\":\"\",\"where\"\
+  :\"\"},\"applied_time_extras\":{},\"columns\":[\"section_with_name\",\"subsection_with_name\"\
+  ],\"metrics\":[{\"aggregate\":\"COUNT_DISTINCT\",\"column\":{\"advanced_data_type\"\
+  :null,\"certification_details\":null,\"certified_by\":null,\"column_name\":\"actor_id\"\
+  ,\"description\":null,\"expression\":null,\"filterable\":true,\"groupby\":true,\"\
+  id\":469,\"is_certified\":false,\"is_dttm\":false,\"python_date_format\":null,\"\
+  type\":\"STRING\",\"type_generic\":1,\"verbose_name\":null,\"warning_markdown\"\
+  :null},\"datasourceWarning\":false,\"expressionType\":\"SIMPLE\",\"hasCustomLabel\"\
+  :true,\"label\":\"Number of Learners\",\"optionName\":\"metric_irehgr64yc_a873p00dn94\"\
+  ,\"sqlExpression\":null},{\"aggregate\":\"SUM\",\"column\":{\"advanced_data_type\"\
+  :null,\"certification_details\":null,\"certified_by\":null,\"column_name\":\"page_count\"\
+  ,\"description\":null,\"expression\":null,\"filterable\":true,\"groupby\":true,\"\
+  id\":468,\"is_certified\":false,\"is_dttm\":false,\"python_date_format\":null,\"\
+  type\":\"UINT64\",\"type_generic\":0,\"verbose_name\":null,\"warning_markdown\"\
+  :null},\"datasourceWarning\":false,\"expressionType\":\"SIMPLE\",\"hasCustomLabel\"\
+  :true,\"label\":\"Views\",\"optionName\":\"metric_lmuvjt8ora9_y80kswm8xuo\",\"sqlExpression\"\
+  :null}],\"orderby\":[[{\"aggregate\":\"COUNT_DISTINCT\",\"column\":{\"advanced_data_type\"\
+  :null,\"certification_details\":null,\"certified_by\":null,\"column_name\":\"actor_id\"\
+  ,\"description\":null,\"expression\":null,\"filterable\":true,\"groupby\":true,\"\
+  id\":469,\"is_certified\":false,\"is_dttm\":false,\"python_date_format\":null,\"\
+  type\":\"STRING\",\"type_generic\":1,\"verbose_name\":null,\"warning_markdown\"\
+  :null},\"datasourceWarning\":false,\"expressionType\":\"SIMPLE\",\"hasCustomLabel\"\
+  :true,\"label\":\"Number of Learners\",\"optionName\":\"metric_irehgr64yc_a873p00dn94\"\
+  ,\"sqlExpression\":null},false]],\"annotation_layers\":[],\"row_limit\":1000,\"\
+  series_limit\":0,\"order_desc\":true,\"url_params\":{},\"custom_params\":{},\"custom_form_data\"\
+  :{},\"post_processing\":[]}],\"form_data\":{\"datasource\":\"42__table\",\"viz_type\"\
+  :\"table\",\"slice_id\":192,\"query_mode\":\"aggregate\",\"groupby\":[\"section_with_name\"\
+  ,\"subsection_with_name\"],\"time_grain_sqla\":\"P1D\",\"temporal_columns_lookup\"\
+  :{\"visited_on\":true},\"metrics\":[{\"aggregate\":\"COUNT_DISTINCT\",\"column\"\
+  :{\"advanced_data_type\":null,\"certification_details\":null,\"certified_by\":null,\"\
+  column_name\":\"actor_id\",\"description\":null,\"expression\":null,\"filterable\"\
+  :true,\"groupby\":true,\"id\":469,\"is_certified\":false,\"is_dttm\":false,\"python_date_format\"\
+  :null,\"type\":\"STRING\",\"type_generic\":1,\"verbose_name\":null,\"warning_markdown\"\
+  :null},\"datasourceWarning\":false,\"expressionType\":\"SIMPLE\",\"hasCustomLabel\"\
+  :true,\"label\":\"Number of Learners\",\"optionName\":\"metric_irehgr64yc_a873p00dn94\"\
+  ,\"sqlExpression\":null},{\"aggregate\":\"SUM\",\"column\":{\"advanced_data_type\"\
+  :null,\"certification_details\":null,\"certified_by\":null,\"column_name\":\"page_count\"\
+  ,\"description\":null,\"expression\":null,\"filterable\":true,\"groupby\":true,\"\
+  id\":468,\"is_certified\":false,\"is_dttm\":false,\"python_date_format\":null,\"\
+  type\":\"UINT64\",\"type_generic\":0,\"verbose_name\":null,\"warning_markdown\"\
+  :null},\"datasourceWarning\":false,\"expressionType\":\"SIMPLE\",\"hasCustomLabel\"\
+  :true,\"label\":\"Views\",\"optionName\":\"metric_lmuvjt8ora9_y80kswm8xuo\",\"sqlExpression\"\
+  :null}],\"all_columns\":[],\"percent_metrics\":[],\"adhoc_filters\":[{\"clause\"\
+  :\"WHERE\",\"comparator\":\"No filter\",\"expressionType\":\"SIMPLE\",\"operator\"\
+  :\"TEMPORAL_RANGE\",\"subject\":\"visited_on\"}],\"order_by_cols\":[],\"row_limit\"\
+  :1000,\"server_page_length\":10,\"order_desc\":true,\"table_timestamp_format\":\"\
+  smart_date\",\"show_cell_bars\":true,\"color_pn\":true,\"conditional_formatting\"\
+  :[{\"colorScheme\":\"#ACE1C4\",\"column\":\"Number of Learners\",\"operator\":\"\
+  \u2265\",\"targetValue\":1},{\"colorScheme\":\"#ACE1C4\",\"column\":\"Views\",\"\
+  operator\":\"\u2265\",\"targetValue\":1}],\"extra_form_data\":{},\"dashboards\"\
+  :[16],\"force\":false,\"result_format\":\"json\",\"result_type\":\"full\"},\"result_format\"\
+  :\"json\",\"result_type\":\"full\"}"
+slice_name: Subsection Summary
+uuid: 2a8d96be-687d-4918-98fe-ae9fbd599152
+version: 1.0.0
+viz_type: table

--- a/tutoraspects/templates/aspects/build/aspects-superset/openedx-assets/assets/charts/Subsection_Summary.yaml
+++ b/tutoraspects/templates/aspects/build/aspects-superset/openedx-assets/assets/charts/Subsection_Summary.yaml
@@ -12,6 +12,7 @@ params:
     operator: TEMPORAL_RANGE
     subject: visited_on
   all_columns: []
+  annotation_layers: []
   color_pn: true
   conditional_formatting:
   - colorScheme: '#ACE1C4'

--- a/tutoraspects/templates/aspects/build/aspects-superset/openedx-assets/assets/charts/Superset_Active_Users.yaml
+++ b/tutoraspects/templates/aspects/build/aspects-superset/openedx-assets/assets/charts/Superset_Active_Users.yaml
@@ -7,6 +7,7 @@ description: Count of unique users who performed an action in Superset over the 
   time period.
 params:
   adhoc_filters: []
+  annotation_layers: []
   color_picker:
     a: 1
     b: 150
@@ -53,6 +54,7 @@ params:
   url_params: {}
   viz_type: big_number
   y_axis_format: SMART_NUMBER
+query_context: null
 slice_name: Superset Active Users
 uuid: bc5f7a27-670c-4794-963b-8082b258566f
 version: 1.0.0

--- a/tutoraspects/templates/aspects/build/aspects-superset/openedx-assets/assets/charts/Superset_Active_Users_Over_Time.yaml
+++ b/tutoraspects/templates/aspects/build/aspects-superset/openedx-assets/assets/charts/Superset_Active_Users_Over_Time.yaml
@@ -65,6 +65,7 @@ params:
   y_axis_format: SMART_NUMBER
   y_axis_title_margin: 15
   y_axis_title_position: Left
+query_context: null
 slice_name: Superset Active Users Over Time
 uuid: 66ef96e7-9616-4f28-90b6-68f13ce58b0a
 version: 1.0.0

--- a/tutoraspects/templates/aspects/build/aspects-superset/openedx-assets/assets/charts/Superset_Registered_Users_Over_Time.yaml
+++ b/tutoraspects/templates/aspects/build/aspects-superset/openedx-assets/assets/charts/Superset_Registered_Users_Over_Time.yaml
@@ -69,6 +69,7 @@ params:
   y_axis_format: SMART_NUMBER
   y_axis_title_margin: 15
   y_axis_title_position: Left
+query_context: null
 slice_name: Superset Registered Users Over Time
 uuid: 68011361-ea45-4875-9165-c84ddbcd1fc5
 version: 1.0.0

--- a/tutoraspects/templates/aspects/build/aspects-superset/openedx-assets/assets/charts/Total_Actors_v2.yaml
+++ b/tutoraspects/templates/aspects/build/aspects-superset/openedx-assets/assets/charts/Total_Actors_v2.yaml
@@ -11,6 +11,7 @@ params:
     expressionType: SIMPLE
     operator: TEMPORAL_RANGE
     subject: emission_time
+  annotation_layers: []
   conditional_formatting: []
   extra_form_data: {}
   force_timestamp_formatting: false
@@ -29,6 +30,7 @@ params:
   time_format: smart_date
   viz_type: big_number_total
   y_axis_format: SMART_NUMBER
+query_context: null
 slice_name: Total Actors v2
 uuid: 15620ae6-5452-4a11-bc7e-56c7e5987a4d
 version: 1.0.0

--- a/tutoraspects/templates/aspects/build/aspects-superset/openedx-assets/assets/charts/Total_Organizations.yaml
+++ b/tutoraspects/templates/aspects/build/aspects-superset/openedx-assets/assets/charts/Total_Organizations.yaml
@@ -6,6 +6,7 @@ dataset_uuid: 41278a97-d0ff-4645-9514-d79f80d275df
 description: null
 params:
   adhoc_filters: []
+  annotation_layers: []
   extra_form_data: {}
   granularity_sqla: emission_time
   header_font_size: 0.4
@@ -40,6 +41,7 @@ params:
   time_range: No filter
   viz_type: big_number_total
   y_axis_format: SMART_NUMBER
+query_context: null
 slice_name: Total Organizations
 uuid: e66b1cdb-6974-4fa2-a769-4908665118f6
 version: 1.0.0

--- a/tutoraspects/templates/aspects/build/aspects-superset/openedx-assets/assets/charts/User_Actions.yaml
+++ b/tutoraspects/templates/aspects/build/aspects-superset/openedx-assets/assets/charts/User_Actions.yaml
@@ -8,6 +8,7 @@ description: Chart showing the number of Superset actions taken by each user ove
 params:
   adhoc_filters: []
   all_columns: []
+  annotation_layers: []
   color_pn: false
   conditional_formatting: []
   extra_form_data: {}
@@ -81,6 +82,7 @@ params:
     sqlExpression: null
   url_params: {}
   viz_type: table
+query_context: null
 slice_name: User Actions
 uuid: 8059fd82-efae-47a1-9c23-0b74f2707aa5
 version: 1.0.0

--- a/tutoraspects/templates/aspects/build/aspects-superset/openedx-assets/assets/charts/Video_views_per_section_subsection.yaml
+++ b/tutoraspects/templates/aspects/build/aspects-superset/openedx-assets/assets/charts/Video_views_per_section_subsection.yaml
@@ -1,0 +1,84 @@
+_file_name: Video_views_per_section_subsection.yaml
+cache_timeout: null
+certification_details: null
+certified_by: null
+dataset_uuid: 1c443466-300e-4f01-a690-3d9d1b934d9a
+description: null
+params:
+  adhoc_filters:
+  - clause: WHERE
+    comparator: No filter
+    expressionType: SIMPLE
+    operator: TEMPORAL_RANGE
+    subject: emission_time
+  annotation_layers: []
+  color_scheme: supersetColors
+  comparison_type: values
+  extra_form_data: {}
+  forecastInterval: 0.8
+  forecastPeriods: 10
+  groupby: []
+  legendOrientation: top
+  legendType: scroll
+  metrics:
+  - aggregate: null
+    column: null
+    datasourceWarning: false
+    expressionType: SQL
+    hasCustomLabel: true
+    label: At least one video viewed
+    optionName: metric_pjnwyhoqed_98z4w1j60l
+    sqlExpression: rand() % 20
+  - aggregate: null
+    column: null
+    datasourceWarning: false
+    expressionType: SQL
+    hasCustomLabel: true
+    label: All videos viewed
+    optionName: metric_jo791jxqdd_ob1j1gmk0uh
+    sqlExpression: rand() % 10
+  only_total: true
+  order_desc: true
+  orientation: vertical
+  rich_tooltip: true
+  row_limit: 10000
+  show_empty_columns: true
+  show_legend: true
+  sort_series_type: sum
+  time_grain_sqla: P1M
+  tooltipTimeFormat: smart_date
+  truncate_metric: true
+  viz_type: echarts_timeseries_bar
+  xAxisLabelRotation: 45
+  x_axis: block_name_with_location
+  x_axis_sort_asc: true
+  x_axis_sort_series: name
+  x_axis_sort_series_ascending: true
+  x_axis_time_format: smart_date
+  x_axis_title_margin: 15
+  y_axis_bounds:
+  - null
+  - null
+  y_axis_format: SMART_NUMBER
+  y_axis_title: Number of learners
+  y_axis_title_margin: 30
+  y_axis_title_position: Left
+  zoomable: true
+query_context: '{"datasource":{"id":69,"type":"table"},"force":false,"queries":[{"filters":[{"col":"emission_time","op":"TEMPORAL_RANGE","val":"No
+  filter"}],"extras":{"having":"","where":""},"applied_time_extras":{},"columns":[{"timeGrain":"P1M","columnType":"BASE_AXIS","sqlExpression":"block_name_with_location","label":"block_name_with_location","expressionType":"SQL"}],"metrics":[{"aggregate":null,"column":null,"datasourceWarning":false,"expressionType":"SQL","hasCustomLabel":true,"label":"At
+  least one video viewed","optionName":"metric_pjnwyhoqed_98z4w1j60l","sqlExpression":"rand()
+  % 20"},{"aggregate":null,"column":null,"datasourceWarning":false,"expressionType":"SQL","hasCustomLabel":true,"label":"All
+  videos viewed","optionName":"metric_jo791jxqdd_ob1j1gmk0uh","sqlExpression":"rand()
+  % 10"}],"orderby":[[{"aggregate":null,"column":null,"datasourceWarning":false,"expressionType":"SQL","hasCustomLabel":true,"label":"At
+  least one video viewed","optionName":"metric_pjnwyhoqed_98z4w1j60l","sqlExpression":"rand()
+  % 20"},false]],"annotation_layers":[],"row_limit":10000,"series_columns":[],"series_limit":0,"order_desc":true,"url_params":{},"custom_params":{},"custom_form_data":{},"time_offsets":[],"post_processing":[{"operation":"pivot","options":{"index":["block_name_with_location"],"columns":[],"aggregates":{"At
+  least one video viewed":{"operator":"mean"},"All videos viewed":{"operator":"mean"}},"drop_missing_columns":false}},{"operation":"flatten"}]}],"form_data":{"datasource":"69__table","viz_type":"echarts_timeseries_bar","slice_id":203,"x_axis":"block_name_with_location","time_grain_sqla":"P1M","x_axis_sort_asc":true,"x_axis_sort_series":"name","x_axis_sort_series_ascending":true,"metrics":[{"aggregate":null,"column":null,"datasourceWarning":false,"expressionType":"SQL","hasCustomLabel":true,"label":"At
+  least one video viewed","optionName":"metric_pjnwyhoqed_98z4w1j60l","sqlExpression":"rand()
+  % 20"},{"aggregate":null,"column":null,"datasourceWarning":false,"expressionType":"SQL","hasCustomLabel":true,"label":"All
+  videos viewed","optionName":"metric_jo791jxqdd_ob1j1gmk0uh","sqlExpression":"rand()
+  % 10"}],"groupby":[],"adhoc_filters":[{"clause":"WHERE","comparator":"No filter","expressionType":"SIMPLE","operator":"TEMPORAL_RANGE","subject":"emission_time"}],"order_desc":true,"row_limit":10000,"truncate_metric":true,"show_empty_columns":true,"comparison_type":"values","annotation_layers":[],"forecastPeriods":10,"forecastInterval":0.8,"orientation":"vertical","x_axis_title_margin":15,"y_axis_title":"Number
+  of learners","y_axis_title_margin":30,"y_axis_title_position":"Left","sort_series_type":"sum","color_scheme":"supersetColors","only_total":true,"zoomable":true,"show_legend":true,"legendType":"scroll","legendOrientation":"top","x_axis_time_format":"smart_date","xAxisLabelRotation":45,"y_axis_format":"SMART_NUMBER","y_axis_bounds":[null,null],"rich_tooltip":true,"tooltipTimeFormat":"smart_date","extra_form_data":{},"dashboards":[16],"force":false,"result_format":"json","result_type":"full"},"result_format":"json","result_type":"full"}'
+slice_name: Video views per section/subsection
+uuid: 2c8072e7-44d1-4337-a843-aa2eb670b70e
+version: 1.0.0
+viz_type: echarts_timeseries_bar

--- a/tutoraspects/templates/aspects/build/aspects-superset/openedx-assets/assets/charts/Watched_Video_Segments.yaml
+++ b/tutoraspects/templates/aspects/build/aspects-superset/openedx-assets/assets/charts/Watched_Video_Segments.yaml
@@ -32,7 +32,10 @@ params:
   - null
   y_axis_format: SMART_NUMBER
   y_axis_label: Number Of Viewers / Views
-query_context: null
+query_context: '{"datasource":{"id":183,"type":"table"},"force":false,"queries":[{"filters":[{"col":"started_at","op":"TEMPORAL_RANGE","val":"No
+  filter"}],"extras":{"having":"","where":""},"applied_time_extras":{},"columns":["segment_start"],"metrics":["unique_viewers","repeat_views"],"annotation_layers":[],"row_limit":10000,"series_limit":0,"order_desc":true,"url_params":{},"custom_params":{},"custom_form_data":{}}],"form_data":{"datasource":"183__table","viz_type":"dist_bar","slice_id":371,"metrics":["unique_viewers","repeat_views"],"adhoc_filters":[{"clause":"WHERE","subject":"started_at","operator":"TEMPORAL_RANGE","comparator":"No
+  filter","expressionType":"SIMPLE"}],"groupby":["segment_start"],"columns":[],"row_limit":10000,"order_desc":true,"color_scheme":"supersetColors","show_legend":true,"rich_tooltip":true,"bar_stacked":true,"order_bars":true,"y_axis_format":"SMART_NUMBER","y_axis_label":"Number
+  Of Viewers / Views","y_axis_bounds":[null,null],"x_axis_label":"Seconds Of Video","bottom_margin":"auto","x_ticks_layout":"auto","extra_form_data":{},"dashboards":[148],"force":false,"result_format":"json","result_type":"full"},"result_format":"json","result_type":"full"}'
 slice_name: Watched Video Segments
 uuid: 2985a9db-c338-4008-af52-2930b81ee2e5
 version: 1.0.0

--- a/tutoraspects/templates/aspects/build/aspects-superset/openedx-assets/assets/charts/Watched_Video_Segments.yaml
+++ b/tutoraspects/templates/aspects/build/aspects-superset/openedx-assets/assets/charts/Watched_Video_Segments.yaml
@@ -6,18 +6,13 @@ dataset_uuid: c2c391b3-3403-4f05-bc0b-3de53bd366ec
 description: This chart shows which parts of a video are most watched, and which are
   most re-watched. Each segment represents 5 seconds of the video.
 params:
-  adhoc_filters:
-  - clause: WHERE
-    comparator: No filter
-    expressionType: SIMPLE
-    operator: TEMPORAL_RANGE
-    subject: started_at
-  annotation_layers: []
+  adhoc_filters: []
   bar_stacked: true
   bottom_margin: auto
   color_scheme: supersetColors
   columns: []
   extra_form_data: {}
+  granularity_sqla: started_at
   groupby:
   - segment_start
   metrics:
@@ -36,10 +31,7 @@ params:
   - null
   y_axis_format: SMART_NUMBER
   y_axis_label: Number Of Viewers / Views
-query_context: '{"datasource":{"id":183,"type":"table"},"force":false,"queries":[{"filters":[{"col":"started_at","op":"TEMPORAL_RANGE","val":"No
-  filter"}],"extras":{"having":"","where":""},"applied_time_extras":{},"columns":["segment_start"],"metrics":["unique_viewers","repeat_views"],"annotation_layers":[],"row_limit":10000,"series_limit":0,"order_desc":true,"url_params":{},"custom_params":{},"custom_form_data":{}}],"form_data":{"datasource":"183__table","viz_type":"dist_bar","slice_id":371,"metrics":["unique_viewers","repeat_views"],"adhoc_filters":[{"clause":"WHERE","subject":"started_at","operator":"TEMPORAL_RANGE","comparator":"No
-  filter","expressionType":"SIMPLE"}],"groupby":["segment_start"],"columns":[],"row_limit":10000,"order_desc":true,"color_scheme":"supersetColors","show_legend":true,"rich_tooltip":true,"bar_stacked":true,"order_bars":true,"y_axis_format":"SMART_NUMBER","y_axis_label":"Number
-  Of Viewers / Views","y_axis_bounds":[null,null],"x_axis_label":"Seconds Of Video","bottom_margin":"auto","x_ticks_layout":"auto","extra_form_data":{},"dashboards":[148],"force":false,"result_format":"json","result_type":"full"},"result_format":"json","result_type":"full"}'
+query_context: null
 slice_name: Watched Video Segments
 uuid: 2985a9db-c338-4008-af52-2930b81ee2e5
 version: 1.0.0

--- a/tutoraspects/templates/aspects/build/aspects-superset/openedx-assets/assets/charts/Watched_Video_Segments.yaml
+++ b/tutoraspects/templates/aspects/build/aspects-superset/openedx-assets/assets/charts/Watched_Video_Segments.yaml
@@ -7,6 +7,7 @@ description: This chart shows which parts of a video are most watched, and which
   most re-watched. Each segment represents 5 seconds of the video.
 params:
   adhoc_filters: []
+  annotation_layers: []
   bar_stacked: true
   bottom_margin: auto
   color_scheme: supersetColors

--- a/tutoraspects/templates/aspects/build/aspects-superset/openedx-assets/assets/charts/xAPI_Events_Over_Time_v2.yaml
+++ b/tutoraspects/templates/aspects/build/aspects-superset/openedx-assets/assets/charts/xAPI_Events_Over_Time_v2.yaml
@@ -11,6 +11,7 @@ params:
     expressionType: SIMPLE
     operator: TEMPORAL_RANGE
     subject: emission_time
+  annotation_layers: []
   color_picker:
     a: 1
     b: 135
@@ -36,6 +37,7 @@ params:
   viz_type: big_number
   x_axis: emission_time
   y_axis_format: SMART_NUMBER
+query_context: null
 slice_name: xAPI Events Over Time v2
 uuid: 8a81d381-7c40-4902-8bb9-bcbe50aa8780
 version: 1.0.0

--- a/tutoraspects/templates/aspects/build/aspects-superset/openedx-assets/assets/dashboards/Course_Dashboard_V1.yaml
+++ b/tutoraspects/templates/aspects/build/aspects-superset/openedx-assets/assets/dashboards/Course_Dashboard_V1.yaml
@@ -1,4 +1,6 @@
 _file_name: Course_Dashboard_V1.yaml
+_roles:
+- '{{ SUPERSET_ROLES_MAPPING.instructor }}'
 css: ''
 dashboard_title: Course Dashboard V1
 description: null

--- a/tutoraspects/templates/aspects/build/aspects-superset/openedx-assets/assets/dashboards/Course_Dashboard_V1.yaml
+++ b/tutoraspects/templates/aspects/build/aspects-superset/openedx-assets/assets/dashboards/Course_Dashboard_V1.yaml
@@ -281,8 +281,28 @@ metadata:
         - 203
         scope: global
       id: 204
-  color_scheme: ''
-  color_scheme_domain: []
+  color_scheme: supersetColors
+  color_scheme_domain:
+  - '#1FA8C9'
+  - '#454E7C'
+  - '#5AC189'
+  - '#FF7F44'
+  - '#666666'
+  - '#E04355'
+  - '#FCC700'
+  - '#A868B7'
+  - '#3CCCCB'
+  - '#A38F79'
+  - '#8FD3E4'
+  - '#A1A6BD'
+  - '#ACE1C4'
+  - '#FEC0A1'
+  - '#B2B2B2'
+  - '#EFA1AA'
+  - '#FDE380'
+  - '#D3B3DA'
+  - '#9EE5E5'
+  - '#D1C6BC'
   cross_filters_enabled: true
   default_filters: '{}'
   expanded_slices: {}
@@ -550,17 +570,7 @@ metadata:
       datasetUuid: 6ec360a5-e247-42e7-b301-fa8275fc93f9
     type: NATIVE_FILTER
   refresh_frequency: 0
-  shared_label_colors:
-    All pages viewed: '#3CCCCB'
-    All videos viewed: '#8FD3E4'
-    At least one page viewed: '#666666'
-    At least one video viewed: '#A868B7'
-    Number of Learners: '#1FA8C9'
-    Total Learners: '#5AC189'
-    Total Views: '#FCC700'
-    audit: '#FF7F44'
-    honor: '#454E7C'
-    verified: '#E04355'
+  shared_label_colors: {}
   timed_refresh_immune_slices: []
 position:
   CHART-8p_tmmvFsY:
@@ -1224,6 +1234,6 @@ position:
     - TAB-_Ey4nPhFr
     type: TABS
 published: true
-slug: null
+slug: course-dashboard-v1
 uuid: c0e64194-33d1-4d5a-8c10-4f51530c5ee9
 version: 1.0.0

--- a/tutoraspects/templates/aspects/build/aspects-superset/openedx-assets/assets/dashboards/Course_Dashboard_V1.yaml
+++ b/tutoraspects/templates/aspects/build/aspects-superset/openedx-assets/assets/dashboards/Course_Dashboard_V1.yaml
@@ -1,0 +1,1226 @@
+_file_name: Course_Dashboard_V1.yaml
+css: ''
+dashboard_title: Course Dashboard V1
+description: null
+metadata:
+  chart_configuration:
+    '186':
+      crossFilters:
+        chartsInScope:
+        - 45
+        - 185
+        - 188
+        - 189
+        - 191
+        - 192
+        - 194
+        - 195
+        - 196
+        - 197
+        - 198
+        - 199
+        - 201
+        - 202
+        - 203
+        - 204
+        scope: global
+      id: 186
+    '188':
+      crossFilters:
+        chartsInScope:
+        - 45
+        - 185
+        - 186
+        - 189
+        - 191
+        - 192
+        - 194
+        - 195
+        - 196
+        - 197
+        - 198
+        - 199
+        - 201
+        - 202
+        - 203
+        - 204
+        scope: global
+      id: 188
+    '189':
+      crossFilters:
+        chartsInScope:
+        - 45
+        - 185
+        - 186
+        - 188
+        - 191
+        - 192
+        - 194
+        - 195
+        - 196
+        - 197
+        - 198
+        - 199
+        - 201
+        - 202
+        - 203
+        - 204
+        scope: global
+      id: 189
+    '191':
+      crossFilters:
+        chartsInScope:
+        - 45
+        - 185
+        - 186
+        - 188
+        - 189
+        - 192
+        - 194
+        - 195
+        - 196
+        - 197
+        - 198
+        - 199
+        - 201
+        - 202
+        - 203
+        - 204
+        scope: global
+      id: 191
+    '192':
+      crossFilters:
+        chartsInScope:
+        - 45
+        - 185
+        - 186
+        - 188
+        - 189
+        - 191
+        - 194
+        - 195
+        - 196
+        - 197
+        - 198
+        - 199
+        - 201
+        - 202
+        - 203
+        - 204
+        scope: global
+      id: 192
+    '194':
+      crossFilters:
+        chartsInScope:
+        - 45
+        - 185
+        - 186
+        - 188
+        - 189
+        - 191
+        - 192
+        - 195
+        - 196
+        - 197
+        - 198
+        - 199
+        - 201
+        - 202
+        - 203
+        - 204
+        scope: global
+      id: 194
+    '195':
+      crossFilters:
+        chartsInScope:
+        - 45
+        - 185
+        - 186
+        - 188
+        - 189
+        - 191
+        - 192
+        - 194
+        - 196
+        - 197
+        - 198
+        - 199
+        - 201
+        - 202
+        - 203
+        - 204
+        scope: global
+      id: 195
+    '198':
+      crossFilters:
+        chartsInScope:
+        - 45
+        - 185
+        - 186
+        - 188
+        - 189
+        - 191
+        - 192
+        - 194
+        - 195
+        - 196
+        - 197
+        - 199
+        - 201
+        - 202
+        - 203
+        - 204
+        scope: global
+      id: 198
+    '199':
+      crossFilters:
+        chartsInScope:
+        - 45
+        - 185
+        - 186
+        - 188
+        - 189
+        - 191
+        - 192
+        - 194
+        - 195
+        - 196
+        - 197
+        - 198
+        - 201
+        - 202
+        - 203
+        - 204
+        scope: global
+      id: 199
+    '201':
+      crossFilters:
+        chartsInScope:
+        - 45
+        - 185
+        - 186
+        - 188
+        - 189
+        - 191
+        - 192
+        - 194
+        - 195
+        - 196
+        - 197
+        - 198
+        - 199
+        - 202
+        - 203
+        - 204
+        scope: global
+      id: 201
+    '202':
+      crossFilters:
+        chartsInScope:
+        - 45
+        - 185
+        - 186
+        - 188
+        - 189
+        - 191
+        - 192
+        - 194
+        - 195
+        - 196
+        - 197
+        - 198
+        - 199
+        - 201
+        - 203
+        - 204
+        scope: global
+      id: 202
+    '203':
+      crossFilters:
+        chartsInScope:
+        - 45
+        - 185
+        - 186
+        - 188
+        - 189
+        - 191
+        - 192
+        - 194
+        - 195
+        - 196
+        - 197
+        - 198
+        - 199
+        - 201
+        - 202
+        - 204
+        scope: global
+      id: 203
+    '204':
+      crossFilters:
+        chartsInScope:
+        - 45
+        - 185
+        - 186
+        - 188
+        - 189
+        - 191
+        - 192
+        - 194
+        - 195
+        - 196
+        - 197
+        - 198
+        - 199
+        - 201
+        - 202
+        - 203
+        scope: global
+      id: 204
+  color_scheme: ''
+  color_scheme_domain: []
+  cross_filters_enabled: true
+  default_filters: '{}'
+  expanded_slices: {}
+  global_chart_configuration:
+    chartsInScope:
+    - 45
+    - 185
+    - 186
+    - 188
+    - 189
+    - 191
+    - 192
+    - 194
+    - 195
+    - 196
+    - 197
+    - 198
+    - 199
+    - 201
+    - 202
+    - 203
+    - 204
+    scope:
+      excluded: []
+      rootPath:
+      - ROOT_ID
+  label_colors: {}
+  native_filter_configuration:
+  - cascadeParentIds: []
+    chartsInScope:
+    - 191
+    - 192
+    - 194
+    - 195
+    controlValues:
+      defaultToFirstItem: true
+      enableEmptyFilter: false
+      inverseSelection: false
+      multiSelect: true
+      searchAllOptions: false
+    defaultDataMask:
+      __cache: {}
+      extraFormData: {}
+      filterState: {}
+      ownState: {}
+    description: ''
+    filterType: filter_select
+    id: NATIVE_FILTER-QrTlO4wBf
+    name: Organization
+    requiredFirst: true
+    scope:
+      excluded: []
+      rootPath:
+      - ROOT_ID
+    tabsInScope:
+    - TAB-_Ey4nPhFr
+    - TAB-nqLFUR_Tg
+    targets:
+    - column:
+        name: org
+      datasetUuid: 1b1cbf0a-1193-4251-ad52-724c2f0190ae
+    type: NATIVE_FILTER
+  - cascadeParentIds: []
+    chartsInScope:
+    - 45
+    - 185
+    - 186
+    - 188
+    - 189
+    - 191
+    - 192
+    - 194
+    - 195
+    - 196
+    - 197
+    - 198
+    - 199
+    - 201
+    - 202
+    - 203
+    - 204
+    controlValues:
+      defaultToFirstItem: true
+      enableEmptyFilter: false
+      inverseSelection: false
+      multiSelect: true
+      searchAllOptions: false
+    defaultDataMask:
+      __cache: {}
+      extraFormData: {}
+      filterState: {}
+      ownState: {}
+    description: ''
+    filterType: filter_select
+    id: NATIVE_FILTER-IfS-Rd0ZS
+    name: Course Name
+    requiredFirst: true
+    scope:
+      excluded: []
+      rootPath:
+      - ROOT_ID
+    tabsInScope:
+    - TAB-4ptSkqs5MS
+    - TAB-5Guk2p9fd
+    - TAB-V5zNdxwhsP
+    - TAB-_Ey4nPhFr
+    - TAB-nqLFUR_Tg
+    - TAB-vze5iq6jg
+    targets:
+    - column:
+        name: course_name
+      datasetUuid: a234545d-08ff-480d-8361-961c3d15f14f
+    type: NATIVE_FILTER
+  - cascadeParentIds:
+    - NATIVE_FILTER-IfS-Rd0ZS
+    chartsInScope:
+    - 185
+    - 186
+    - 187
+    - 188
+    controlValues:
+      defaultToFirstItem: false
+      enableEmptyFilter: false
+      inverseSelection: false
+      multiSelect: true
+      searchAllOptions: true
+    defaultDataMask:
+      __cache: {}
+      extraFormData: {}
+      filterState: {}
+      ownState: {}
+    description: ''
+    filterType: filter_select
+    id: NATIVE_FILTER-w863AfFgi
+    name: Course Run
+    scope:
+      excluded: []
+      rootPath:
+      - ROOT_ID
+    tabsInScope:
+    - TAB-4ptSkqs5MS
+    targets:
+    - column:
+        name: course_run
+      datasetUuid: a234545d-08ff-480d-8361-961c3d15f14f
+    type: NATIVE_FILTER
+  - chartsInScope: []
+    description: ''
+    id: NATIVE_FILTER_DIVIDER-HAScs3d7P
+    scope:
+      excluded: []
+      rootPath:
+      - ROOT_ID
+    tabsInScope: []
+    title: Time filters
+    type: DIVIDER
+  - cascadeParentIds: []
+    chartsInScope:
+    - 185
+    - 187
+    - 188
+    - 189
+    controlValues:
+      enableEmptyFilter: false
+    defaultDataMask:
+      __cache: {}
+      extraFormData: {}
+      filterState: {}
+      ownState: {}
+    description: ''
+    filterType: filter_time
+    id: NATIVE_FILTER-T8dy9gl7K
+    name: Date
+    scope:
+      excluded:
+      - 186
+      - 191
+      - 192
+      - 194
+      - 195
+      rootPath:
+      - ROOT_ID
+    tabsInScope:
+    - TAB-4ptSkqs5MS
+    targets:
+    - {}
+    type: NATIVE_FILTER
+  - cascadeParentIds: []
+    chartsInScope:
+    - 189
+    - 194
+    - 195
+    controlValues:
+      enableEmptyFilter: false
+    defaultDataMask:
+      extraFormData:
+        time_grain_sqla: P1M
+      filterState:
+        label: Month
+        value:
+        - P1M
+    description: ''
+    filterType: filter_timegrain
+    id: NATIVE_FILTER-uPaSvFul8
+    name: Time Grain
+    scope:
+      excluded:
+      - 187
+      - 188
+      - 191
+      - 192
+      rootPath:
+      - TAB-4ptSkqs5MS
+      - TAB-_Ey4nPhFr
+    tabsInScope:
+    - TAB-4ptSkqs5MS
+    - TAB-_Ey4nPhFr
+    - TAB-nqLFUR_Tg
+    targets:
+    - datasetUuid: a234545d-08ff-480d-8361-961c3d15f14f
+    type: NATIVE_FILTER
+  - cascadeParentIds:
+    - NATIVE_FILTER-IfS-Rd0ZS
+    chartsInScope:
+    - 45
+    - 203
+    - 204
+    controlValues:
+      defaultToFirstItem: false
+      enableEmptyFilter: false
+      inverseSelection: false
+      multiSelect: false
+      searchAllOptions: false
+    defaultDataMask:
+      __cache: {}
+      extraFormData: {}
+      filterState: {}
+      ownState: {}
+    description: ''
+    filterType: filter_select
+    id: NATIVE_FILTER-aT2KP-m-p
+    name: Video name
+    scope:
+      excluded:
+      - 201
+      - 202
+      - 185
+      - 186
+      - 187
+      - 188
+      - 189
+      - 191
+      - 192
+      - 194
+      - 195
+      - 196
+      - 197
+      - 198
+      - 199
+      rootPath:
+      - ROOT_ID
+    tabsInScope:
+    - TAB-V5zNdxwhsP
+    targets:
+    - column:
+        name: video_name
+      datasetUuid: 6ec360a5-e247-42e7-b301-fa8275fc93f9
+    type: NATIVE_FILTER
+  refresh_frequency: 0
+  shared_label_colors:
+    All pages viewed: '#3CCCCB'
+    All videos viewed: '#8FD3E4'
+    At least one page viewed: '#666666'
+    At least one video viewed: '#A868B7'
+    Number of Learners: '#1FA8C9'
+    Total Learners: '#5AC189'
+    Total Views: '#FCC700'
+    audit: '#FF7F44'
+    honor: '#454E7C'
+    verified: '#E04355'
+  timed_refresh_immune_slices: []
+position:
+  CHART-8p_tmmvFsY:
+    children: []
+    id: CHART-8p_tmmvFsY
+    meta:
+      chartId: 201
+      height: 50
+      sliceName: Page views per section/subsection
+      uuid: 0538470d-0328-4f15-9e48-ffc9e84c4c06
+      width: 12
+    parents:
+    - ROOT_ID
+    - GRID_ID
+    - TABS-UDkdlBRw4n
+    - TAB-_Ey4nPhFr
+    - TABS-nk8aeLmc5o
+    - TAB-nqLFUR_Tg
+    - ROW-6oVc0KNyM1
+    type: CHART
+  CHART-LiY7tPJWZv:
+    children: []
+    id: CHART-LiY7tPJWZv
+    meta:
+      chartId: 202
+      height: 50
+      sliceName: Problems attempted per section/subsection
+      uuid: 869edaf6-f911-4ca7-9e4b-28435bba2e82
+      width: 12
+    parents:
+    - ROOT_ID
+    - GRID_ID
+    - TABS-UDkdlBRw4n
+    - TAB-_Ey4nPhFr
+    - TABS-nk8aeLmc5o
+    - TAB-vze5iq6jg
+    - ROW-iV463iCf2a
+    type: CHART
+  CHART-Q6nr6irIdz:
+    children: []
+    id: CHART-Q6nr6irIdz
+    meta:
+      chartId: 45
+      height: 50
+      sliceName: Watched Video Segments
+      uuid: 2985a9db-c338-4008-af52-2930b81ee2e5
+      width: 12
+    parents:
+    - ROOT_ID
+    - GRID_ID
+    - TABS-UDkdlBRw4n
+    - TAB-_Ey4nPhFr
+    - TABS-nk8aeLmc5o
+    - TAB-V5zNdxwhsP
+    - ROW-ToSAm6kqA2
+    type: CHART
+  CHART-_BfZOEhMVM:
+    children: []
+    id: CHART-_BfZOEhMVM
+    meta:
+      chartId: 204
+      height: 50
+      sliceName: Partial and full views per video
+      uuid: 14c5cd80-cb50-4136-9911-d77da1737d69
+      width: 12
+    parents:
+    - ROOT_ID
+    - GRID_ID
+    - TABS-UDkdlBRw4n
+    - TAB-_Ey4nPhFr
+    - TABS-nk8aeLmc5o
+    - TAB-V5zNdxwhsP
+    - ROW-_dGQijoSEk
+    type: CHART
+  CHART-explore-185-1:
+    children: []
+    id: CHART-explore-185-1
+    meta:
+      chartId: 185
+      height: 28
+      sliceName: Current Enrollees
+      uuid: 00de2f72-b3ed-4994-b231-fd3cf29d758d
+      width: 2
+    parents:
+    - ROOT_ID
+    - GRID_ID
+    - ROW-qDVwqO3bi4
+    type: CHART
+  CHART-explore-186-1:
+    children: []
+    id: CHART-explore-186-1
+    meta:
+      chartId: 186
+      height: 18
+      sliceName: Course Information
+      uuid: fa249dda-78da-4ccc-9ef3-39177e6aae0c
+      width: 3
+    parents:
+    - ROOT_ID
+    - GRID_ID
+    - ROW-qDVwqO3bi4
+    - COLUMN-ttuyLjaKs0
+    type: CHART
+  CHART-explore-188-1:
+    children: []
+    id: CHART-explore-188-1
+    meta:
+      chartId: 188
+      height: 64
+      sliceName: Enrollees per Enrollment Track
+      uuid: e584199e-0ed6-42bf-afb9-db3b9fe4132b
+      width: 5
+    parents:
+    - ROOT_ID
+    - GRID_ID
+    - TABS-UDkdlBRw4n
+    - TAB-4ptSkqs5MS
+    - ROW-EpJDdqK8c
+    type: CHART
+  CHART-explore-189-1:
+    children: []
+    id: CHART-explore-189-1
+    meta:
+      chartId: 189
+      height: 51
+      sliceName: Cumulative Enrollments by Track
+      uuid: f207c896-030a-462b-b69f-6416230d50b6
+      width: 4
+    parents:
+    - ROOT_ID
+    - GRID_ID
+    - TABS-UDkdlBRw4n
+    - TAB-4ptSkqs5MS
+    - ROW-EpJDdqK8c
+    - COLUMN-2jtUMCFWN3
+    type: CHART
+  CHART-explore-191-1:
+    children: []
+    id: CHART-explore-191-1
+    meta:
+      chartId: 191
+      height: 50
+      sliceName: Section Summary
+      uuid: 47417136-acd1-44a1-b41e-644eb2c237c3
+      width: 4
+    parents:
+    - ROOT_ID
+    - GRID_ID
+    - TABS-UDkdlBRw4n
+    - TAB-_Ey4nPhFr
+    - TABS-nk8aeLmc5o
+    - TAB-nqLFUR_Tg
+    - ROW-_KbR9wzEQb
+    type: CHART
+  CHART-explore-192-1:
+    children: []
+    id: CHART-explore-192-1
+    meta:
+      chartId: 192
+      height: 50
+      sliceName: Subsection Summary
+      uuid: 2a8d96be-687d-4918-98fe-ae9fbd599152
+      width: 4
+    parents:
+    - ROOT_ID
+    - GRID_ID
+    - TABS-UDkdlBRw4n
+    - TAB-_Ey4nPhFr
+    - TABS-nk8aeLmc5o
+    - TAB-nqLFUR_Tg
+    - ROW-GlQl7V_ol
+    type: CHART
+  CHART-explore-194-1:
+    children: []
+    id: CHART-explore-194-1
+    meta:
+      chartId: 194
+      height: 50
+      sliceName: Evolution of engagement
+      uuid: d3ae0546-37a8-4841-a57b-8087a6c33049
+      width: 8
+    parents:
+    - ROOT_ID
+    - GRID_ID
+    - TABS-UDkdlBRw4n
+    - TAB-_Ey4nPhFr
+    - TABS-nk8aeLmc5o
+    - TAB-nqLFUR_Tg
+    - ROW-GlQl7V_ol
+    type: CHART
+  CHART-explore-195-1:
+    children: []
+    id: CHART-explore-195-1
+    meta:
+      chartId: 195
+      height: 50
+      sliceName: Cumulative Interactions
+      uuid: c44e43b5-ba69-4805-8d01-3b04dcbf2cb6
+      width: 8
+    parents:
+    - ROOT_ID
+    - GRID_ID
+    - TABS-UDkdlBRw4n
+    - TAB-_Ey4nPhFr
+    - TABS-nk8aeLmc5o
+    - TAB-nqLFUR_Tg
+    - ROW-_KbR9wzEQb
+    type: CHART
+  CHART-explore-196-1:
+    children: []
+    id: CHART-explore-196-1
+    meta:
+      chartId: 196
+      height: 20
+      sliceName: Learners with Passing Grade
+      uuid: b40cdabc-b265-48d2-913d-a9dfee0b6ab1
+      width: 2
+    parents:
+    - ROOT_ID
+    - GRID_ID
+    - TABS-UDkdlBRw4n
+    - TAB-5Guk2p9fd
+    - ROW-sMfqRh00J
+    - COLUMN-N18OE5OVho
+    type: CHART
+  CHART-explore-197-1:
+    children: []
+    id: CHART-explore-197-1
+    meta:
+      chartId: 197
+      height: 50
+      sliceName: Distribution of Current Course Grade
+      uuid: ea565658-6796-40e8-9d1e-01ffd0778bc9
+      width: 5
+    parents:
+    - ROOT_ID
+    - GRID_ID
+    - TABS-UDkdlBRw4n
+    - TAB-5Guk2p9fd
+    - ROW-sMfqRh00J
+    type: CHART
+  CHART-explore-198-1:
+    children: []
+    id: CHART-explore-198-1
+    meta:
+      chartId: 198
+      height: 50
+      sliceName: Problem Interactions
+      uuid: ba14d2ea-8c53-4f79-aa1b-434011f3c725
+      width: 4
+    parents:
+    - ROOT_ID
+    - GRID_ID
+    - TABS-UDkdlBRw4n
+    - TAB-5Guk2p9fd
+    - ROW-5XL--Uysk
+    type: CHART
+  CHART-explore-199-1:
+    children: []
+    id: CHART-explore-199-1
+    meta:
+      chartId: 199
+      height: 50
+      sliceName: Problem Results
+      uuid: 2d7e5995-922e-44f4-be34-18f553dbcd21
+      width: 4
+    parents:
+    - ROOT_ID
+    - GRID_ID
+    - TABS-UDkdlBRw4n
+    - TAB-5Guk2p9fd
+    - ROW-5XL--Uysk
+    type: CHART
+  CHART-jsy_lFvqGu:
+    children: []
+    id: CHART-jsy_lFvqGu
+    meta:
+      chartId: 203
+      height: 50
+      sliceName: Video views per section/subsection
+      uuid: 2c8072e7-44d1-4337-a843-aa2eb670b70e
+      width: 12
+    parents:
+    - ROOT_ID
+    - GRID_ID
+    - TABS-UDkdlBRw4n
+    - TAB-_Ey4nPhFr
+    - TABS-nk8aeLmc5o
+    - TAB-V5zNdxwhsP
+    - ROW-_dGQijoSEk
+    type: CHART
+  COLUMN-2jtUMCFWN3:
+    children:
+    - MARKDOWN-OJhMYV_oUT
+    - CHART-explore-189-1
+    id: COLUMN-2jtUMCFWN3
+    meta:
+      background: BACKGROUND_TRANSPARENT
+      width: 7
+    parents:
+    - ROOT_ID
+    - GRID_ID
+    - TABS-UDkdlBRw4n
+    - TAB-4ptSkqs5MS
+    - ROW-EpJDdqK8c
+    type: COLUMN
+  COLUMN-N18OE5OVho:
+    children:
+    - CHART-explore-196-1
+    id: COLUMN-N18OE5OVho
+    meta:
+      background: BACKGROUND_TRANSPARENT
+      width: 2
+    parents:
+    - ROOT_ID
+    - GRID_ID
+    - TABS-UDkdlBRw4n
+    - TAB-5Guk2p9fd
+    - ROW-sMfqRh00J
+    type: COLUMN
+  COLUMN-ttuyLjaKs0:
+    children:
+    - MARKDOWN-sjJpVYkXem
+    - CHART-explore-186-1
+    id: COLUMN-ttuyLjaKs0
+    meta:
+      background: BACKGROUND_TRANSPARENT
+      width: 8
+    parents:
+    - ROOT_ID
+    - GRID_ID
+    - ROW-qDVwqO3bi4
+    type: COLUMN
+  DASHBOARD_VERSION_KEY: v2
+  GRID_ID:
+    children:
+    - ROW-qDVwqO3bi4
+    - TABS-UDkdlBRw4n
+    id: GRID_ID
+    parents:
+    - ROOT_ID
+    type: GRID
+  HEADER_ID:
+    id: HEADER_ID
+    meta:
+      text: Course Dashboard V1
+    type: HEADER
+  MARKDOWN-30KBrMMImF:
+    children: []
+    id: MARKDOWN-30KBrMMImF
+    meta:
+      code: Information is needed on which section and subsection each problem is
+        located in and whether or not these are graded. I have already sent the request
+        and the report is being worked on.
+      height: 50
+      width: 4
+    parents:
+    - ROOT_ID
+    - GRID_ID
+    - TABS-UDkdlBRw4n
+    - TAB-5Guk2p9fd
+    - ROW-5XL--Uysk
+    type: MARKDOWN
+  MARKDOWN-OJhMYV_oUT:
+    children: []
+    id: MARKDOWN-OJhMYV_oUT
+    meta:
+      code: "\u23F2\uFE0F Use the \u2018Time Grain\u2019 filter to update the time\
+        \ frame intervals shown in the following graph(s)"
+      height: 8
+      width: 3
+    parents:
+    - ROOT_ID
+    - GRID_ID
+    - TABS-UDkdlBRw4n
+    - TAB-4ptSkqs5MS
+    - ROW-EpJDdqK8c
+    - COLUMN-2jtUMCFWN3
+    type: MARKDOWN
+  MARKDOWN-sjJpVYkXem:
+    children: []
+    id: MARKDOWN-sjJpVYkXem
+    meta:
+      code: ' The number of learners who completed at least one graded problem in
+        the course.'
+      height: 8
+      width: 4
+    parents:
+    - ROOT_ID
+    - GRID_ID
+    - ROW-qDVwqO3bi4
+    - COLUMN-ttuyLjaKs0
+    type: MARKDOWN
+  ROOT_ID:
+    children:
+    - GRID_ID
+    id: ROOT_ID
+    type: ROOT
+  ROW-5XL--Uysk:
+    children:
+    - CHART-explore-198-1
+    - CHART-explore-199-1
+    - MARKDOWN-30KBrMMImF
+    id: ROW-5XL--Uysk
+    meta:
+      background: BACKGROUND_TRANSPARENT
+    parents:
+    - ROOT_ID
+    - GRID_ID
+    - TABS-UDkdlBRw4n
+    - TAB-5Guk2p9fd
+    type: ROW
+  ROW-6oVc0KNyM1:
+    children:
+    - CHART-8p_tmmvFsY
+    id: ROW-6oVc0KNyM1
+    meta:
+      background: BACKGROUND_TRANSPARENT
+    parents:
+    - ROOT_ID
+    - GRID_ID
+    - TABS-UDkdlBRw4n
+    - TAB-_Ey4nPhFr
+    - TABS-nk8aeLmc5o
+    - TAB-nqLFUR_Tg
+    type: ROW
+  ROW-EpJDdqK8c:
+    children:
+    - CHART-explore-188-1
+    - COLUMN-2jtUMCFWN3
+    id: ROW-EpJDdqK8c
+    meta:
+      background: BACKGROUND_TRANSPARENT
+    parents:
+    - ROOT_ID
+    - GRID_ID
+    - TABS-UDkdlBRw4n
+    - TAB-4ptSkqs5MS
+    type: ROW
+  ROW-GlQl7V_ol:
+    children:
+    - CHART-explore-192-1
+    - CHART-explore-194-1
+    id: ROW-GlQl7V_ol
+    meta:
+      background: BACKGROUND_TRANSPARENT
+    parents:
+    - ROOT_ID
+    - GRID_ID
+    - TABS-UDkdlBRw4n
+    - TAB-_Ey4nPhFr
+    - TABS-nk8aeLmc5o
+    - TAB-nqLFUR_Tg
+    type: ROW
+  ROW-ToSAm6kqA2:
+    children:
+    - CHART-Q6nr6irIdz
+    id: ROW-ToSAm6kqA2
+    meta:
+      background: BACKGROUND_TRANSPARENT
+    parents:
+    - ROOT_ID
+    - GRID_ID
+    - TABS-UDkdlBRw4n
+    - TAB-_Ey4nPhFr
+    - TABS-nk8aeLmc5o
+    - TAB-V5zNdxwhsP
+    type: ROW
+  ROW-_KbR9wzEQb:
+    children:
+    - CHART-explore-191-1
+    - CHART-explore-195-1
+    id: ROW-_KbR9wzEQb
+    meta:
+      background: BACKGROUND_TRANSPARENT
+    parents:
+    - ROOT_ID
+    - GRID_ID
+    - TABS-UDkdlBRw4n
+    - TAB-_Ey4nPhFr
+    - TABS-nk8aeLmc5o
+    - TAB-nqLFUR_Tg
+    type: ROW
+  ROW-_dGQijoSEk:
+    children:
+    - CHART-jsy_lFvqGu
+    id: ROW-_dGQijoSEk
+    meta:
+      background: BACKGROUND_TRANSPARENT
+    parents:
+    - ROOT_ID
+    - GRID_ID
+    - TABS-UDkdlBRw4n
+    - TAB-_Ey4nPhFr
+    - TABS-nk8aeLmc5o
+    - TAB-V5zNdxwhsP
+    type: ROW
+  ROW-iV463iCf2a:
+    children:
+    - CHART-LiY7tPJWZv
+    id: ROW-iV463iCf2a
+    meta:
+      background: BACKGROUND_TRANSPARENT
+    parents:
+    - ROOT_ID
+    - GRID_ID
+    - TABS-UDkdlBRw4n
+    - TAB-_Ey4nPhFr
+    - TABS-nk8aeLmc5o
+    - TAB-vze5iq6jg
+    type: ROW
+  ROW-qDVwqO3bi4:
+    children:
+    - CHART-explore-185-1
+    - COLUMN-ttuyLjaKs0
+    id: ROW-qDVwqO3bi4
+    meta:
+      background: BACKGROUND_TRANSPARENT
+    parents:
+    - ROOT_ID
+    - GRID_ID
+    type: ROW
+  ROW-sMfqRh00J:
+    children:
+    - COLUMN-N18OE5OVho
+    - CHART-explore-197-1
+    id: ROW-sMfqRh00J
+    meta:
+      background: BACKGROUND_TRANSPARENT
+    parents:
+    - ROOT_ID
+    - GRID_ID
+    - TABS-UDkdlBRw4n
+    - TAB-5Guk2p9fd
+    type: ROW
+  ROW-vpQpToPQb:
+    children:
+    - CHART-_BfZOEhMVM
+    id: ROW-vpQpToPQb
+    meta:
+      background: BACKGROUND_TRANSPARENT
+    parents:
+    - ROOT_ID
+    - GRID_ID
+    - TABS-UDkdlBRw4n
+    - TAB-_Ey4nPhFr
+    - TABS-nk8aeLmc5o
+    - TAB-V5zNdxwhsP
+    type: ROW
+  TAB-4ptSkqs5MS:
+    children:
+    - ROW-EpJDdqK8c
+    id: TAB-4ptSkqs5MS
+    meta:
+      defaultText: Tab title
+      placeholder: Tab title
+      text: Enrollment
+    parents:
+    - ROOT_ID
+    - GRID_ID
+    - TABS-UDkdlBRw4n
+    type: TAB
+  TAB-5Guk2p9fd:
+    children:
+    - ROW-sMfqRh00J
+    - ROW-5XL--Uysk
+    id: TAB-5Guk2p9fd
+    meta:
+      defaultText: Tab title
+      placeholder: Tab title
+      text: Performance
+    parents:
+    - ROOT_ID
+    - GRID_ID
+    - TABS-UDkdlBRw4n
+    type: TAB
+  TAB-V5zNdxwhsP:
+    children:
+    - ROW-_dGQijoSEk
+    - ROW-vpQpToPQb
+    - ROW-ToSAm6kqA2
+    id: TAB-V5zNdxwhsP
+    meta:
+      defaultText: Tab title
+      placeholder: Tab title
+      text: Videos
+    parents:
+    - ROOT_ID
+    - GRID_ID
+    - TABS-UDkdlBRw4n
+    - TAB-_Ey4nPhFr
+    - TABS-nk8aeLmc5o
+    type: TAB
+  TAB-_Ey4nPhFr:
+    children:
+    - TABS-nk8aeLmc5o
+    id: TAB-_Ey4nPhFr
+    meta:
+      defaultText: Tab title
+      placeholder: Tab title
+      text: Engagement
+    parents:
+    - ROOT_ID
+    - GRID_ID
+    - TABS-UDkdlBRw4n
+    type: TAB
+  TAB-nqLFUR_Tg:
+    children:
+    - ROW-6oVc0KNyM1
+    - ROW-_KbR9wzEQb
+    - ROW-GlQl7V_ol
+    id: TAB-nqLFUR_Tg
+    meta:
+      defaultText: Tab title
+      placeholder: Tab title
+      text: Pages
+    parents:
+    - ROOT_ID
+    - GRID_ID
+    - TABS-UDkdlBRw4n
+    - TAB-_Ey4nPhFr
+    - TABS-nk8aeLmc5o
+    type: TAB
+  TAB-vze5iq6jg:
+    children:
+    - ROW-iV463iCf2a
+    id: TAB-vze5iq6jg
+    meta:
+      defaultText: Tab title
+      placeholder: Tab title
+      text: Problems
+    parents:
+    - ROOT_ID
+    - GRID_ID
+    - TABS-UDkdlBRw4n
+    - TAB-_Ey4nPhFr
+    - TABS-nk8aeLmc5o
+    type: TAB
+  TABS-UDkdlBRw4n:
+    children:
+    - TAB-4ptSkqs5MS
+    - TAB-_Ey4nPhFr
+    - TAB-5Guk2p9fd
+    id: TABS-UDkdlBRw4n
+    meta: {}
+    parents:
+    - ROOT_ID
+    - GRID_ID
+    type: TABS
+  TABS-nk8aeLmc5o:
+    children:
+    - TAB-nqLFUR_Tg
+    - TAB-vze5iq6jg
+    - TAB-V5zNdxwhsP
+    id: TABS-nk8aeLmc5o
+    meta: {}
+    parents:
+    - ROOT_ID
+    - GRID_ID
+    - TABS-UDkdlBRw4n
+    - TAB-_Ey4nPhFr
+    type: TABS
+slug: null
+uuid: c0e64194-33d1-4d5a-8c10-4f51530c5ee9
+version: 1.0.0

--- a/tutoraspects/templates/aspects/build/aspects-superset/openedx-assets/assets/dashboards/Course_Dashboard_V1.yaml
+++ b/tutoraspects/templates/aspects/build/aspects-superset/openedx-assets/assets/dashboards/Course_Dashboard_V1.yaml
@@ -1,6 +1,8 @@
 _file_name: Course_Dashboard_V1.yaml
 _roles:
 - '{{ SUPERSET_ROLES_MAPPING.instructor }}'
+certification_details: null
+certified_by: null
 css: ''
 dashboard_title: Course Dashboard V1
 description: null
@@ -456,11 +458,11 @@ metadata:
     name: Date
     scope:
       excluded:
-      - 186
-      - 191
-      - 192
-      - 194
-      - 195
+      - 51
+      - 54
+      - 55
+      - 52
+      - 47
       rootPath:
       - ROOT_ID
     tabsInScope:
@@ -488,10 +490,9 @@ metadata:
     name: Time Grain
     scope:
       excluded:
-      - 187
-      - 188
-      - 191
-      - 192
+      - 50
+      - 54
+      - 55
       rootPath:
       - TAB-4ptSkqs5MS
       - TAB-_Ey4nPhFr
@@ -525,21 +526,20 @@ metadata:
     name: Video name
     scope:
       excluded:
-      - 201
-      - 202
-      - 185
-      - 186
-      - 187
-      - 188
-      - 189
-      - 191
-      - 192
-      - 194
-      - 195
-      - 196
-      - 197
-      - 198
-      - 199
+      - 49
+      - 46
+      - 58
+      - 51
+      - 50
+      - 60
+      - 54
+      - 55
+      - 52
+      - 47
+      - 59
+      - 48
+      - 57
+      - 56
       rootPath:
       - ROOT_ID
     tabsInScope:
@@ -567,7 +567,7 @@ position:
     children: []
     id: CHART-8p_tmmvFsY
     meta:
-      chartId: 201
+      chartId: 49
       height: 50
       sliceName: Page views per section/subsection
       uuid: 0538470d-0328-4f15-9e48-ffc9e84c4c06
@@ -585,7 +585,7 @@ position:
     children: []
     id: CHART-LiY7tPJWZv
     meta:
-      chartId: 202
+      chartId: 46
       height: 50
       sliceName: Problems attempted per section/subsection
       uuid: 869edaf6-f911-4ca7-9e4b-28435bba2e82
@@ -603,7 +603,7 @@ position:
     children: []
     id: CHART-Q6nr6irIdz
     meta:
-      chartId: 45
+      chartId: 28
       height: 50
       sliceName: Watched Video Segments
       uuid: 2985a9db-c338-4008-af52-2930b81ee2e5
@@ -621,7 +621,7 @@ position:
     children: []
     id: CHART-_BfZOEhMVM
     meta:
-      chartId: 204
+      chartId: 61
       height: 50
       sliceName: Partial and full views per video
       uuid: 14c5cd80-cb50-4136-9911-d77da1737d69
@@ -639,7 +639,7 @@ position:
     children: []
     id: CHART-explore-185-1
     meta:
-      chartId: 185
+      chartId: 58
       height: 28
       sliceName: Current Enrollees
       uuid: 00de2f72-b3ed-4994-b231-fd3cf29d758d
@@ -653,7 +653,7 @@ position:
     children: []
     id: CHART-explore-186-1
     meta:
-      chartId: 186
+      chartId: 51
       height: 18
       sliceName: Course Information
       uuid: fa249dda-78da-4ccc-9ef3-39177e6aae0c
@@ -668,7 +668,7 @@ position:
     children: []
     id: CHART-explore-188-1
     meta:
-      chartId: 188
+      chartId: 50
       height: 64
       sliceName: Enrollees per Enrollment Track
       uuid: e584199e-0ed6-42bf-afb9-db3b9fe4132b
@@ -684,7 +684,7 @@ position:
     children: []
     id: CHART-explore-189-1
     meta:
-      chartId: 189
+      chartId: 60
       height: 51
       sliceName: Cumulative Enrollments by Track
       uuid: f207c896-030a-462b-b69f-6416230d50b6
@@ -701,7 +701,7 @@ position:
     children: []
     id: CHART-explore-191-1
     meta:
-      chartId: 191
+      chartId: 54
       height: 50
       sliceName: Section Summary
       uuid: 47417136-acd1-44a1-b41e-644eb2c237c3
@@ -719,7 +719,7 @@ position:
     children: []
     id: CHART-explore-192-1
     meta:
-      chartId: 192
+      chartId: 55
       height: 50
       sliceName: Subsection Summary
       uuid: 2a8d96be-687d-4918-98fe-ae9fbd599152
@@ -737,7 +737,7 @@ position:
     children: []
     id: CHART-explore-194-1
     meta:
-      chartId: 194
+      chartId: 52
       height: 50
       sliceName: Evolution of engagement
       uuid: d3ae0546-37a8-4841-a57b-8087a6c33049
@@ -755,7 +755,7 @@ position:
     children: []
     id: CHART-explore-195-1
     meta:
-      chartId: 195
+      chartId: 47
       height: 50
       sliceName: Cumulative Interactions
       uuid: c44e43b5-ba69-4805-8d01-3b04dcbf2cb6
@@ -773,7 +773,7 @@ position:
     children: []
     id: CHART-explore-196-1
     meta:
-      chartId: 196
+      chartId: 59
       height: 20
       sliceName: Learners with Passing Grade
       uuid: b40cdabc-b265-48d2-913d-a9dfee0b6ab1
@@ -790,7 +790,7 @@ position:
     children: []
     id: CHART-explore-197-1
     meta:
-      chartId: 197
+      chartId: 48
       height: 50
       sliceName: Distribution of Current Course Grade
       uuid: ea565658-6796-40e8-9d1e-01ffd0778bc9
@@ -806,7 +806,7 @@ position:
     children: []
     id: CHART-explore-198-1
     meta:
-      chartId: 198
+      chartId: 57
       height: 50
       sliceName: Problem Interactions
       uuid: ba14d2ea-8c53-4f79-aa1b-434011f3c725
@@ -822,7 +822,7 @@ position:
     children: []
     id: CHART-explore-199-1
     meta:
-      chartId: 199
+      chartId: 56
       height: 50
       sliceName: Problem Results
       uuid: 2d7e5995-922e-44f4-be34-18f553dbcd21
@@ -838,7 +838,7 @@ position:
     children: []
     id: CHART-jsy_lFvqGu
     meta:
-      chartId: 203
+      chartId: 53
       height: 50
       sliceName: Video views per section/subsection
       uuid: 2c8072e7-44d1-4337-a843-aa2eb670b70e
@@ -1223,6 +1223,7 @@ position:
     - TABS-UDkdlBRw4n
     - TAB-_Ey4nPhFr
     type: TABS
+published: true
 slug: null
 uuid: c0e64194-33d1-4d5a-8c10-4f51530c5ee9
 version: 1.0.0

--- a/tutoraspects/templates/aspects/build/aspects-superset/openedx-assets/assets/dashboards/Individual_Learner_Reports.yaml
+++ b/tutoraspects/templates/aspects/build/aspects-superset/openedx-assets/assets/dashboards/Individual_Learner_Reports.yaml
@@ -1,13 +1,35 @@
 _file_name: Individual_Learner_Reports.yaml
 _roles:
 - '{{ SUPERSET_ROLES_MAPPING.instructor }}'
+certification_details: null
+certified_by: null
 css: ''
 dashboard_title: Individual Learner Reports
 description: null
 metadata:
   chart_configuration: {}
-  color_scheme: ''
-  color_scheme_domain: []
+  color_scheme: supersetColors
+  color_scheme_domain:
+  - '#1FA8C9'
+  - '#454E7C'
+  - '#5AC189'
+  - '#FF7F44'
+  - '#666666'
+  - '#E04355'
+  - '#FCC700'
+  - '#A868B7'
+  - '#3CCCCB'
+  - '#A38F79'
+  - '#8FD3E4'
+  - '#A1A6BD'
+  - '#ACE1C4'
+  - '#FEC0A1'
+  - '#B2B2B2'
+  - '#EFA1AA'
+  - '#FDE380'
+  - '#D3B3DA'
+  - '#9EE5E5'
+  - '#D1C6BC'
   cross_filters_enabled: true
   default_filters: '{}'
   expanded_slices: {}
@@ -39,6 +61,7 @@ position:
     - GRID_ID
     id: ROOT_ID
     type: ROOT
+published: true
 slug: individual-learner
 uuid: abae8a25-1ba4-4653-81bd-d3937a162a11
 version: 1.0.0

--- a/tutoraspects/templates/aspects/build/aspects-superset/openedx-assets/assets/dashboards/Instructor_Dashboard.yaml
+++ b/tutoraspects/templates/aspects/build/aspects-superset/openedx-assets/assets/dashboards/Instructor_Dashboard.yaml
@@ -118,30 +118,28 @@ metadata:
         - 921
         scope: global
       id: 901
-    '921':
-      crossFilters:
-        chartsInScope:
-        - 114
-        - 154
-        - 156
-        - 229
-        - 325
-        - 327
-        - 339
-        - 516
-        - 597
-        - 625
-        - 682
-        - 695
-        - 701
-        - 770
-        - 783
-        - 816
-        - 901
-        scope: global
-      id: 921
-  color_scheme: ''
-  color_scheme_domain: []
+  color_scheme: supersetColors
+  color_scheme_domain:
+  - '#1FA8C9'
+  - '#454E7C'
+  - '#5AC189'
+  - '#FF7F44'
+  - '#666666'
+  - '#E04355'
+  - '#FCC700'
+  - '#A868B7'
+  - '#3CCCCB'
+  - '#A38F79'
+  - '#8FD3E4'
+  - '#A1A6BD'
+  - '#ACE1C4'
+  - '#FEC0A1'
+  - '#B2B2B2'
+  - '#EFA1AA'
+  - '#FDE380'
+  - '#D3B3DA'
+  - '#9EE5E5'
+  - '#D1C6BC'
   cross_filters_enabled: false
   default_filters: '{}'
   expanded_slices: {}

--- a/tutoraspects/templates/aspects/build/aspects-superset/openedx-assets/assets/dashboards/Learner_Groups_Reports.yaml
+++ b/tutoraspects/templates/aspects/build/aspects-superset/openedx-assets/assets/dashboards/Learner_Groups_Reports.yaml
@@ -1,13 +1,35 @@
 _file_name: Learner_Groups_Reports.yaml
 _roles:
 - '{{ SUPERSET_ROLES_MAPPING.instructor }}'
+certification_details: null
+certified_by: null
 css: ''
 dashboard_title: Learner Groups Reports
 description: null
 metadata:
   chart_configuration: {}
-  color_scheme: ''
-  color_scheme_domain: []
+  color_scheme: supersetColors
+  color_scheme_domain:
+  - '#1FA8C9'
+  - '#454E7C'
+  - '#5AC189'
+  - '#FF7F44'
+  - '#666666'
+  - '#E04355'
+  - '#FCC700'
+  - '#A868B7'
+  - '#3CCCCB'
+  - '#A38F79'
+  - '#8FD3E4'
+  - '#A1A6BD'
+  - '#ACE1C4'
+  - '#FEC0A1'
+  - '#B2B2B2'
+  - '#EFA1AA'
+  - '#FDE380'
+  - '#D3B3DA'
+  - '#9EE5E5'
+  - '#D1C6BC'
   cross_filters_enabled: true
   default_filters: '{}'
   expanded_slices: {}
@@ -39,6 +61,7 @@ position:
     - GRID_ID
     id: ROOT_ID
     type: ROOT
+published: true
 slug: learner-groups
 uuid: 8661d20c-cee6-4245-9fcc-610daea5fd24
 version: 1.0.0

--- a/tutoraspects/templates/aspects/build/aspects-superset/openedx-assets/assets/dashboards/Operator_Dashboard.yaml
+++ b/tutoraspects/templates/aspects/build/aspects-superset/openedx-assets/assets/dashboards/Operator_Dashboard.yaml
@@ -1,6 +1,8 @@
 _file_name: Operator_Dashboard.yaml
 _roles:
 - '{{ SUPERSET_ROLES_MAPPING.operator }}'
+certification_details: null
+certified_by: null
 css: ''
 dashboard_title: Operator Dashboard
 description: null
@@ -711,10 +713,10 @@ metadata:
     name: Action Cluster
     scope:
       excluded:
-      - 662
-      - 3
-      - 566
-      - 235
+      - 34
+      - 29
+      - 18
+      - 45
       rootPath:
       - TAB-z7LunkNp63
     tabsInScope:
@@ -737,7 +739,7 @@ position:
     children: []
     id: CHART-4xInxcau02
     meta:
-      chartId: 469
+      chartId: 44
       height: 50
       sliceName: ClickHouse metrics
       uuid: 2f84cbc3-4068-4d4d-bd40-ae348e4be95d
@@ -753,7 +755,7 @@ position:
     children: []
     id: CHART-5vkH5rVBW4
     meta:
-      chartId: 566
+      chartId: 18
       height: 50
       sliceName: Chart Count
       uuid: a5e0f18b-fb83-4d65-81e0-5f0e620fa05b
@@ -769,7 +771,7 @@ position:
     children: []
     id: CHART-6LMXcXxaaa
     meta:
-      chartId: 3
+      chartId: 29
       height: 50
       sliceName: Dashboard Count
       uuid: 8368fe0b-5e64-4ad5-b93b-93f8a6f848af
@@ -785,7 +787,7 @@ position:
     children: []
     id: CHART-6cANA_o-Ss
     meta:
-      chartId: 783
+      chartId: 26
       height: 17
       sliceName: Total Actors v2
       uuid: 15620ae6-5452-4a11-bc7e-56c7e5987a4d
@@ -802,7 +804,7 @@ position:
     children: []
     id: CHART-8MbVYXA12V
     meta:
-      chartId: 349
+      chartId: 7
       height: 50
       sliceName: Most-used Dashboards
       uuid: 36842ef1-d4e9-4cb6-83f7-cb9b34eaab77
@@ -818,7 +820,7 @@ position:
     children: []
     id: CHART-8rDUkRBgv9
     meta:
-      chartId: 351
+      chartId: 23
       height: 50
       sliceName: Enrollments By Type
       uuid: 6c473b09-6a1a-4531-b71d-ab82e09721ef
@@ -834,7 +836,7 @@ position:
     children: []
     id: CHART-H4NTUWfMqH
     meta:
-      chartId: 22
+      chartId: 1
       height: 50
       sliceName: Course Enrollments Over Time
       uuid: bf4f4671-c276-4185-9b9a-b10864efea6c
@@ -850,7 +852,7 @@ position:
     children: []
     id: CHART-La3O2IbbVV
     meta:
-      chartId: 245
+      chartId: 19
       height: 50
       sliceName: Slowest ClickHouse Queries
       uuid: 953af3e5-8fc6-441e-bff1-22987735edf0
@@ -866,7 +868,7 @@ position:
     children: []
     id: CHART-SG5jU4pQPt
     meta:
-      chartId: 235
+      chartId: 45
       height: 36
       sliceName: Registered Users Over Time
       uuid: 68011361-ea45-4875-9165-c84ddbcd1fc5
@@ -882,7 +884,7 @@ position:
     children: []
     id: CHART-Yv5sneg3nD
     meta:
-      chartId: 526
+      chartId: 15
       height: 36
       sliceName: Active Users
       uuid: bc5f7a27-670c-4794-963b-8082b258566f
@@ -898,7 +900,7 @@ position:
     children: []
     id: CHART-ZUWwFA9-Gd
     meta:
-      chartId: 782
+      chartId: 31
       height: 50
       sliceName: xAPI Events Over Time v2
       uuid: 8a81d381-7c40-4902-8bb9-bcbe50aa8780
@@ -914,7 +916,7 @@ position:
     children: []
     id: CHART-dLbZ-a2Mj1
     meta:
-      chartId: 393
+      chartId: 14
       height: 36
       sliceName: Active Users Over Time
       uuid: 66ef96e7-9616-4f28-90b6-68f13ce58b0a
@@ -930,7 +932,7 @@ position:
     children: []
     id: CHART-eOEkWVWOcd
     meta:
-      chartId: 54
+      chartId: 36
       height: 50
       sliceName: Most-used Charts
       uuid: 9d5f69e8-f335-42a0-bbfa-272f43d74ad0
@@ -946,7 +948,7 @@ position:
     children: []
     id: CHART-explore-17-1
     meta:
-      chartId: 749
+      chartId: 43
       height: 16
       sliceName: Last Received Event
       uuid: ffdaabc5-8d01-47d7-8f29-66efa643befb
@@ -962,7 +964,7 @@ position:
     children: []
     id: CHART-explore-19-1
     meta:
-      chartId: 513
+      chartId: 33
       height: 16
       sliceName: Last course syncronized
       sliceNameOverride: Last Course Published
@@ -979,7 +981,7 @@ position:
     children: []
     id: CHART-explore-20-1
     meta:
-      chartId: 358
+      chartId: 24
       height: 14
       sliceName: Total Organizations
       uuid: e66b1cdb-6974-4fa2-a769-4908665118f6
@@ -996,7 +998,7 @@ position:
     children: []
     id: CHART-explore-22-1
     meta:
-      chartId: 149
+      chartId: 9
       height: 15
       sliceName: Courses
       sliceNameOverride: Total Courses
@@ -1014,7 +1016,7 @@ position:
     children: []
     id: CHART-explore-784-1
     meta:
-      chartId: 784
+      chartId: 37
       height: 50
       sliceName: Events per course
       uuid: 269c5919-2d2e-493d-8c29-14e7b8222ee4
@@ -1030,7 +1032,7 @@ position:
     children: []
     id: CHART-explore-786-1
     meta:
-      chartId: 786
+      chartId: 41
       height: 50
       sliceName: Most Active Courses Per Day
       uuid: 0c377fa6-6a0b-4b07-8de4-c828915d4aa6
@@ -1046,7 +1048,7 @@ position:
     children: []
     id: CHART-explore-787-1
     meta:
-      chartId: 787
+      chartId: 42
       height: 50
       sliceName: Courses Per Organization
       uuid: 12fc799d-5d02-4861-892c-4e04cbc1f87a
@@ -1062,7 +1064,7 @@ position:
     children: []
     id: CHART-explore-788-1
     meta:
-      chartId: 788
+      chartId: 5
       height: 50
       sliceName: Active Users Per Organization
       uuid: 02af00f5-6539-428f-b3ab-632997de7528
@@ -1078,7 +1080,7 @@ position:
     children: []
     id: CHART-o3DU3d8aMU
     meta:
-      chartId: 486
+      chartId: 21
       height: 38
       sliceName: User Actions
       uuid: 8059fd82-efae-47a1-9c23-0b74f2707aa5
@@ -1094,7 +1096,7 @@ position:
     children: []
     id: CHART-sCnLhdyOJf
     meta:
-      chartId: 662
+      chartId: 34
       height: 50
       sliceName: Charts by Type
       uuid: 84393abe-04ab-4084-a195-116ad568badd
@@ -1110,7 +1112,7 @@ position:
     children: []
     id: CHART-s_HCV-cTCd
     meta:
-      chartId: 781
+      chartId: 40
       height: 50
       sliceName: Active Users Over Time v2
       uuid: e1d619a2-6238-4264-a000-6b6856027edd
@@ -1491,9 +1493,7 @@ position:
     - TAB-EygpebMa1
     - TAB-gvqU89mvT
     - TAB-z7LunkNp63
-    # {% if ASPECTS_OPERATOR_HELP_MARKDOWN %}
     - TAB-RtC9PHwXy
-    # {% endif %}
     - TAB-nXpinnLEX
     id: TABS-7nA6MwltSD
     meta: {}
@@ -1501,6 +1501,7 @@ position:
     - ROOT_ID
     - GRID_ID
     type: TABS
+published: true
 slug: operator-dashboard
 uuid: 02c0121c-40e9-4d8a-b86a-6b996a1cc6fe
 version: 1.0.0

--- a/tutoraspects/templates/aspects/build/aspects-superset/openedx-assets/assets/datasets/ab_user.yaml
+++ b/tutoraspects/templates/aspects/build/aspects-superset/openedx-assets/assets/datasets/ab_user.yaml
@@ -1,42 +1,7 @@
 _file_name: ab_user.yaml
+always_filter_main_dttm: false
 cache_timeout: null
 columns:
-- advanced_data_type: null
-  column_name: created_on
-  description: null
-  expression: ''
-  extra: {}
-  filterable: true
-  groupby: true
-  is_active: true
-  is_dttm: true
-  python_date_format: null
-  type: TIMESTAMP WITHOUT TIME ZONE
-  verbose_name: Created On
-- advanced_data_type: null
-  column_name: changed_on
-  description: null
-  expression: ''
-  extra: {}
-  filterable: true
-  groupby: true
-  is_active: true
-  is_dttm: true
-  python_date_format: null
-  type: TIMESTAMP WITHOUT TIME ZONE
-  verbose_name: Changed On
-- advanced_data_type: null
-  column_name: last_login
-  description: null
-  expression: ''
-  extra: {}
-  filterable: true
-  groupby: true
-  is_active: true
-  is_dttm: true
-  python_date_format: null
-  type: TIMESTAMP WITHOUT TIME ZONE
-  verbose_name: Last Login
 - advanced_data_type: null
   column_name: created_by_fk
   description: null
@@ -47,7 +12,7 @@ columns:
   is_active: true
   is_dttm: false
   python_date_format: null
-  type: INTEGER
+  type: LONG
   verbose_name: Created By Fk
 - advanced_data_type: null
   column_name: changed_by_fk
@@ -59,7 +24,7 @@ columns:
   is_active: true
   is_dttm: false
   python_date_format: null
-  type: INTEGER
+  type: LONG
   verbose_name: Changed By Fk
 - advanced_data_type: null
   column_name: fail_login_count
@@ -71,8 +36,44 @@ columns:
   is_active: true
   is_dttm: false
   python_date_format: null
-  type: INTEGER
+  type: LONG
   verbose_name: Fail Login Count
+- advanced_data_type: null
+  column_name: created_on
+  description: null
+  expression: ''
+  extra: {}
+  filterable: true
+  groupby: true
+  is_active: true
+  is_dttm: true
+  python_date_format: null
+  type: DATETIME
+  verbose_name: Created On
+- advanced_data_type: null
+  column_name: changed_on
+  description: null
+  expression: ''
+  extra: {}
+  filterable: true
+  groupby: true
+  is_active: true
+  is_dttm: true
+  python_date_format: null
+  type: DATETIME
+  verbose_name: Changed On
+- advanced_data_type: null
+  column_name: last_login
+  description: null
+  expression: ''
+  extra: {}
+  filterable: true
+  groupby: true
+  is_active: true
+  is_dttm: true
+  python_date_format: null
+  type: DATETIME
+  verbose_name: Last Login
 - advanced_data_type: null
   column_name: first_name
   description: null
@@ -83,7 +84,7 @@ columns:
   is_active: true
   is_dttm: false
   python_date_format: null
-  type: VARCHAR(64)
+  type: VAR_STRING
   verbose_name: First Name
 - advanced_data_type: null
   column_name: last_name
@@ -95,7 +96,7 @@ columns:
   is_active: true
   is_dttm: false
   python_date_format: null
-  type: VARCHAR(64)
+  type: VAR_STRING
   verbose_name: Last Name
 - advanced_data_type: null
   column_name: login_count
@@ -107,20 +108,8 @@ columns:
   is_active: true
   is_dttm: false
   python_date_format: null
-  type: INTEGER
+  type: LONG
   verbose_name: Login Count
-- advanced_data_type: null
-  column_name: password
-  description: null
-  expression: ''
-  extra: {}
-  filterable: true
-  groupby: true
-  is_active: true
-  is_dttm: false
-  python_date_format: null
-  type: VARCHAR(256)
-  verbose_name: Password
 - advanced_data_type: null
   column_name: email
   description: null
@@ -131,8 +120,20 @@ columns:
   is_active: true
   is_dttm: false
   python_date_format: null
-  type: VARCHAR(64)
+  type: VAR_STRING
   verbose_name: Email
+- advanced_data_type: null
+  column_name: password
+  description: null
+  expression: ''
+  extra: {}
+  filterable: true
+  groupby: true
+  is_active: true
+  is_dttm: false
+  python_date_format: null
+  type: VAR_STRING
+  verbose_name: Password
 - advanced_data_type: null
   column_name: username
   description: null
@@ -143,7 +144,7 @@ columns:
   is_active: true
   is_dttm: false
   python_date_format: null
-  type: VARCHAR(64)
+  type: VAR_STRING
   verbose_name: Username
 - advanced_data_type: null
   column_name: active
@@ -155,7 +156,7 @@ columns:
   is_active: true
   is_dttm: false
   python_date_format: null
-  type: BOOLEAN
+  type: TINY
   verbose_name: Active
 - advanced_data_type: null
   column_name: id
@@ -167,7 +168,7 @@ columns:
   is_active: true
   is_dttm: false
   python_date_format: null
-  type: INTEGER
+  type: LONG
   verbose_name: Id
 database_uuid: 06cd566f-e22a-4a79-b0e0-4c947de93ee0
 default_endpoint: null

--- a/tutoraspects/templates/aspects/build/aspects-superset/openedx-assets/assets/datasets/ab_user.yaml
+++ b/tutoraspects/templates/aspects/build/aspects-superset/openedx-assets/assets/datasets/ab_user.yaml
@@ -190,7 +190,7 @@ metrics:
 normalize_columns: false
 offset: 0
 params: null
-schema: superset
+schema: {{ SUPERSET_DB_NAME }}
 sql: select * from ab_user
 table_name: ab_user
 template_params: null

--- a/tutoraspects/templates/aspects/build/aspects-superset/openedx-assets/assets/datasets/ab_user.yaml
+++ b/tutoraspects/templates/aspects/build/aspects-superset/openedx-assets/assets/datasets/ab_user.yaml
@@ -191,7 +191,7 @@ normalize_columns: false
 offset: 0
 params: null
 schema: superset
-sql: select * from superset.ab_user
+sql: select * from ab_user
 table_name: ab_user
 template_params: null
 uuid: 304a5d6d-c589-483a-8e8d-3fadbccef648

--- a/tutoraspects/templates/aspects/build/aspects-superset/openedx-assets/assets/datasets/ab_user.yaml
+++ b/tutoraspects/templates/aspects/build/aspects-superset/openedx-assets/assets/datasets/ab_user.yaml
@@ -190,7 +190,7 @@ metrics:
 normalize_columns: false
 offset: 0
 params: null
-schema: {{ SUPERSET_DB_NAME }}
+schema: '{{ SUPERSET_DB_NAME }}'
 sql: select * from ab_user
 table_name: ab_user
 template_params: null

--- a/tutoraspects/templates/aspects/build/aspects-superset/openedx-assets/assets/datasets/clickhouse_computed_metrics.yaml
+++ b/tutoraspects/templates/aspects/build/aspects-superset/openedx-assets/assets/datasets/clickhouse_computed_metrics.yaml
@@ -1,10 +1,11 @@
 _file_name: clickhouse_computed_metrics.yaml
+always_filter_main_dttm: false
 cache_timeout: null
 columns:
 - advanced_data_type: null
   column_name: value
   description: null
-  expression: null
+  expression: ''
   extra: {}
   filterable: true
   groupby: true
@@ -16,7 +17,7 @@ columns:
 - advanced_data_type: null
   column_name: description
   description: null
-  expression: null
+  expression: ''
   extra: {}
   filterable: true
   groupby: true
@@ -28,7 +29,7 @@ columns:
 - advanced_data_type: null
   column_name: name
   description: null
-  expression: null
+  expression: ''
   extra: {}
   filterable: true
   groupby: true

--- a/tutoraspects/templates/aspects/build/aspects-superset/openedx-assets/assets/datasets/course_blocks.yaml
+++ b/tutoraspects/templates/aspects/build/aspects-superset/openedx-assets/assets/datasets/course_blocks.yaml
@@ -127,7 +127,7 @@ metrics:
   warning_text: null
 offset: 0
 params: null
-schema: main
+schema: {{ASPECTS_EVENT_SINK_DATABASE}}
 sql: "select * from {{ASPECTS_EVENT_SINK_DATABASE}}.{{ ASPECTS_EVENT_SINK_NODES_TABLE }}"
 table_name: "{{ ASPECTS_EVENT_SINK_NODES_TABLE }}"
 template_params: null

--- a/tutoraspects/templates/aspects/build/aspects-superset/openedx-assets/assets/datasets/course_blocks.yaml
+++ b/tutoraspects/templates/aspects/build/aspects-superset/openedx-assets/assets/datasets/course_blocks.yaml
@@ -127,7 +127,7 @@ metrics:
   warning_text: null
 offset: 0
 params: null
-schema: {{ASPECTS_EVENT_SINK_DATABASE}}
+schema: '{{ASPECTS_EVENT_SINK_DATABASE}}'
 sql: "select * from {{ASPECTS_EVENT_SINK_DATABASE}}.{{ ASPECTS_EVENT_SINK_NODES_TABLE }}"
 table_name: "{{ ASPECTS_EVENT_SINK_NODES_TABLE }}"
 template_params: null

--- a/tutoraspects/templates/aspects/build/aspects-superset/openedx-assets/assets/datasets/course_names.yaml
+++ b/tutoraspects/templates/aspects/build/aspects-superset/openedx-assets/assets/datasets/course_names.yaml
@@ -70,7 +70,7 @@ metrics:
 normalize_columns: true
 offset: 0
 params: null
-schema: main
+schema: {{ASPECTS_EVENT_SINK_DATABASE}}
 sql: select * from {{ ASPECTS_EVENT_SINK_DATABASE }}.course_names
 table_name: course_names
 template_params: null

--- a/tutoraspects/templates/aspects/build/aspects-superset/openedx-assets/assets/datasets/course_names.yaml
+++ b/tutoraspects/templates/aspects/build/aspects-superset/openedx-assets/assets/datasets/course_names.yaml
@@ -70,7 +70,7 @@ metrics:
 normalize_columns: true
 offset: 0
 params: null
-schema: {{ASPECTS_EVENT_SINK_DATABASE}}
+schema: '{{ASPECTS_EVENT_SINK_DATABASE}}'
 sql: select * from {{ ASPECTS_EVENT_SINK_DATABASE }}.course_names
 table_name: course_names
 template_params: null

--- a/tutoraspects/templates/aspects/build/aspects-superset/openedx-assets/assets/datasets/course_overviews.yaml
+++ b/tutoraspects/templates/aspects/build/aspects-superset/openedx-assets/assets/datasets/course_overviews.yaml
@@ -177,7 +177,7 @@ metrics:
 normalize_columns: true
 offset: 0
 params: null
-schema: {{ ASPECTS_EVENT_SINK_DATABASE }}
+schema: '{{ ASPECTS_EVENT_SINK_DATABASE }}'
 sql: select * from {{ ASPECTS_EVENT_SINK_DATABASE }}.course_overviews
 table_name: course_overviews
 template_params: null

--- a/tutoraspects/templates/aspects/build/aspects-superset/openedx-assets/assets/datasets/course_overviews.yaml
+++ b/tutoraspects/templates/aspects/build/aspects-superset/openedx-assets/assets/datasets/course_overviews.yaml
@@ -177,7 +177,7 @@ metrics:
 normalize_columns: true
 offset: 0
 params: null
-schema: main
+schema: {{ ASPECTS_EVENT_SINK_DATABASE }}
 sql: select * from {{ ASPECTS_EVENT_SINK_DATABASE }}.course_overviews
 table_name: course_overviews
 template_params: null

--- a/tutoraspects/templates/aspects/build/aspects-superset/openedx-assets/assets/datasets/course_overviews.yaml
+++ b/tutoraspects/templates/aspects/build/aspects-superset/openedx-assets/assets/datasets/course_overviews.yaml
@@ -1,10 +1,11 @@
 _file_name: course_overviews.yaml
+always_filter_main_dttm: false
 cache_timeout: null
 columns:
 - advanced_data_type: null
   column_name: course_data_json
   description: null
-  expression: null
+  expression: ''
   extra: {}
   filterable: true
   groupby: true
@@ -16,7 +17,7 @@ columns:
 - advanced_data_type: null
   column_name: time_last_dumped
   description: null
-  expression: null
+  expression: ''
   extra: {}
   filterable: true
   groupby: true
@@ -28,7 +29,7 @@ columns:
 - advanced_data_type: null
   column_name: self_paced
   description: null
-  expression: null
+  expression: ''
   extra: {}
   filterable: true
   groupby: true
@@ -40,7 +41,7 @@ columns:
 - advanced_data_type: null
   column_name: course_end
   description: null
-  expression: null
+  expression: ''
   extra: {}
   filterable: true
   groupby: true
@@ -52,7 +53,7 @@ columns:
 - advanced_data_type: null
   column_name: course_key
   description: null
-  expression: null
+  expression: ''
   extra: {}
   filterable: true
   groupby: true
@@ -64,7 +65,7 @@ columns:
 - advanced_data_type: null
   column_name: course_start
   description: null
-  expression: null
+  expression: ''
   extra: {}
   filterable: true
   groupby: true
@@ -76,7 +77,7 @@ columns:
 - advanced_data_type: null
   column_name: dump_id
   description: null
-  expression: null
+  expression: ''
   extra: {}
   filterable: true
   groupby: true
@@ -88,7 +89,7 @@ columns:
 - advanced_data_type: null
   column_name: display_name
   description: null
-  expression: null
+  expression: ''
   extra: {}
   filterable: true
   groupby: true
@@ -100,7 +101,7 @@ columns:
 - advanced_data_type: null
   column_name: enrollment_end
   description: null
-  expression: null
+  expression: ''
   extra: {}
   filterable: true
   groupby: true
@@ -112,7 +113,7 @@ columns:
 - advanced_data_type: null
   column_name: enrollment_start
   description: null
-  expression: null
+  expression: ''
   extra: {}
   filterable: true
   groupby: true
@@ -124,7 +125,7 @@ columns:
 - advanced_data_type: null
   column_name: created
   description: null
-  expression: null
+  expression: ''
   extra: {}
   filterable: true
   groupby: true
@@ -136,7 +137,7 @@ columns:
 - advanced_data_type: null
   column_name: modified
   description: null
-  expression: null
+  expression: ''
   extra: {}
   filterable: true
   groupby: true
@@ -148,7 +149,7 @@ columns:
 - advanced_data_type: null
   column_name: org
   description: null
-  expression: null
+  expression: ''
   extra: {}
   filterable: true
   groupby: true

--- a/tutoraspects/templates/aspects/build/aspects-superset/openedx-assets/assets/datasets/dashboards.yaml
+++ b/tutoraspects/templates/aspects/build/aspects-superset/openedx-assets/assets/datasets/dashboards.yaml
@@ -226,7 +226,7 @@ metrics:
 normalize_columns: true
 offset: 0
 params: null
-schema: {{ SUPERSET_DB_NAME }}
+schema: '{{ SUPERSET_DB_NAME }}'
 sql: 'select * from dashboards'
 table_name: dashboards
 template_params: null

--- a/tutoraspects/templates/aspects/build/aspects-superset/openedx-assets/assets/datasets/dashboards.yaml
+++ b/tutoraspects/templates/aspects/build/aspects-superset/openedx-assets/assets/datasets/dashboards.yaml
@@ -226,7 +226,7 @@ metrics:
 normalize_columns: true
 offset: 0
 params: null
-schema: superset
+schema: {{ SUPERSET_DB_NAME }}
 sql: 'select * from dashboards'
 table_name: dashboards
 template_params: null

--- a/tutoraspects/templates/aspects/build/aspects-superset/openedx-assets/assets/datasets/dashboards.yaml
+++ b/tutoraspects/templates/aspects/build/aspects-superset/openedx-assets/assets/datasets/dashboards.yaml
@@ -1,8 +1,9 @@
 _file_name: dashboards.yaml
+always_filter_main_dttm: false
 cache_timeout: null
 columns:
 - advanced_data_type: null
-  column_name: dashboard_title
+  column_name: created_by_fk
   description: null
   expression: ''
   extra: {}
@@ -11,22 +12,10 @@ columns:
   is_active: true
   is_dttm: false
   python_date_format: null
-  type: VARCHAR(500)
-  verbose_name: Dashboard Title
+  type: LONG
+  verbose_name: Created By Fk
 - advanced_data_type: null
-  column_name: uuid
-  description: null
-  expression: ''
-  extra: {}
-  filterable: true
-  groupby: true
-  is_active: true
-  is_dttm: null
-  python_date_format: null
-  type: BINARY(16)
-  verbose_name: UUID
-- advanced_data_type: null
-  column_name: published
+  column_name: changed_by_fk
   description: null
   expression: ''
   extra: {}
@@ -35,10 +24,10 @@ columns:
   is_active: true
   is_dttm: false
   python_date_format: null
-  type: TINYINT(1)
-  verbose_name: Published
+  type: LONG
+  verbose_name: Changed By Fk
 - advanced_data_type: null
-  column_name: slug
+  column_name: is_managed_externally
   description: null
   expression: ''
   extra: {}
@@ -47,8 +36,8 @@ columns:
   is_active: true
   is_dttm: false
   python_date_format: null
-  type: VARCHAR(255)
-  verbose_name: Slug
+  type: TINY
+  verbose_name: Is Managed Externally
 - advanced_data_type: null
   column_name: created_on
   description: null
@@ -74,6 +63,54 @@ columns:
   type: DATETIME
   verbose_name: Changed On
 - advanced_data_type: null
+  column_name: dashboard_title
+  description: null
+  expression: ''
+  extra: {}
+  filterable: true
+  groupby: true
+  is_active: true
+  is_dttm: false
+  python_date_format: null
+  type: VAR_STRING
+  verbose_name: Dashboard Title
+- advanced_data_type: null
+  column_name: certified_by
+  description: null
+  expression: ''
+  extra: {}
+  filterable: true
+  groupby: true
+  is_active: true
+  is_dttm: false
+  python_date_format: null
+  type: BLOB
+  verbose_name: Certified By
+- advanced_data_type: null
+  column_name: certification_details
+  description: null
+  expression: ''
+  extra: {}
+  filterable: true
+  groupby: true
+  is_active: true
+  is_dttm: false
+  python_date_format: null
+  type: BLOB
+  verbose_name: Certification Details
+- advanced_data_type: null
+  column_name: external_url
+  description: null
+  expression: ''
+  extra: {}
+  filterable: true
+  groupby: true
+  is_active: true
+  is_dttm: false
+  python_date_format: null
+  type: BLOB
+  verbose_name: External Url
+- advanced_data_type: null
   column_name: json_metadata
   description: null
   expression: ''
@@ -83,7 +120,7 @@ columns:
   is_active: true
   is_dttm: false
   python_date_format: null
-  type: MEDIUMTEXT
+  type: BLOB
   verbose_name: JSON Metadata
 - advanced_data_type: null
   column_name: position_json
@@ -95,10 +132,10 @@ columns:
   is_active: true
   is_dttm: false
   python_date_format: null
-  type: MEDIUMTEXT
+  type: BLOB
   verbose_name: Position Json
 - advanced_data_type: null
-  column_name: created_by_fk
+  column_name: slug
   description: null
   expression: ''
   extra: {}
@@ -107,68 +144,8 @@ columns:
   is_active: true
   is_dttm: false
   python_date_format: null
-  type: INTEGER
-  verbose_name: Created By Fk
-- advanced_data_type: null
-  column_name: changed_by_fk
-  description: null
-  expression: ''
-  extra: {}
-  filterable: true
-  groupby: true
-  is_active: true
-  is_dttm: false
-  python_date_format: null
-  type: INTEGER
-  verbose_name: Changed By Fk
-- advanced_data_type: null
-  column_name: id
-  description: null
-  expression: ''
-  extra: {}
-  filterable: true
-  groupby: true
-  is_active: true
-  is_dttm: false
-  python_date_format: null
-  type: INTEGER
-  verbose_name: ID
-- advanced_data_type: null
-  column_name: certification_details
-  description: null
-  expression: ''
-  extra: {}
-  filterable: true
-  groupby: true
-  is_active: true
-  is_dttm: false
-  python_date_format: null
-  type: TEXT
-  verbose_name: Certification Details
-- advanced_data_type: null
-  column_name: certified_by
-  description: null
-  expression: ''
-  extra: {}
-  filterable: true
-  groupby: true
-  is_active: true
-  is_dttm: false
-  python_date_format: null
-  type: TEXT
-  verbose_name: Certified By
-- advanced_data_type: null
-  column_name: description
-  description: null
-  expression: ''
-  extra: {}
-  filterable: true
-  groupby: true
-  is_active: true
-  is_dttm: false
-  python_date_format: null
-  type: TEXT
-  verbose_name: Description
+  type: VAR_STRING
+  verbose_name: Slug
 - advanced_data_type: null
   column_name: css
   description: null
@@ -179,32 +156,56 @@ columns:
   is_active: true
   is_dttm: false
   python_date_format: null
-  type: TEXT
+  type: BLOB
   verbose_name: CSS
 - advanced_data_type: null
-  column_name: is_managed_externally
+  column_name: description
   description: null
-  expression: null
+  expression: ''
   extra: {}
   filterable: true
   groupby: true
   is_active: true
   is_dttm: false
   python_date_format: null
-  type: TINYINT(1)
-  verbose_name: Is Managed Externally
+  type: BLOB
+  verbose_name: Description
 - advanced_data_type: null
-  column_name: external_url
+  column_name: id
   description: null
-  expression: null
+  expression: ''
   extra: {}
   filterable: true
   groupby: true
   is_active: true
   is_dttm: false
   python_date_format: null
-  type: TEXT
-  verbose_name: External Url
+  type: LONG
+  verbose_name: ID
+- advanced_data_type: null
+  column_name: uuid
+  description: null
+  expression: ''
+  extra: {}
+  filterable: true
+  groupby: true
+  is_active: true
+  is_dttm: null
+  python_date_format: null
+  type: STRING
+  verbose_name: UUID
+- advanced_data_type: null
+  column_name: published
+  description: null
+  expression: ''
+  extra: {}
+  filterable: true
+  groupby: true
+  is_active: true
+  is_dttm: false
+  python_date_format: null
+  type: TINY
+  verbose_name: Published
 database_uuid: 06cd566f-e22a-4a79-b0e0-4c947de93ee0
 default_endpoint: null
 description: null
@@ -227,7 +228,7 @@ normalize_columns: true
 offset: 0
 params: null
 schema: '{{ SUPERSET_DB_NAME }}'
-sql: 'select * from dashboards'
+sql: select * from dashboards
 table_name: dashboards
 template_params: null
 uuid: 3dee777a-3dd4-4fcb-a749-4d13651b3444

--- a/tutoraspects/templates/aspects/build/aspects-superset/openedx-assets/assets/datasets/dim_course_problems.yaml
+++ b/tutoraspects/templates/aspects/build/aspects-superset/openedx-assets/assets/datasets/dim_course_problems.yaml
@@ -106,7 +106,7 @@ metrics:
 normalize_columns: true
 offset: 0
 params: null
-schema: main
+schema: {{ DBT_PROFILE_TARGET_DATABASE }}
 sql: |-
   {% filter indent(width=2) %}{% include 'openedx-assets/queries/dim_course_problems.sql' %}{% endfilter %}
 table_name: dim_course_problems

--- a/tutoraspects/templates/aspects/build/aspects-superset/openedx-assets/assets/datasets/dim_course_problems.yaml
+++ b/tutoraspects/templates/aspects/build/aspects-superset/openedx-assets/assets/datasets/dim_course_problems.yaml
@@ -106,7 +106,7 @@ metrics:
 normalize_columns: true
 offset: 0
 params: null
-schema: {{ DBT_PROFILE_TARGET_DATABASE }}
+schema: '{{ DBT_PROFILE_TARGET_DATABASE }}'
 sql: |-
   {% filter indent(width=2) %}{% include 'openedx-assets/queries/dim_course_problems.sql' %}{% endfilter %}
 table_name: dim_course_problems

--- a/tutoraspects/templates/aspects/build/aspects-superset/openedx-assets/assets/datasets/dim_course_videos.yaml
+++ b/tutoraspects/templates/aspects/build/aspects-superset/openedx-assets/assets/datasets/dim_course_videos.yaml
@@ -106,7 +106,7 @@ metrics:
 normalize_columns: true
 offset: 0
 params: null
-schema: main
+schema: {{ DBT_PROFILE_TARGET_DATABASE }}
 sql: |-
   {% filter indent(width=2) %}{% include 'openedx-assets/queries/dim_course_videos.sql' %}{% endfilter %}
 table_name: dim_course_videos

--- a/tutoraspects/templates/aspects/build/aspects-superset/openedx-assets/assets/datasets/dim_course_videos.yaml
+++ b/tutoraspects/templates/aspects/build/aspects-superset/openedx-assets/assets/datasets/dim_course_videos.yaml
@@ -106,7 +106,7 @@ metrics:
 normalize_columns: true
 offset: 0
 params: null
-schema: {{ DBT_PROFILE_TARGET_DATABASE }}
+schema: '{{ DBT_PROFILE_TARGET_DATABASE }}'
 sql: |-
   {% filter indent(width=2) %}{% include 'openedx-assets/queries/dim_course_videos.sql' %}{% endfilter %}
 table_name: dim_course_videos

--- a/tutoraspects/templates/aspects/build/aspects-superset/openedx-assets/assets/datasets/fact_course_grades.yaml
+++ b/tutoraspects/templates/aspects/build/aspects-superset/openedx-assets/assets/datasets/fact_course_grades.yaml
@@ -151,7 +151,7 @@ metrics:
 normalize_columns: true
 offset: 0
 params: null
-schema: {{ DBT_PROFILE_TARGET_DATABASE }}
+schema: '{{ DBT_PROFILE_TARGET_DATABASE }}'
 sql: |-
   {% filter indent(width=2) %}{% include 'openedx-assets/queries/fact_course_grades.sql' %}{% endfilter %}
 table_name: fact_course_grades

--- a/tutoraspects/templates/aspects/build/aspects-superset/openedx-assets/assets/datasets/fact_course_grades.yaml
+++ b/tutoraspects/templates/aspects/build/aspects-superset/openedx-assets/assets/datasets/fact_course_grades.yaml
@@ -151,7 +151,7 @@ metrics:
 normalize_columns: true
 offset: 0
 params: null
-schema: main
+schema: {{ DBT_PROFILE_TARGET_DATABASE }}
 sql: |-
   {% filter indent(width=2) %}{% include 'openedx-assets/queries/fact_course_grades.sql' %}{% endfilter %}
 table_name: fact_course_grades

--- a/tutoraspects/templates/aspects/build/aspects-superset/openedx-assets/assets/datasets/fact_enrollment_status.yaml
+++ b/tutoraspects/templates/aspects/build/aspects-superset/openedx-assets/assets/datasets/fact_enrollment_status.yaml
@@ -100,7 +100,7 @@ metrics:
 normalize_columns: false
 offset: 0
 params: null
-schema: main
+schema: {{ DBT_PROFILE_TARGET_DATABASE }}
 sql: select * from {{ DBT_PROFILE_TARGET_DATABASE }}.fact_enrollment_status
 table_name: fact_enrollment_status
 template_params: null

--- a/tutoraspects/templates/aspects/build/aspects-superset/openedx-assets/assets/datasets/fact_enrollment_status.yaml
+++ b/tutoraspects/templates/aspects/build/aspects-superset/openedx-assets/assets/datasets/fact_enrollment_status.yaml
@@ -1,0 +1,108 @@
+_file_name: fact_enrollment_status.yaml
+cache_timeout: null
+columns:
+- advanced_data_type: null
+  column_name: emission_time
+  description: null
+  expression: null
+  extra:
+    warning_markdown: null
+  filterable: true
+  groupby: true
+  is_active: true
+  is_dttm: true
+  python_date_format: null
+  type: DATETIME
+  verbose_name: null
+- advanced_data_type: null
+  column_name: actor_id
+  description: null
+  expression: null
+  extra:
+    warning_markdown: null
+  filterable: true
+  groupby: true
+  is_active: true
+  is_dttm: false
+  python_date_format: null
+  type: STRING
+  verbose_name: null
+- advanced_data_type: null
+  column_name: enrollment_status
+  description: null
+  expression: null
+  extra:
+    warning_markdown: null
+  filterable: true
+  groupby: true
+  is_active: true
+  is_dttm: false
+  python_date_format: null
+  type: STRING
+  verbose_name: null
+- advanced_data_type: null
+  column_name: course_key
+  description: null
+  expression: null
+  extra:
+    warning_markdown: null
+  filterable: true
+  groupby: true
+  is_active: true
+  is_dttm: false
+  python_date_format: null
+  type: STRING
+  verbose_name: null
+- advanced_data_type: null
+  column_name: enrollment_mode
+  description: null
+  expression: null
+  extra:
+    warning_markdown: null
+  filterable: true
+  groupby: true
+  is_active: true
+  is_dttm: false
+  python_date_format: null
+  type: STRING
+  verbose_name: null
+- advanced_data_type: null
+  column_name: org
+  description: null
+  expression: null
+  extra:
+    warning_markdown: null
+  filterable: true
+  groupby: true
+  is_active: true
+  is_dttm: false
+  python_date_format: null
+  type: STRING
+  verbose_name: null
+database_uuid: 21174b6c-4d40-4958-8161-d6c3cf5e77b6
+default_endpoint: null
+description: null
+extra: null
+fetch_values_predicate: null
+filter_select_enabled: true
+main_dttm_col: emission_time
+metrics:
+- currency: null
+  d3format: null
+  description: null
+  expression: COUNT(*)
+  extra:
+    warning_markdown: ''
+  metric_name: count
+  metric_type: count
+  verbose_name: COUNT(*)
+  warning_text: null
+normalize_columns: false
+offset: 0
+params: null
+schema: reporting
+sql: ''
+table_name: fact_enrollment_status
+template_params: null
+uuid: 3dde421d-c0d0-43ab-8087-ca470985e88e
+version: 1.0.0

--- a/tutoraspects/templates/aspects/build/aspects-superset/openedx-assets/assets/datasets/fact_enrollment_status.yaml
+++ b/tutoraspects/templates/aspects/build/aspects-superset/openedx-assets/assets/datasets/fact_enrollment_status.yaml
@@ -100,8 +100,8 @@ metrics:
 normalize_columns: false
 offset: 0
 params: null
-schema: reporting
-sql: ''
+schema: main
+sql: select * from {{ DBT_PROFILE_TARGET_DATABASE }}.fact_enrollment_status
 table_name: fact_enrollment_status
 template_params: null
 uuid: 3dde421d-c0d0-43ab-8087-ca470985e88e

--- a/tutoraspects/templates/aspects/build/aspects-superset/openedx-assets/assets/datasets/fact_enrollment_status.yaml
+++ b/tutoraspects/templates/aspects/build/aspects-superset/openedx-assets/assets/datasets/fact_enrollment_status.yaml
@@ -1,10 +1,11 @@
 _file_name: fact_enrollment_status.yaml
+always_filter_main_dttm: false
 cache_timeout: null
 columns:
 - advanced_data_type: null
   column_name: emission_time
   description: null
-  expression: null
+  expression: ''
   extra:
     warning_markdown: null
   filterable: true
@@ -12,12 +13,12 @@ columns:
   is_active: true
   is_dttm: true
   python_date_format: null
-  type: DATETIME
+  type: DateTime
   verbose_name: null
 - advanced_data_type: null
   column_name: actor_id
   description: null
-  expression: null
+  expression: ''
   extra:
     warning_markdown: null
   filterable: true
@@ -25,12 +26,12 @@ columns:
   is_active: true
   is_dttm: false
   python_date_format: null
-  type: STRING
+  type: String
   verbose_name: null
 - advanced_data_type: null
   column_name: enrollment_status
   description: null
-  expression: null
+  expression: ''
   extra:
     warning_markdown: null
   filterable: true
@@ -38,12 +39,12 @@ columns:
   is_active: true
   is_dttm: false
   python_date_format: null
-  type: STRING
+  type: String
   verbose_name: null
 - advanced_data_type: null
   column_name: course_key
   description: null
-  expression: null
+  expression: ''
   extra:
     warning_markdown: null
   filterable: true
@@ -51,12 +52,12 @@ columns:
   is_active: true
   is_dttm: false
   python_date_format: null
-  type: STRING
+  type: String
   verbose_name: null
 - advanced_data_type: null
   column_name: enrollment_mode
   description: null
-  expression: null
+  expression: ''
   extra:
     warning_markdown: null
   filterable: true
@@ -64,12 +65,12 @@ columns:
   is_active: true
   is_dttm: false
   python_date_format: null
-  type: STRING
+  type: String
   verbose_name: null
 - advanced_data_type: null
   column_name: org
   description: null
-  expression: null
+  expression: ''
   extra:
     warning_markdown: null
   filterable: true
@@ -77,7 +78,7 @@ columns:
   is_active: true
   is_dttm: false
   python_date_format: null
-  type: STRING
+  type: String
   verbose_name: null
 database_uuid: 21174b6c-4d40-4958-8161-d6c3cf5e77b6
 default_endpoint: null
@@ -100,7 +101,7 @@ metrics:
 normalize_columns: false
 offset: 0
 params: null
-schema: {{ DBT_PROFILE_TARGET_DATABASE }}
+schema: '{{ DBT_PROFILE_TARGET_DATABASE }}'
 sql: select * from {{ DBT_PROFILE_TARGET_DATABASE }}.fact_enrollment_status
 table_name: fact_enrollment_status
 template_params: null

--- a/tutoraspects/templates/aspects/build/aspects-superset/openedx-assets/assets/datasets/fact_enrollments.yaml
+++ b/tutoraspects/templates/aspects/build/aspects-superset/openedx-assets/assets/datasets/fact_enrollments.yaml
@@ -118,7 +118,7 @@ metrics:
 normalize_columns: true
 offset: 0
 params: null
-schema: main
+schema: {{ DBT_PROFILE_TARGET_DATABASE }}
 sql: |-
   {% filter indent(width=2) %}{% include 'openedx-assets/queries/fact_enrollments.sql' %}{% endfilter %}
 table_name: fact_enrollments

--- a/tutoraspects/templates/aspects/build/aspects-superset/openedx-assets/assets/datasets/fact_enrollments.yaml
+++ b/tutoraspects/templates/aspects/build/aspects-superset/openedx-assets/assets/datasets/fact_enrollments.yaml
@@ -118,7 +118,7 @@ metrics:
 normalize_columns: true
 offset: 0
 params: null
-schema: {{ DBT_PROFILE_TARGET_DATABASE }}
+schema: '{{ DBT_PROFILE_TARGET_DATABASE }}'
 sql: |-
   {% filter indent(width=2) %}{% include 'openedx-assets/queries/fact_enrollments.sql' %}{% endfilter %}
 table_name: fact_enrollments

--- a/tutoraspects/templates/aspects/build/aspects-superset/openedx-assets/assets/datasets/fact_enrollments_by_day.yaml
+++ b/tutoraspects/templates/aspects/build/aspects-superset/openedx-assets/assets/datasets/fact_enrollments_by_day.yaml
@@ -118,7 +118,7 @@ metrics:
 normalize_columns: true
 offset: 0
 params: null
-schema: {{ DBT_PROFILE_TARGET_DATABASE }}
+schema: '{{ DBT_PROFILE_TARGET_DATABASE }}'
 sql: |-
   {% filter indent(width=2) %}{% include 'openedx-assets/queries/fact_enrollments_by_day.sql' %}{% endfilter %}
 table_name: fact_enrollments_by_day

--- a/tutoraspects/templates/aspects/build/aspects-superset/openedx-assets/assets/datasets/fact_enrollments_by_day.yaml
+++ b/tutoraspects/templates/aspects/build/aspects-superset/openedx-assets/assets/datasets/fact_enrollments_by_day.yaml
@@ -118,7 +118,7 @@ metrics:
 normalize_columns: true
 offset: 0
 params: null
-schema: main
+schema: {{ DBT_PROFILE_TARGET_DATABASE }}
 sql: |-
   {% filter indent(width=2) %}{% include 'openedx-assets/queries/fact_enrollments_by_day.sql' %}{% endfilter %}
 table_name: fact_enrollments_by_day

--- a/tutoraspects/templates/aspects/build/aspects-superset/openedx-assets/assets/datasets/fact_forum_interactions.yaml
+++ b/tutoraspects/templates/aspects/build/aspects-superset/openedx-assets/assets/datasets/fact_forum_interactions.yaml
@@ -130,7 +130,7 @@ metrics:
 normalize_columns: true
 offset: 0
 params: null
-schema: main
+schema: {{ DBT_PROFILE_TARGET_DATABASE }}
 sql: |-
   {% filter indent(width=2) %}{% include 'openedx-assets/queries/fact_forum_interactions.sql' %}{% endfilter %}
 table_name: fact_forum_interactions

--- a/tutoraspects/templates/aspects/build/aspects-superset/openedx-assets/assets/datasets/fact_forum_interactions.yaml
+++ b/tutoraspects/templates/aspects/build/aspects-superset/openedx-assets/assets/datasets/fact_forum_interactions.yaml
@@ -130,7 +130,7 @@ metrics:
 normalize_columns: true
 offset: 0
 params: null
-schema: {{ DBT_PROFILE_TARGET_DATABASE }}
+schema: '{{ DBT_PROFILE_TARGET_DATABASE }}'
 sql: |-
   {% filter indent(width=2) %}{% include 'openedx-assets/queries/fact_forum_interactions.sql' %}{% endfilter %}
 table_name: fact_forum_interactions

--- a/tutoraspects/templates/aspects/build/aspects-superset/openedx-assets/assets/datasets/fact_learner_problem_course_summary.yaml
+++ b/tutoraspects/templates/aspects/build/aspects-superset/openedx-assets/assets/datasets/fact_learner_problem_course_summary.yaml
@@ -154,7 +154,7 @@ metrics:
 normalize_columns: true
 offset: 0
 params: null
-schema: {{ DBT_PROFILE_TARGET_DATABASE }}
+schema: '{{ DBT_PROFILE_TARGET_DATABASE }}'
 sql: |-
   {% filter indent(width=2) %}{% include 'openedx-assets/queries/fact_learner_problem_course_summary.sql' %}{% endfilter %}
 table_name: fact_learner_problem_course_summary

--- a/tutoraspects/templates/aspects/build/aspects-superset/openedx-assets/assets/datasets/fact_learner_problem_course_summary.yaml
+++ b/tutoraspects/templates/aspects/build/aspects-superset/openedx-assets/assets/datasets/fact_learner_problem_course_summary.yaml
@@ -154,7 +154,7 @@ metrics:
 normalize_columns: true
 offset: 0
 params: null
-schema: main
+schema: {{ DBT_PROFILE_TARGET_DATABASE }}
 sql: |-
   {% filter indent(width=2) %}{% include 'openedx-assets/queries/fact_learner_problem_course_summary.sql' %}{% endfilter %}
 table_name: fact_learner_problem_course_summary

--- a/tutoraspects/templates/aspects/build/aspects-superset/openedx-assets/assets/datasets/fact_learner_problem_summary.yaml
+++ b/tutoraspects/templates/aspects/build/aspects-superset/openedx-assets/assets/datasets/fact_learner_problem_summary.yaml
@@ -163,7 +163,7 @@ metrics:
 normalize_columns: true
 offset: 0
 params: null
-schema: {{ DBT_PROFILE_TARGET_DATABASE }}
+schema: '{{ DBT_PROFILE_TARGET_DATABASE }}'
 sql: |-
   {% filter indent(width=2) %}{% include 'openedx-assets/queries/fact_learner_problem_summary.sql' %}{% endfilter %}
 table_name: fact_learner_problem_summary

--- a/tutoraspects/templates/aspects/build/aspects-superset/openedx-assets/assets/datasets/fact_learner_problem_summary.yaml
+++ b/tutoraspects/templates/aspects/build/aspects-superset/openedx-assets/assets/datasets/fact_learner_problem_summary.yaml
@@ -163,7 +163,7 @@ metrics:
 normalize_columns: true
 offset: 0
 params: null
-schema: main
+schema: {{ DBT_PROFILE_TARGET_DATABASE }}
 sql: |-
   {% filter indent(width=2) %}{% include 'openedx-assets/queries/fact_learner_problem_summary.sql' %}{% endfilter %}
 table_name: fact_learner_problem_summary

--- a/tutoraspects/templates/aspects/build/aspects-superset/openedx-assets/assets/datasets/fact_navigation.yaml
+++ b/tutoraspects/templates/aspects/build/aspects-superset/openedx-assets/assets/datasets/fact_navigation.yaml
@@ -165,7 +165,7 @@ metrics:
 normalize_columns: false
 offset: 0
 params: null
-schema: main
+schema: {{ DBT_PROFILE_TARGET_DATABASE }}
 sql: select * from {{ DBT_PROFILE_TARGET_DATABASE }}.fact_navigation
 table_name: fact_navigation
 template_params: null

--- a/tutoraspects/templates/aspects/build/aspects-superset/openedx-assets/assets/datasets/fact_navigation.yaml
+++ b/tutoraspects/templates/aspects/build/aspects-superset/openedx-assets/assets/datasets/fact_navigation.yaml
@@ -1,0 +1,173 @@
+_file_name: fact_navigation.yaml
+cache_timeout: null
+columns:
+- advanced_data_type: null
+  column_name: starting_position
+  description: null
+  expression: null
+  extra: null
+  filterable: true
+  groupby: true
+  is_active: true
+  is_dttm: false
+  python_date_format: null
+  type: INT64
+  verbose_name: null
+- advanced_data_type: null
+  column_name: emission_time
+  description: null
+  expression: null
+  extra: null
+  filterable: true
+  groupby: true
+  is_active: true
+  is_dttm: true
+  python_date_format: null
+  type: DATETIME
+  verbose_name: null
+- advanced_data_type: null
+  column_name: block_name_with_location
+  description: null
+  expression: null
+  extra: null
+  filterable: true
+  groupby: true
+  is_active: true
+  is_dttm: false
+  python_date_format: null
+  type: STRING
+  verbose_name: null
+- advanced_data_type: null
+  column_name: block_name
+  description: null
+  expression: null
+  extra: null
+  filterable: true
+  groupby: true
+  is_active: true
+  is_dttm: false
+  python_date_format: null
+  type: STRING
+  verbose_name: null
+- advanced_data_type: null
+  column_name: actor_id
+  description: null
+  expression: null
+  extra: null
+  filterable: true
+  groupby: true
+  is_active: true
+  is_dttm: false
+  python_date_format: null
+  type: STRING
+  verbose_name: null
+- advanced_data_type: null
+  column_name: course_name
+  description: null
+  expression: null
+  extra: null
+  filterable: true
+  groupby: true
+  is_active: true
+  is_dttm: false
+  python_date_format: null
+  type: STRING
+  verbose_name: null
+- advanced_data_type: null
+  column_name: block_id
+  description: null
+  expression: null
+  extra: null
+  filterable: true
+  groupby: true
+  is_active: true
+  is_dttm: false
+  python_date_format: null
+  type: STRING
+  verbose_name: null
+- advanced_data_type: null
+  column_name: object_type
+  description: null
+  expression: null
+  extra: null
+  filterable: true
+  groupby: true
+  is_active: true
+  is_dttm: false
+  python_date_format: null
+  type: STRING
+  verbose_name: null
+- advanced_data_type: null
+  column_name: course_key
+  description: null
+  expression: null
+  extra: null
+  filterable: true
+  groupby: true
+  is_active: true
+  is_dttm: false
+  python_date_format: null
+  type: STRING
+  verbose_name: null
+- advanced_data_type: null
+  column_name: course_run
+  description: null
+  expression: null
+  extra: null
+  filterable: true
+  groupby: true
+  is_active: true
+  is_dttm: false
+  python_date_format: null
+  type: STRING
+  verbose_name: null
+- advanced_data_type: null
+  column_name: ending_point
+  description: null
+  expression: null
+  extra: null
+  filterable: true
+  groupby: true
+  is_active: true
+  is_dttm: false
+  python_date_format: null
+  type: STRING
+  verbose_name: null
+- advanced_data_type: null
+  column_name: org
+  description: null
+  expression: null
+  extra: null
+  filterable: true
+  groupby: true
+  is_active: true
+  is_dttm: false
+  python_date_format: null
+  type: STRING
+  verbose_name: null
+database_uuid: 21174b6c-4d40-4958-8161-d6c3cf5e77b6
+default_endpoint: null
+description: null
+extra: null
+fetch_values_predicate: null
+filter_select_enabled: true
+main_dttm_col: emission_time
+metrics:
+- currency: null
+  d3format: null
+  description: null
+  expression: COUNT(*)
+  extra: null
+  metric_name: count
+  metric_type: count
+  verbose_name: COUNT(*)
+  warning_text: null
+normalize_columns: false
+offset: 0
+params: null
+schema: reporting
+sql: null
+table_name: fact_navigation
+template_params: null
+uuid: 1c443466-300e-4f01-a690-3d9d1b934d9a
+version: 1.0.0

--- a/tutoraspects/templates/aspects/build/aspects-superset/openedx-assets/assets/datasets/fact_navigation.yaml
+++ b/tutoraspects/templates/aspects/build/aspects-superset/openedx-assets/assets/datasets/fact_navigation.yaml
@@ -1,149 +1,150 @@
 _file_name: fact_navigation.yaml
+always_filter_main_dttm: false
 cache_timeout: null
 columns:
 - advanced_data_type: null
   column_name: starting_position
   description: null
-  expression: null
+  expression: ''
   extra: null
   filterable: true
   groupby: true
   is_active: true
   is_dttm: false
   python_date_format: null
-  type: INT64
+  type: Int64
   verbose_name: null
 - advanced_data_type: null
   column_name: emission_time
   description: null
-  expression: null
+  expression: ''
   extra: null
   filterable: true
   groupby: true
   is_active: true
   is_dttm: true
   python_date_format: null
-  type: DATETIME
+  type: DateTime
   verbose_name: null
 - advanced_data_type: null
   column_name: block_name_with_location
   description: null
-  expression: null
+  expression: ''
   extra: null
   filterable: true
   groupby: true
   is_active: true
   is_dttm: false
   python_date_format: null
-  type: STRING
+  type: String
   verbose_name: null
 - advanced_data_type: null
   column_name: block_name
   description: null
-  expression: null
+  expression: ''
   extra: null
   filterable: true
   groupby: true
   is_active: true
   is_dttm: false
   python_date_format: null
-  type: STRING
+  type: String
   verbose_name: null
 - advanced_data_type: null
   column_name: actor_id
   description: null
-  expression: null
+  expression: ''
   extra: null
   filterable: true
   groupby: true
   is_active: true
   is_dttm: false
   python_date_format: null
-  type: STRING
+  type: String
   verbose_name: null
 - advanced_data_type: null
   column_name: course_name
   description: null
-  expression: null
+  expression: ''
   extra: null
   filterable: true
   groupby: true
   is_active: true
   is_dttm: false
   python_date_format: null
-  type: STRING
+  type: String
   verbose_name: null
 - advanced_data_type: null
   column_name: block_id
   description: null
-  expression: null
+  expression: ''
   extra: null
   filterable: true
   groupby: true
   is_active: true
   is_dttm: false
   python_date_format: null
-  type: STRING
+  type: String
   verbose_name: null
 - advanced_data_type: null
   column_name: object_type
   description: null
-  expression: null
+  expression: ''
   extra: null
   filterable: true
   groupby: true
   is_active: true
   is_dttm: false
   python_date_format: null
-  type: STRING
+  type: String
   verbose_name: null
 - advanced_data_type: null
   column_name: course_key
   description: null
-  expression: null
+  expression: ''
   extra: null
   filterable: true
   groupby: true
   is_active: true
   is_dttm: false
   python_date_format: null
-  type: STRING
+  type: String
   verbose_name: null
 - advanced_data_type: null
   column_name: course_run
   description: null
-  expression: null
+  expression: ''
   extra: null
   filterable: true
   groupby: true
   is_active: true
   is_dttm: false
   python_date_format: null
-  type: STRING
+  type: String
   verbose_name: null
 - advanced_data_type: null
   column_name: ending_point
   description: null
-  expression: null
+  expression: ''
   extra: null
   filterable: true
   groupby: true
   is_active: true
   is_dttm: false
   python_date_format: null
-  type: STRING
+  type: String
   verbose_name: null
 - advanced_data_type: null
   column_name: org
   description: null
-  expression: null
+  expression: ''
   extra: null
   filterable: true
   groupby: true
   is_active: true
   is_dttm: false
   python_date_format: null
-  type: STRING
+  type: String
   verbose_name: null
 database_uuid: 21174b6c-4d40-4958-8161-d6c3cf5e77b6
 default_endpoint: null
@@ -165,7 +166,7 @@ metrics:
 normalize_columns: false
 offset: 0
 params: null
-schema: {{ DBT_PROFILE_TARGET_DATABASE }}
+schema: '{{ DBT_PROFILE_TARGET_DATABASE }}'
 sql: select * from {{ DBT_PROFILE_TARGET_DATABASE }}.fact_navigation
 table_name: fact_navigation
 template_params: null

--- a/tutoraspects/templates/aspects/build/aspects-superset/openedx-assets/assets/datasets/fact_navigation.yaml
+++ b/tutoraspects/templates/aspects/build/aspects-superset/openedx-assets/assets/datasets/fact_navigation.yaml
@@ -165,8 +165,8 @@ metrics:
 normalize_columns: false
 offset: 0
 params: null
-schema: reporting
-sql: null
+schema: main
+sql: select * from {{ DBT_PROFILE_TARGET_DATABASE }}.fact_navigation
 table_name: fact_navigation
 template_params: null
 uuid: 1c443466-300e-4f01-a690-3d9d1b934d9a

--- a/tutoraspects/templates/aspects/build/aspects-superset/openedx-assets/assets/datasets/fact_navigation_completion.yaml
+++ b/tutoraspects/templates/aspects/build/aspects-superset/openedx-assets/assets/datasets/fact_navigation_completion.yaml
@@ -117,8 +117,8 @@ metrics:
 normalize_columns: false
 offset: 0
 params: null
-schema: reporting
-sql: null
+schema: main
+sql: select * from {{ DBT_PROFILE_TARGET_DATABASE }}.fact_navigation_completion
 table_name: fact_navigation_completion
 template_params: null
 uuid: 1b1cbf0a-1193-4251-ad52-724c2f0190ae

--- a/tutoraspects/templates/aspects/build/aspects-superset/openedx-assets/assets/datasets/fact_navigation_completion.yaml
+++ b/tutoraspects/templates/aspects/build/aspects-superset/openedx-assets/assets/datasets/fact_navigation_completion.yaml
@@ -1,0 +1,125 @@
+_file_name: fact_navigation_completion.yaml
+cache_timeout: null
+columns:
+- advanced_data_type: null
+  column_name: page_count
+  description: null
+  expression: null
+  extra: null
+  filterable: true
+  groupby: true
+  is_active: true
+  is_dttm: false
+  python_date_format: null
+  type: UINT64
+  verbose_name: null
+- advanced_data_type: null
+  column_name: visited_on
+  description: null
+  expression: null
+  extra: null
+  filterable: true
+  groupby: true
+  is_active: true
+  is_dttm: true
+  python_date_format: null
+  type: DATE
+  verbose_name: null
+- advanced_data_type: null
+  column_name: subsection_with_name
+  description: null
+  expression: null
+  extra: null
+  filterable: true
+  groupby: true
+  is_active: true
+  is_dttm: false
+  python_date_format: null
+  type: STRING
+  verbose_name: null
+- advanced_data_type: null
+  column_name: section_with_name
+  description: null
+  expression: null
+  extra: null
+  filterable: true
+  groupby: true
+  is_active: true
+  is_dttm: false
+  python_date_format: null
+  type: STRING
+  verbose_name: null
+- advanced_data_type: null
+  column_name: actor_id
+  description: null
+  expression: null
+  extra: null
+  filterable: true
+  groupby: true
+  is_active: true
+  is_dttm: false
+  python_date_format: null
+  type: STRING
+  verbose_name: null
+- advanced_data_type: null
+  column_name: block_id
+  description: null
+  expression: null
+  extra: null
+  filterable: true
+  groupby: true
+  is_active: true
+  is_dttm: false
+  python_date_format: null
+  type: STRING
+  verbose_name: null
+- advanced_data_type: null
+  column_name: course_key
+  description: null
+  expression: null
+  extra: null
+  filterable: true
+  groupby: true
+  is_active: true
+  is_dttm: false
+  python_date_format: null
+  type: STRING
+  verbose_name: null
+- advanced_data_type: null
+  column_name: org
+  description: null
+  expression: null
+  extra: null
+  filterable: true
+  groupby: true
+  is_active: true
+  is_dttm: false
+  python_date_format: null
+  type: STRING
+  verbose_name: null
+database_uuid: 21174b6c-4d40-4958-8161-d6c3cf5e77b6
+default_endpoint: null
+description: null
+extra: null
+fetch_values_predicate: null
+filter_select_enabled: true
+main_dttm_col: visited_on
+metrics:
+- currency: null
+  d3format: null
+  description: null
+  expression: COUNT(*)
+  extra: null
+  metric_name: count
+  metric_type: count
+  verbose_name: COUNT(*)
+  warning_text: null
+normalize_columns: false
+offset: 0
+params: null
+schema: reporting
+sql: null
+table_name: fact_navigation_completion
+template_params: null
+uuid: 1b1cbf0a-1193-4251-ad52-724c2f0190ae
+version: 1.0.0

--- a/tutoraspects/templates/aspects/build/aspects-superset/openedx-assets/assets/datasets/fact_navigation_completion.yaml
+++ b/tutoraspects/templates/aspects/build/aspects-superset/openedx-assets/assets/datasets/fact_navigation_completion.yaml
@@ -1,92 +1,105 @@
 _file_name: fact_navigation_completion.yaml
+always_filter_main_dttm: false
 cache_timeout: null
 columns:
 - advanced_data_type: null
   column_name: page_count
   description: null
-  expression: null
+  expression: ''
   extra: null
   filterable: true
   groupby: true
   is_active: true
   is_dttm: false
   python_date_format: null
-  type: UINT64
+  type: UInt64
   verbose_name: null
 - advanced_data_type: null
   column_name: visited_on
   description: null
-  expression: null
+  expression: ''
   extra: null
   filterable: true
   groupby: true
   is_active: true
   is_dttm: true
   python_date_format: null
-  type: DATE
+  type: Date
   verbose_name: null
 - advanced_data_type: null
   column_name: subsection_with_name
   description: null
-  expression: null
+  expression: ''
   extra: null
   filterable: true
   groupby: true
   is_active: true
   is_dttm: false
   python_date_format: null
-  type: STRING
+  type: String
   verbose_name: null
 - advanced_data_type: null
   column_name: section_with_name
   description: null
-  expression: null
+  expression: ''
   extra: null
   filterable: true
   groupby: true
   is_active: true
   is_dttm: false
   python_date_format: null
-  type: STRING
+  type: String
   verbose_name: null
 - advanced_data_type: null
   column_name: actor_id
   description: null
-  expression: null
+  expression: ''
   extra: null
   filterable: true
   groupby: true
   is_active: true
   is_dttm: false
   python_date_format: null
-  type: STRING
+  type: String
   verbose_name: null
 - advanced_data_type: null
   column_name: block_id
   description: null
-  expression: null
+  expression: ''
   extra: null
   filterable: true
   groupby: true
   is_active: true
   is_dttm: false
   python_date_format: null
-  type: STRING
+  type: String
   verbose_name: null
 - advanced_data_type: null
   column_name: course_key
   description: null
-  expression: null
+  expression: ''
   extra: null
   filterable: true
   groupby: true
   is_active: true
   is_dttm: false
   python_date_format: null
-  type: STRING
+  type: String
   verbose_name: null
 - advanced_data_type: null
   column_name: org
+  description: null
+  expression: ''
+  extra: null
+  filterable: true
+  groupby: true
+  is_active: true
+  is_dttm: false
+  python_date_format: null
+  type: String
+  verbose_name: null
+- advanced_data_type: null
+  column_name: course_run
   description: null
   expression: null
   extra: null
@@ -95,7 +108,7 @@ columns:
   is_active: true
   is_dttm: false
   python_date_format: null
-  type: STRING
+  type: String
   verbose_name: null
 database_uuid: 21174b6c-4d40-4958-8161-d6c3cf5e77b6
 default_endpoint: null
@@ -117,7 +130,7 @@ metrics:
 normalize_columns: false
 offset: 0
 params: null
-schema: {{ DBT_PROFILE_TARGET_DATABASE }}
+schema: '{{ DBT_PROFILE_TARGET_DATABASE }}'
 sql: select * from {{ DBT_PROFILE_TARGET_DATABASE }}.fact_navigation_completion
 table_name: fact_navigation_completion
 template_params: null

--- a/tutoraspects/templates/aspects/build/aspects-superset/openedx-assets/assets/datasets/fact_navigation_completion.yaml
+++ b/tutoraspects/templates/aspects/build/aspects-superset/openedx-assets/assets/datasets/fact_navigation_completion.yaml
@@ -117,7 +117,7 @@ metrics:
 normalize_columns: false
 offset: 0
 params: null
-schema: main
+schema: {{ DBT_PROFILE_TARGET_DATABASE }}
 sql: select * from {{ DBT_PROFILE_TARGET_DATABASE }}.fact_navigation_completion
 table_name: fact_navigation_completion
 template_params: null

--- a/tutoraspects/templates/aspects/build/aspects-superset/openedx-assets/assets/datasets/fact_pageview_engagement.yaml
+++ b/tutoraspects/templates/aspects/build/aspects-superset/openedx-assets/assets/datasets/fact_pageview_engagement.yaml
@@ -106,7 +106,7 @@ metrics:
 normalize_columns: true
 offset: 0
 params: null
-schema: {{ DBT_PROFILE_TARGET_DATABASE }}
+schema: '{{ DBT_PROFILE_TARGET_DATABASE }}'
 sql: |-
   {% filter indent(width=2) %}{% include 'openedx-assets/queries/fact_pageview_engagement.sql' %}{% endfilter %}
 table_name: fact_pageview_engagement

--- a/tutoraspects/templates/aspects/build/aspects-superset/openedx-assets/assets/datasets/fact_pageview_engagement.yaml
+++ b/tutoraspects/templates/aspects/build/aspects-superset/openedx-assets/assets/datasets/fact_pageview_engagement.yaml
@@ -106,7 +106,7 @@ metrics:
 normalize_columns: true
 offset: 0
 params: null
-schema: main
+schema: {{ DBT_PROFILE_TARGET_DATABASE }}
 sql: |-
   {% filter indent(width=2) %}{% include 'openedx-assets/queries/fact_pageview_engagement.sql' %}{% endfilter %}
 table_name: fact_pageview_engagement

--- a/tutoraspects/templates/aspects/build/aspects-superset/openedx-assets/assets/datasets/fact_problem_engagement.yaml
+++ b/tutoraspects/templates/aspects/build/aspects-superset/openedx-assets/assets/datasets/fact_problem_engagement.yaml
@@ -105,7 +105,7 @@ metrics:
 normalize_columns: true
 offset: 0
 params: null
-schema: main
+schema: reporting
 sql: |-
   {% filter indent(width=2) %}{% include 'openedx-assets/queries/fact_problem_engagement.sql' %}{% endfilter %}
 table_name: fact_problem_engagement

--- a/tutoraspects/templates/aspects/build/aspects-superset/openedx-assets/assets/datasets/fact_problem_grades.yaml
+++ b/tutoraspects/templates/aspects/build/aspects-superset/openedx-assets/assets/datasets/fact_problem_grades.yaml
@@ -163,7 +163,7 @@ metrics:
 normalize_columns: true
 offset: 0
 params: null
-schema: {{ DBT_PROFILE_TARGET_DATABASE }}
+schema: '{{ DBT_PROFILE_TARGET_DATABASE }}'
 sql: |-
   {% filter indent(width=2) %}{% include 'openedx-assets/queries/fact_problem_grades.sql' %}{% endfilter %}
 table_name: fact_problem_grades

--- a/tutoraspects/templates/aspects/build/aspects-superset/openedx-assets/assets/datasets/fact_problem_grades.yaml
+++ b/tutoraspects/templates/aspects/build/aspects-superset/openedx-assets/assets/datasets/fact_problem_grades.yaml
@@ -163,7 +163,7 @@ metrics:
 normalize_columns: true
 offset: 0
 params: null
-schema: main
+schema: {{ DBT_PROFILE_TARGET_DATABASE }}
 sql: |-
   {% filter indent(width=2) %}{% include 'openedx-assets/queries/fact_problem_grades.sql' %}{% endfilter %}
 table_name: fact_problem_grades

--- a/tutoraspects/templates/aspects/build/aspects-superset/openedx-assets/assets/datasets/fact_problem_responses.yaml
+++ b/tutoraspects/templates/aspects/build/aspects-superset/openedx-assets/assets/datasets/fact_problem_responses.yaml
@@ -175,7 +175,7 @@ metrics:
 normalize_columns: true
 offset: 0
 params: null
-schema: main
+schema: {{ DBT_PROFILE_TARGET_DATABASE }}
 sql: |-
   {% filter indent(width=2) %}{% include 'openedx-assets/queries/fact_problem_responses.sql' %}{% endfilter %}
 table_name: fact_problem_responses

--- a/tutoraspects/templates/aspects/build/aspects-superset/openedx-assets/assets/datasets/fact_problem_responses.yaml
+++ b/tutoraspects/templates/aspects/build/aspects-superset/openedx-assets/assets/datasets/fact_problem_responses.yaml
@@ -175,7 +175,7 @@ metrics:
 normalize_columns: true
 offset: 0
 params: null
-schema: {{ DBT_PROFILE_TARGET_DATABASE }}
+schema: '{{ DBT_PROFILE_TARGET_DATABASE }}'
 sql: |-
   {% filter indent(width=2) %}{% include 'openedx-assets/queries/fact_problem_responses.sql' %}{% endfilter %}
 table_name: fact_problem_responses

--- a/tutoraspects/templates/aspects/build/aspects-superset/openedx-assets/assets/datasets/fact_student_status.yaml
+++ b/tutoraspects/templates/aspects/build/aspects-superset/openedx-assets/assets/datasets/fact_student_status.yaml
@@ -1,0 +1,162 @@
+_file_name: fact_student_status.yaml
+cache_timeout: null
+columns:
+- advanced_data_type: null
+  column_name: Course Grade
+  description: null
+  expression: course_grade * 100
+  extra: {}
+  filterable: true
+  groupby: true
+  is_active: true
+  is_dttm: false
+  python_date_format: null
+  type: null
+  verbose_name: null
+- advanced_data_type: null
+  column_name: course_grade
+  description: null
+  expression: null
+  extra: {}
+  filterable: true
+  groupby: true
+  is_active: true
+  is_dttm: false
+  python_date_format: null
+  type: FLOAT64
+  verbose_name: null
+- advanced_data_type: null
+  column_name: approving_state
+  description: null
+  expression: null
+  extra: {}
+  filterable: true
+  groupby: true
+  is_active: true
+  is_dttm: false
+  python_date_format: null
+  type: STRING
+  verbose_name: null
+- advanced_data_type: null
+  column_name: grade_bucket
+  description: null
+  expression: null
+  extra: {}
+  filterable: true
+  groupby: true
+  is_active: true
+  is_dttm: false
+  python_date_format: null
+  type: STRING
+  verbose_name: null
+- advanced_data_type: null
+  column_name: actor_id
+  description: null
+  expression: null
+  extra: {}
+  filterable: true
+  groupby: true
+  is_active: true
+  is_dttm: false
+  python_date_format: null
+  type: STRING
+  verbose_name: null
+- advanced_data_type: null
+  column_name: course_name
+  description: null
+  expression: null
+  extra: {}
+  filterable: true
+  groupby: true
+  is_active: true
+  is_dttm: false
+  python_date_format: null
+  type: STRING
+  verbose_name: null
+- advanced_data_type: null
+  column_name: enrollment_status
+  description: null
+  expression: null
+  extra: {}
+  filterable: true
+  groupby: true
+  is_active: true
+  is_dttm: false
+  python_date_format: null
+  type: STRING
+  verbose_name: null
+- advanced_data_type: null
+  column_name: course_key
+  description: null
+  expression: null
+  extra: {}
+  filterable: true
+  groupby: true
+  is_active: true
+  is_dttm: false
+  python_date_format: null
+  type: STRING
+  verbose_name: null
+- advanced_data_type: null
+  column_name: course_run
+  description: null
+  expression: null
+  extra: {}
+  filterable: true
+  groupby: true
+  is_active: true
+  is_dttm: false
+  python_date_format: null
+  type: STRING
+  verbose_name: null
+- advanced_data_type: null
+  column_name: enrollment_mode
+  description: null
+  expression: null
+  extra: {}
+  filterable: true
+  groupby: true
+  is_active: true
+  is_dttm: false
+  python_date_format: null
+  type: STRING
+  verbose_name: null
+- advanced_data_type: null
+  column_name: org
+  description: null
+  expression: null
+  extra: {}
+  filterable: true
+  groupby: true
+  is_active: true
+  is_dttm: false
+  python_date_format: null
+  type: STRING
+  verbose_name: null
+database_uuid: 21174b6c-4d40-4958-8161-d6c3cf5e77b6
+default_endpoint: null
+description: null
+extra: null
+fetch_values_predicate: null
+filter_select_enabled: true
+main_dttm_col: null
+metrics:
+- currency: null
+  d3format: null
+  description: null
+  expression: COUNT(*)
+  extra:
+    warning_markdown: ''
+  metric_name: count
+  metric_type: count
+  verbose_name: COUNT(*)
+  warning_text: null
+normalize_columns: false
+offset: 0
+params: null
+schema: reporting
+sql: ''
+table_name: fact_student_status
+template_params: null
+uuid: 633a1d4e-cd40-482f-a5dc-d5901c2181c2
+version: 1.0.0

--- a/tutoraspects/templates/aspects/build/aspects-superset/openedx-assets/assets/datasets/fact_student_status.yaml
+++ b/tutoraspects/templates/aspects/build/aspects-superset/openedx-assets/assets/datasets/fact_student_status.yaml
@@ -1,4 +1,5 @@
 _file_name: fact_student_status.yaml
+always_filter_main_dttm: false
 cache_timeout: null
 columns:
 - advanced_data_type: null
@@ -16,122 +17,122 @@ columns:
 - advanced_data_type: null
   column_name: course_grade
   description: null
-  expression: null
+  expression: ''
   extra: {}
   filterable: true
   groupby: true
   is_active: true
   is_dttm: false
   python_date_format: null
-  type: FLOAT64
+  type: Float64
   verbose_name: null
 - advanced_data_type: null
   column_name: approving_state
   description: null
-  expression: null
+  expression: ''
   extra: {}
   filterable: true
   groupby: true
   is_active: true
   is_dttm: false
   python_date_format: null
-  type: STRING
+  type: String
   verbose_name: null
 - advanced_data_type: null
   column_name: grade_bucket
   description: null
-  expression: null
+  expression: ''
   extra: {}
   filterable: true
   groupby: true
   is_active: true
   is_dttm: false
   python_date_format: null
-  type: STRING
+  type: String
   verbose_name: null
 - advanced_data_type: null
   column_name: actor_id
   description: null
-  expression: null
+  expression: ''
   extra: {}
   filterable: true
   groupby: true
   is_active: true
   is_dttm: false
   python_date_format: null
-  type: STRING
+  type: String
   verbose_name: null
 - advanced_data_type: null
   column_name: course_name
   description: null
-  expression: null
+  expression: ''
   extra: {}
   filterable: true
   groupby: true
   is_active: true
   is_dttm: false
   python_date_format: null
-  type: STRING
+  type: String
   verbose_name: null
 - advanced_data_type: null
   column_name: enrollment_status
   description: null
-  expression: null
+  expression: ''
   extra: {}
   filterable: true
   groupby: true
   is_active: true
   is_dttm: false
   python_date_format: null
-  type: STRING
+  type: String
   verbose_name: null
 - advanced_data_type: null
   column_name: course_key
   description: null
-  expression: null
+  expression: ''
   extra: {}
   filterable: true
   groupby: true
   is_active: true
   is_dttm: false
   python_date_format: null
-  type: STRING
+  type: String
   verbose_name: null
 - advanced_data_type: null
   column_name: course_run
   description: null
-  expression: null
+  expression: ''
   extra: {}
   filterable: true
   groupby: true
   is_active: true
   is_dttm: false
   python_date_format: null
-  type: STRING
+  type: String
   verbose_name: null
 - advanced_data_type: null
   column_name: enrollment_mode
   description: null
-  expression: null
+  expression: ''
   extra: {}
   filterable: true
   groupby: true
   is_active: true
   is_dttm: false
   python_date_format: null
-  type: STRING
+  type: String
   verbose_name: null
 - advanced_data_type: null
   column_name: org
   description: null
-  expression: null
+  expression: ''
   extra: {}
   filterable: true
   groupby: true
   is_active: true
   is_dttm: false
   python_date_format: null
-  type: STRING
+  type: String
   verbose_name: null
 database_uuid: 21174b6c-4d40-4958-8161-d6c3cf5e77b6
 default_endpoint: null
@@ -154,7 +155,7 @@ metrics:
 normalize_columns: false
 offset: 0
 params: null
-schema: {{ DBT_PROFILE_TARGET_DATABASE }}
+schema: '{{ DBT_PROFILE_TARGET_DATABASE }}'
 sql: select * from {{ DBT_PROFILE_TARGET_DATABASE }}.fact_student_status
 table_name: fact_student_status
 template_params: null

--- a/tutoraspects/templates/aspects/build/aspects-superset/openedx-assets/assets/datasets/fact_student_status.yaml
+++ b/tutoraspects/templates/aspects/build/aspects-superset/openedx-assets/assets/datasets/fact_student_status.yaml
@@ -154,8 +154,8 @@ metrics:
 normalize_columns: false
 offset: 0
 params: null
-schema: reporting
-sql: ''
+schema: main
+sql: select * from {{ DBT_PROFILE_TARGET_DATABASE }}.fact_student_status
 table_name: fact_student_status
 template_params: null
 uuid: 633a1d4e-cd40-482f-a5dc-d5901c2181c2

--- a/tutoraspects/templates/aspects/build/aspects-superset/openedx-assets/assets/datasets/fact_student_status.yaml
+++ b/tutoraspects/templates/aspects/build/aspects-superset/openedx-assets/assets/datasets/fact_student_status.yaml
@@ -154,7 +154,7 @@ metrics:
 normalize_columns: false
 offset: 0
 params: null
-schema: main
+schema: {{ DBT_PROFILE_TARGET_DATABASE }}
 sql: select * from {{ DBT_PROFILE_TARGET_DATABASE }}.fact_student_status
 table_name: fact_student_status
 template_params: null

--- a/tutoraspects/templates/aspects/build/aspects-superset/openedx-assets/assets/datasets/fact_transcript_usage.yaml
+++ b/tutoraspects/templates/aspects/build/aspects-superset/openedx-assets/assets/datasets/fact_transcript_usage.yaml
@@ -138,7 +138,7 @@ metrics:
 normalize_columns: true
 offset: 0
 params: null
-schema: {{ DBT_PROFILE_TARGET_DATABASE }}
+schema: '{{ DBT_PROFILE_TARGET_DATABASE }}'
 sql: |-
   {% filter indent(width=2) %}{% include 'openedx-assets/queries/fact_transcript_usage.sql' %}{% endfilter %}
 table_name: fact_transcript_usage

--- a/tutoraspects/templates/aspects/build/aspects-superset/openedx-assets/assets/datasets/fact_transcript_usage.yaml
+++ b/tutoraspects/templates/aspects/build/aspects-superset/openedx-assets/assets/datasets/fact_transcript_usage.yaml
@@ -138,7 +138,7 @@ metrics:
 normalize_columns: true
 offset: 0
 params: null
-schema: main
+schema: {{ DBT_PROFILE_TARGET_DATABASE }}
 sql: |-
   {% filter indent(width=2) %}{% include 'openedx-assets/queries/fact_transcript_usage.sql' %}{% endfilter %}
 table_name: fact_transcript_usage

--- a/tutoraspects/templates/aspects/build/aspects-superset/openedx-assets/assets/datasets/fact_video_engagement.yaml
+++ b/tutoraspects/templates/aspects/build/aspects-superset/openedx-assets/assets/datasets/fact_video_engagement.yaml
@@ -106,7 +106,7 @@ metrics:
 normalize_columns: true
 offset: 0
 params: null
-schema: main
+schema: {{ DBT_PROFILE_TARGET_DATABASE }}
 sql: |-
   {% filter indent(width=2) %}{% include 'openedx-assets/queries/fact_video_engagement.sql' %}{% endfilter %}
 table_name: fact_video_engagement

--- a/tutoraspects/templates/aspects/build/aspects-superset/openedx-assets/assets/datasets/fact_video_engagement.yaml
+++ b/tutoraspects/templates/aspects/build/aspects-superset/openedx-assets/assets/datasets/fact_video_engagement.yaml
@@ -106,7 +106,7 @@ metrics:
 normalize_columns: true
 offset: 0
 params: null
-schema: {{ DBT_PROFILE_TARGET_DATABASE }}
+schema: '{{ DBT_PROFILE_TARGET_DATABASE }}'
 sql: |-
   {% filter indent(width=2) %}{% include 'openedx-assets/queries/fact_video_engagement.sql' %}{% endfilter %}
 table_name: fact_video_engagement

--- a/tutoraspects/templates/aspects/build/aspects-superset/openedx-assets/assets/datasets/fact_video_engagement.yaml
+++ b/tutoraspects/templates/aspects/build/aspects-superset/openedx-assets/assets/datasets/fact_video_engagement.yaml
@@ -3,7 +3,7 @@ always_filter_main_dttm: false
 cache_timeout: null
 columns:
 - advanced_data_type: null
-  column_name: section/subsection page engagement
+  column_name: section/subsection video engagement
   description: null
   expression: null
   extra: null
@@ -17,7 +17,7 @@ columns:
 - advanced_data_type: null
   column_name: section/subsection name
   description: null
-  expression: null
+  expression: ''
   extra: null
   filterable: true
   groupby: true
@@ -29,7 +29,7 @@ columns:
 - advanced_data_type: null
   column_name: content level
   description: null
-  expression: null
+  expression: ''
   extra: null
   filterable: true
   groupby: true
@@ -41,7 +41,7 @@ columns:
 - advanced_data_type: null
   column_name: actor_id
   description: null
-  expression: null
+  expression: ''
   extra: null
   filterable: true
   groupby: true
@@ -53,19 +53,7 @@ columns:
 - advanced_data_type: null
   column_name: course_key
   description: null
-  expression: null
-  extra: null
-  filterable: true
-  groupby: true
-  is_active: true
-  is_dttm: false
-  python_date_format: null
-  type: String
-  verbose_name: null
-- advanced_data_type: null
-  column_name: course_run
-  description: null
-  expression: null
+  expression: ''
   extra: null
   filterable: true
   groupby: true
@@ -77,7 +65,7 @@ columns:
 - advanced_data_type: null
   column_name: org
   description: null
-  expression: null
+  expression: ''
   extra: null
   filterable: true
   groupby: true

--- a/tutoraspects/templates/aspects/build/aspects-superset/openedx-assets/assets/datasets/fact_video_plays.yaml
+++ b/tutoraspects/templates/aspects/build/aspects-superset/openedx-assets/assets/datasets/fact_video_plays.yaml
@@ -199,7 +199,7 @@ metrics:
 normalize_columns: true
 offset: 0
 params: null
-schema: main
+schema: {{ DBT_PROFILE_TARGET_DATABASE }}
 sql: |-
   {% filter indent(width=2) %}{% include 'openedx-assets/queries/fact_video_plays.sql' %}{% endfilter %}
 table_name: fact_video_plays

--- a/tutoraspects/templates/aspects/build/aspects-superset/openedx-assets/assets/datasets/fact_video_plays.yaml
+++ b/tutoraspects/templates/aspects/build/aspects-superset/openedx-assets/assets/datasets/fact_video_plays.yaml
@@ -199,7 +199,7 @@ metrics:
 normalize_columns: true
 offset: 0
 params: null
-schema: {{ DBT_PROFILE_TARGET_DATABASE }}
+schema: '{{ DBT_PROFILE_TARGET_DATABASE }}'
 sql: |-
   {% filter indent(width=2) %}{% include 'openedx-assets/queries/fact_video_plays.sql' %}{% endfilter %}
 table_name: fact_video_plays

--- a/tutoraspects/templates/aspects/build/aspects-superset/openedx-assets/assets/datasets/fact_watched_video_segments.yaml
+++ b/tutoraspects/templates/aspects/build/aspects-superset/openedx-assets/assets/datasets/fact_watched_video_segments.yaml
@@ -149,7 +149,7 @@ metrics:
 normalize_columns: true
 offset: 0
 params: null
-schema: main
+schema: {{ DBT_PROFILE_TARGET_DATABASE }}
 sql: |-
   {% filter indent(width=2) %}{% include 'openedx-assets/queries/fact_watched_video_segments.sql' %}{% endfilter %}
 table_name: fact_watched_video_segments

--- a/tutoraspects/templates/aspects/build/aspects-superset/openedx-assets/assets/datasets/fact_watched_video_segments.yaml
+++ b/tutoraspects/templates/aspects/build/aspects-superset/openedx-assets/assets/datasets/fact_watched_video_segments.yaml
@@ -149,7 +149,7 @@ metrics:
 normalize_columns: true
 offset: 0
 params: null
-schema: {{ DBT_PROFILE_TARGET_DATABASE }}
+schema: '{{ DBT_PROFILE_TARGET_DATABASE }}'
 sql: |-
   {% filter indent(width=2) %}{% include 'openedx-assets/queries/fact_watched_video_segments.sql' %}{% endfilter %}
 table_name: fact_watched_video_segments

--- a/tutoraspects/templates/aspects/build/aspects-superset/openedx-assets/assets/datasets/hints_per_success.yaml
+++ b/tutoraspects/templates/aspects/build/aspects-superset/openedx-assets/assets/datasets/hints_per_success.yaml
@@ -127,7 +127,7 @@ metrics:
 normalize_columns: true
 offset: 0
 params: null
-schema: {{ DBT_PROFILE_TARGET_DATABASE }}
+schema: '{{ DBT_PROFILE_TARGET_DATABASE }}'
 sql: |-
   {% filter indent(width=2) %}{% include 'openedx-assets/queries/hints_per_success.sql' %}{% endfilter %}
 table_name: hints_per_success

--- a/tutoraspects/templates/aspects/build/aspects-superset/openedx-assets/assets/datasets/hints_per_success.yaml
+++ b/tutoraspects/templates/aspects/build/aspects-superset/openedx-assets/assets/datasets/hints_per_success.yaml
@@ -127,7 +127,7 @@ metrics:
 normalize_columns: true
 offset: 0
 params: null
-schema: main
+schema: {{ DBT_PROFILE_TARGET_DATABASE }}
 sql: |-
   {% filter indent(width=2) %}{% include 'openedx-assets/queries/hints_per_success.sql' %}{% endfilter %}
 table_name: hints_per_success

--- a/tutoraspects/templates/aspects/build/aspects-superset/openedx-assets/assets/datasets/indexed_events.yaml
+++ b/tutoraspects/templates/aspects/build/aspects-superset/openedx-assets/assets/datasets/indexed_events.yaml
@@ -1,10 +1,11 @@
 _file_name: indexed_events.yaml
+always_filter_main_dttm: false
 cache_timeout: null
 columns:
 - advanced_data_type: null
   column_name: actor_id
   description: null
-  expression: null
+  expression: ''
   extra: {}
   filterable: true
   groupby: true
@@ -16,7 +17,7 @@ columns:
 - advanced_data_type: null
   column_name: course_key
   description: null
-  expression: null
+  expression: ''
   extra: {}
   filterable: true
   groupby: true
@@ -28,7 +29,7 @@ columns:
 - advanced_data_type: null
   column_name: course_name
   description: null
-  expression: null
+  expression: ''
   extra: {}
   filterable: true
   groupby: true
@@ -40,7 +41,7 @@ columns:
 - advanced_data_type: null
   column_name: course_run
   description: null
-  expression: null
+  expression: ''
   extra: {}
   filterable: true
   groupby: true
@@ -52,7 +53,7 @@ columns:
 - advanced_data_type: null
   column_name: event_id
   description: null
-  expression: null
+  expression: ''
   extra: {}
   filterable: true
   groupby: true
@@ -64,7 +65,7 @@ columns:
 - advanced_data_type: null
   column_name: emission_time
   description: null
-  expression: null
+  expression: ''
   extra: {}
   filterable: true
   groupby: true
@@ -76,7 +77,7 @@ columns:
 - advanced_data_type: null
   column_name: object_id
   description: null
-  expression: null
+  expression: ''
   extra: {}
   filterable: true
   groupby: true
@@ -88,7 +89,7 @@ columns:
 - advanced_data_type: null
   column_name: verb_id
   description: null
-  expression: null
+  expression: ''
   extra: {}
   filterable: true
   groupby: true
@@ -100,7 +101,7 @@ columns:
 - advanced_data_type: null
   column_name: org
   description: null
-  expression: null
+  expression: ''
   extra: {}
   filterable: true
   groupby: true

--- a/tutoraspects/templates/aspects/build/aspects-superset/openedx-assets/assets/datasets/indexed_events.yaml
+++ b/tutoraspects/templates/aspects/build/aspects-superset/openedx-assets/assets/datasets/indexed_events.yaml
@@ -129,7 +129,7 @@ metrics:
 normalize_columns: false
 offset: 0
 params: null
-schema: main
+schema: {{ ASPECTS_XAPI_DATABASE }}
 sql: |-
   {% filter indent(width=2) %}{% include 'openedx-assets/queries/indexed_events.sql' %}{% endfilter %}
 table_name: indexed_events

--- a/tutoraspects/templates/aspects/build/aspects-superset/openedx-assets/assets/datasets/indexed_events.yaml
+++ b/tutoraspects/templates/aspects/build/aspects-superset/openedx-assets/assets/datasets/indexed_events.yaml
@@ -129,7 +129,7 @@ metrics:
 normalize_columns: false
 offset: 0
 params: null
-schema: {{ ASPECTS_XAPI_DATABASE }}
+schema: '{{ ASPECTS_XAPI_DATABASE }}'
 sql: |-
   {% filter indent(width=2) %}{% include 'openedx-assets/queries/indexed_events.sql' %}{% endfilter %}
 table_name: indexed_events

--- a/tutoraspects/templates/aspects/build/aspects-superset/openedx-assets/assets/datasets/int_problem_results.yaml
+++ b/tutoraspects/templates/aspects/build/aspects-superset/openedx-assets/assets/datasets/int_problem_results.yaml
@@ -165,8 +165,8 @@ metrics:
 normalize_columns: false
 offset: 0
 params: null
-schema: main
-sql: select * from int_problem_results
+schema: {{ DBT_PROFILE_TARGET_DATABASE }}
+sql: select * from {{ DBT_PROFILE_TARGET_DATABASE }}.int_problem_results
 table_name: int_problem_results
 template_params: null
 uuid: c0c8b8a3-b18a-4c17-a69b-e6befea0159d

--- a/tutoraspects/templates/aspects/build/aspects-superset/openedx-assets/assets/datasets/int_problem_results.yaml
+++ b/tutoraspects/templates/aspects/build/aspects-superset/openedx-assets/assets/datasets/int_problem_results.yaml
@@ -1,0 +1,173 @@
+_file_name: int_problem_results.yaml
+cache_timeout: null
+columns:
+- advanced_data_type: null
+  column_name: attempts
+  description: null
+  expression: null
+  extra: null
+  filterable: true
+  groupby: true
+  is_active: true
+  is_dttm: false
+  python_date_format: null
+  type: INT16
+  verbose_name: null
+- advanced_data_type: null
+  column_name: emission_time
+  description: null
+  expression: null
+  extra: null
+  filterable: true
+  groupby: true
+  is_active: true
+  is_dttm: true
+  python_date_format: null
+  type: DATETIME
+  verbose_name: null
+- advanced_data_type: null
+  column_name: success
+  description: null
+  expression: null
+  extra: null
+  filterable: true
+  groupby: true
+  is_active: true
+  is_dttm: false
+  python_date_format: null
+  type: BOOL
+  verbose_name: null
+- advanced_data_type: null
+  column_name: problem_name_with_location
+  description: null
+  expression: null
+  extra: null
+  filterable: true
+  groupby: true
+  is_active: true
+  is_dttm: false
+  python_date_format: null
+  type: STRING
+  verbose_name: null
+- advanced_data_type: null
+  column_name: problem_name
+  description: null
+  expression: null
+  extra: null
+  filterable: true
+  groupby: true
+  is_active: true
+  is_dttm: false
+  python_date_format: null
+  type: STRING
+  verbose_name: null
+- advanced_data_type: null
+  column_name: actor_id
+  description: null
+  expression: null
+  extra: null
+  filterable: true
+  groupby: true
+  is_active: true
+  is_dttm: false
+  python_date_format: null
+  type: STRING
+  verbose_name: null
+- advanced_data_type: null
+  column_name: course_name
+  description: null
+  expression: null
+  extra: null
+  filterable: true
+  groupby: true
+  is_active: true
+  is_dttm: false
+  python_date_format: null
+  type: STRING
+  verbose_name: null
+- advanced_data_type: null
+  column_name: problem_id
+  description: null
+  expression: null
+  extra: null
+  filterable: true
+  groupby: true
+  is_active: true
+  is_dttm: false
+  python_date_format: null
+  type: STRING
+  verbose_name: null
+- advanced_data_type: null
+  column_name: course_key
+  description: null
+  expression: null
+  extra: null
+  filterable: true
+  groupby: true
+  is_active: true
+  is_dttm: false
+  python_date_format: null
+  type: STRING
+  verbose_name: null
+- advanced_data_type: null
+  column_name: course_run
+  description: null
+  expression: null
+  extra: null
+  filterable: true
+  groupby: true
+  is_active: true
+  is_dttm: false
+  python_date_format: null
+  type: STRING
+  verbose_name: null
+- advanced_data_type: null
+  column_name: responses
+  description: null
+  expression: null
+  extra: null
+  filterable: true
+  groupby: true
+  is_active: true
+  is_dttm: false
+  python_date_format: null
+  type: STRING
+  verbose_name: null
+- advanced_data_type: null
+  column_name: org
+  description: null
+  expression: null
+  extra: null
+  filterable: true
+  groupby: true
+  is_active: true
+  is_dttm: false
+  python_date_format: null
+  type: STRING
+  verbose_name: null
+database_uuid: 21174b6c-4d40-4958-8161-d6c3cf5e77b6
+default_endpoint: null
+description: null
+extra: null
+fetch_values_predicate: null
+filter_select_enabled: true
+main_dttm_col: emission_time
+metrics:
+- currency: null
+  d3format: null
+  description: null
+  expression: COUNT(*)
+  extra: null
+  metric_name: count
+  metric_type: count
+  verbose_name: COUNT(*)
+  warning_text: null
+normalize_columns: false
+offset: 0
+params: null
+schema: reporting
+sql: null
+table_name: int_problem_results
+template_params: null
+uuid: c0c8b8a3-b18a-4c17-a69b-e6befea0159d
+version: 1.0.0

--- a/tutoraspects/templates/aspects/build/aspects-superset/openedx-assets/assets/datasets/int_problem_results.yaml
+++ b/tutoraspects/templates/aspects/build/aspects-superset/openedx-assets/assets/datasets/int_problem_results.yaml
@@ -1,149 +1,150 @@
 _file_name: int_problem_results.yaml
+always_filter_main_dttm: false
 cache_timeout: null
 columns:
 - advanced_data_type: null
   column_name: attempts
   description: null
-  expression: null
+  expression: ''
   extra: null
   filterable: true
   groupby: true
   is_active: true
   is_dttm: false
   python_date_format: null
-  type: INT16
+  type: Int16
+  verbose_name: null
+- advanced_data_type: null
+  column_name: success
+  description: null
+  expression: ''
+  extra: null
+  filterable: true
+  groupby: true
+  is_active: true
+  is_dttm: false
+  python_date_format: null
+  type: Bool
   verbose_name: null
 - advanced_data_type: null
   column_name: emission_time
   description: null
-  expression: null
+  expression: ''
   extra: null
   filterable: true
   groupby: true
   is_active: true
   is_dttm: true
   python_date_format: null
-  type: DATETIME
-  verbose_name: null
-- advanced_data_type: null
-  column_name: success
-  description: null
-  expression: null
-  extra: null
-  filterable: true
-  groupby: true
-  is_active: true
-  is_dttm: false
-  python_date_format: null
-  type: BOOL
+  type: DateTime
   verbose_name: null
 - advanced_data_type: null
   column_name: problem_name_with_location
   description: null
-  expression: null
+  expression: ''
   extra: null
   filterable: true
   groupby: true
   is_active: true
   is_dttm: false
   python_date_format: null
-  type: STRING
+  type: String
   verbose_name: null
 - advanced_data_type: null
   column_name: problem_name
   description: null
-  expression: null
+  expression: ''
   extra: null
   filterable: true
   groupby: true
   is_active: true
   is_dttm: false
   python_date_format: null
-  type: STRING
+  type: String
   verbose_name: null
 - advanced_data_type: null
   column_name: actor_id
   description: null
-  expression: null
+  expression: ''
   extra: null
   filterable: true
   groupby: true
   is_active: true
   is_dttm: false
   python_date_format: null
-  type: STRING
+  type: String
   verbose_name: null
 - advanced_data_type: null
   column_name: course_name
   description: null
-  expression: null
+  expression: ''
   extra: null
   filterable: true
   groupby: true
   is_active: true
   is_dttm: false
   python_date_format: null
-  type: STRING
+  type: String
   verbose_name: null
 - advanced_data_type: null
   column_name: problem_id
   description: null
-  expression: null
+  expression: ''
   extra: null
   filterable: true
   groupby: true
   is_active: true
   is_dttm: false
   python_date_format: null
-  type: STRING
+  type: String
   verbose_name: null
 - advanced_data_type: null
   column_name: course_key
   description: null
-  expression: null
+  expression: ''
   extra: null
   filterable: true
   groupby: true
   is_active: true
   is_dttm: false
   python_date_format: null
-  type: STRING
+  type: String
   verbose_name: null
 - advanced_data_type: null
   column_name: course_run
   description: null
-  expression: null
+  expression: ''
   extra: null
   filterable: true
   groupby: true
   is_active: true
   is_dttm: false
   python_date_format: null
-  type: STRING
+  type: String
   verbose_name: null
 - advanced_data_type: null
   column_name: responses
   description: null
-  expression: null
+  expression: ''
   extra: null
   filterable: true
   groupby: true
   is_active: true
   is_dttm: false
   python_date_format: null
-  type: STRING
+  type: String
   verbose_name: null
 - advanced_data_type: null
   column_name: org
   description: null
-  expression: null
+  expression: ''
   extra: null
   filterable: true
   groupby: true
   is_active: true
   is_dttm: false
   python_date_format: null
-  type: STRING
+  type: String
   verbose_name: null
 database_uuid: 21174b6c-4d40-4958-8161-d6c3cf5e77b6
 default_endpoint: null
@@ -165,7 +166,7 @@ metrics:
 normalize_columns: false
 offset: 0
 params: null
-schema: {{ DBT_PROFILE_TARGET_DATABASE }}
+schema: '{{ DBT_PROFILE_TARGET_DATABASE }}'
 sql: select * from {{ DBT_PROFILE_TARGET_DATABASE }}.int_problem_results
 table_name: int_problem_results
 template_params: null

--- a/tutoraspects/templates/aspects/build/aspects-superset/openedx-assets/assets/datasets/int_problem_results.yaml
+++ b/tutoraspects/templates/aspects/build/aspects-superset/openedx-assets/assets/datasets/int_problem_results.yaml
@@ -165,8 +165,8 @@ metrics:
 normalize_columns: false
 offset: 0
 params: null
-schema: reporting
-sql: null
+schema: main
+sql: select * from int_problem_results
 table_name: int_problem_results
 template_params: null
 uuid: c0c8b8a3-b18a-4c17-a69b-e6befea0159d

--- a/tutoraspects/templates/aspects/build/aspects-superset/openedx-assets/assets/datasets/posts_per_user.yaml
+++ b/tutoraspects/templates/aspects/build/aspects-superset/openedx-assets/assets/datasets/posts_per_user.yaml
@@ -103,7 +103,7 @@ metrics:
 normalize_columns: true
 offset: 0
 params: null
-schema: main
+schema: {{ DBT_PROFILE_TARGET_DATABASE }}
 sql: |-
   {% filter indent(width=2) %}{% include 'openedx-assets/queries/posts_per_user.sql' %}{% endfilter %}
 table_name: posts_per_user

--- a/tutoraspects/templates/aspects/build/aspects-superset/openedx-assets/assets/datasets/posts_per_user.yaml
+++ b/tutoraspects/templates/aspects/build/aspects-superset/openedx-assets/assets/datasets/posts_per_user.yaml
@@ -103,7 +103,7 @@ metrics:
 normalize_columns: true
 offset: 0
 params: null
-schema: {{ DBT_PROFILE_TARGET_DATABASE }}
+schema: '{{ DBT_PROFILE_TARGET_DATABASE }}'
 sql: |-
   {% filter indent(width=2) %}{% include 'openedx-assets/queries/posts_per_user.sql' %}{% endfilter %}
 table_name: posts_per_user

--- a/tutoraspects/templates/aspects/build/aspects-superset/openedx-assets/assets/datasets/query_log.yaml
+++ b/tutoraspects/templates/aspects/build/aspects-superset/openedx-assets/assets/datasets/query_log.yaml
@@ -106,7 +106,7 @@ metrics:
 normalize_columns: false
 offset: 0
 params: null
-schema: main
+schema: system
 sql: |
   SELECT
       query_duration_ms,

--- a/tutoraspects/templates/aspects/build/aspects-superset/openedx-assets/assets/datasets/slices.yaml
+++ b/tutoraspects/templates/aspects/build/aspects-superset/openedx-assets/assets/datasets/slices.yaml
@@ -273,7 +273,7 @@ metrics:
 normalize_columns: true
 offset: 0
 params: null
-schema: {{ SUPERSET_DB_NAME }}
+schema: '{{ SUPERSET_DB_NAME }}'
 sql: select * from slices
 table_name: slices
 template_params: null

--- a/tutoraspects/templates/aspects/build/aspects-superset/openedx-assets/assets/datasets/slices.yaml
+++ b/tutoraspects/templates/aspects/build/aspects-superset/openedx-assets/assets/datasets/slices.yaml
@@ -273,7 +273,7 @@ metrics:
 normalize_columns: true
 offset: 0
 params: null
-schema: superset
+schema: {{ SUPERSET_DB_NAME }}
 sql: select * from slices
 table_name: slices
 template_params: null

--- a/tutoraspects/templates/aspects/build/aspects-superset/openedx-assets/assets/datasets/slices.yaml
+++ b/tutoraspects/templates/aspects/build/aspects-superset/openedx-assets/assets/datasets/slices.yaml
@@ -274,7 +274,7 @@ normalize_columns: true
 offset: 0
 params: null
 schema: superset
-sql: select * from superset.slices
+sql: select * from slices
 table_name: slices
 template_params: null
 uuid: aaf1ae12-73c1-4b88-b07d-7a8988333018

--- a/tutoraspects/templates/aspects/build/aspects-superset/openedx-assets/assets/datasets/slices.yaml
+++ b/tutoraspects/templates/aspects/build/aspects-superset/openedx-assets/assets/datasets/slices.yaml
@@ -1,42 +1,7 @@
 _file_name: slices.yaml
+always_filter_main_dttm: false
 cache_timeout: null
 columns:
-- advanced_data_type: null
-  column_name: last_saved_at
-  description: null
-  expression: ''
-  extra: {}
-  filterable: true
-  groupby: true
-  is_active: true
-  is_dttm: true
-  python_date_format: null
-  type: TIMESTAMP WITHOUT TIME ZONE
-  verbose_name: Last Saved At
-- advanced_data_type: null
-  column_name: created_on
-  description: null
-  expression: ''
-  extra: {}
-  filterable: true
-  groupby: true
-  is_active: true
-  is_dttm: true
-  python_date_format: null
-  type: TIMESTAMP WITHOUT TIME ZONE
-  verbose_name: Created On
-- advanced_data_type: null
-  column_name: changed_on
-  description: null
-  expression: ''
-  extra: {}
-  filterable: true
-  groupby: true
-  is_active: true
-  is_dttm: true
-  python_date_format: null
-  type: TIMESTAMP WITHOUT TIME ZONE
-  verbose_name: Changed On
 - advanced_data_type: null
   column_name: last_saved_by_fk
   description: null
@@ -47,8 +12,20 @@ columns:
   is_active: true
   is_dttm: false
   python_date_format: null
-  type: INTEGER
+  type: LONG
   verbose_name: Last Saved By Fk
+- advanced_data_type: null
+  column_name: last_saved_at
+  description: null
+  expression: ''
+  extra: {}
+  filterable: true
+  groupby: true
+  is_active: true
+  is_dttm: true
+  python_date_format: null
+  type: DATETIME
+  verbose_name: Last Saved At
 - advanced_data_type: null
   column_name: created_by_fk
   description: null
@@ -59,7 +36,7 @@ columns:
   is_active: true
   is_dttm: false
   python_date_format: null
-  type: INTEGER
+  type: LONG
   verbose_name: Created By Fk
 - advanced_data_type: null
   column_name: changed_by_fk
@@ -71,20 +48,32 @@ columns:
   is_active: true
   is_dttm: false
   python_date_format: null
-  type: INTEGER
+  type: LONG
   verbose_name: Changed By Fk
 - advanced_data_type: null
-  column_name: schema_perm
+  column_name: created_on
   description: null
   expression: ''
   extra: {}
   filterable: true
   groupby: true
   is_active: true
-  is_dttm: false
+  is_dttm: true
   python_date_format: null
-  type: VARCHAR(1000)
-  verbose_name: Schema Perm
+  type: DATETIME
+  verbose_name: Created On
+- advanced_data_type: null
+  column_name: changed_on
+  description: null
+  expression: ''
+  extra: {}
+  filterable: true
+  groupby: true
+  is_active: true
+  is_dttm: true
+  python_date_format: null
+  type: DATETIME
+  verbose_name: Changed On
 - advanced_data_type: null
   column_name: datasource_name
   description: null
@@ -95,7 +84,7 @@ columns:
   is_active: true
   is_dttm: false
   python_date_format: null
-  type: VARCHAR(2000)
+  type: VAR_STRING
   verbose_name: Datasource Name
 - advanced_data_type: null
   column_name: datasource_type
@@ -107,7 +96,7 @@ columns:
   is_active: true
   is_dttm: false
   python_date_format: null
-  type: VARCHAR(200)
+  type: VAR_STRING
   verbose_name: Datasource Type
 - advanced_data_type: null
   column_name: slice_name
@@ -119,8 +108,20 @@ columns:
   is_active: true
   is_dttm: false
   python_date_format: null
-  type: VARCHAR(250)
+  type: VAR_STRING
   verbose_name: Slice Name
+- advanced_data_type: null
+  column_name: schema_perm
+  description: null
+  expression: ''
+  extra: {}
+  filterable: true
+  groupby: true
+  is_active: true
+  is_dttm: false
+  python_date_format: null
+  type: VAR_STRING
+  verbose_name: Schema Perm
 - advanced_data_type: null
   column_name: viz_type
   description: null
@@ -131,7 +132,7 @@ columns:
   is_active: true
   is_dttm: false
   python_date_format: null
-  type: VARCHAR(250)
+  type: VAR_STRING
   verbose_name: Viz Type
 - advanced_data_type: null
   column_name: certified_by
@@ -143,7 +144,7 @@ columns:
   is_active: true
   is_dttm: false
   python_date_format: null
-  type: TEXT
+  type: BLOB
   verbose_name: Certified By
 - advanced_data_type: null
   column_name: certification_details
@@ -155,20 +156,8 @@ columns:
   is_active: true
   is_dttm: false
   python_date_format: null
-  type: TEXT
+  type: BLOB
   verbose_name: Certification Details
-- advanced_data_type: null
-  column_name: cache_timeout
-  description: null
-  expression: ''
-  extra: {}
-  filterable: true
-  groupby: true
-  is_active: true
-  is_dttm: false
-  python_date_format: null
-  type: INTEGER
-  verbose_name: Cache Timeout
 - advanced_data_type: null
   column_name: query_context
   description: null
@@ -179,8 +168,20 @@ columns:
   is_active: true
   is_dttm: false
   python_date_format: null
-  type: TEXT
+  type: BLOB
   verbose_name: Query Context
+- advanced_data_type: null
+  column_name: cache_timeout
+  description: null
+  expression: ''
+  extra: {}
+  filterable: true
+  groupby: true
+  is_active: true
+  is_dttm: false
+  python_date_format: null
+  type: LONG
+  verbose_name: Cache Timeout
 - advanced_data_type: null
   column_name: datasource_id
   description: null
@@ -191,7 +192,7 @@ columns:
   is_active: true
   is_dttm: false
   python_date_format: null
-  type: INTEGER
+  type: LONG
   verbose_name: Datasource ID
 - advanced_data_type: null
   column_name: perm
@@ -203,32 +204,8 @@ columns:
   is_active: true
   is_dttm: false
   python_date_format: null
-  type: VARCHAR(2000)
+  type: VAR_STRING
   verbose_name: Perm
-- advanced_data_type: null
-  column_name: uuid
-  description: null
-  expression: ''
-  extra: {}
-  filterable: true
-  groupby: true
-  is_active: true
-  is_dttm: false
-  python_date_format: null
-  type: UUID
-  verbose_name: UUID
-- advanced_data_type: null
-  column_name: id
-  description: null
-  expression: ''
-  extra: {}
-  filterable: true
-  groupby: true
-  is_active: true
-  is_dttm: false
-  python_date_format: null
-  type: INTEGER
-  verbose_name: ID
 - advanced_data_type: null
   column_name: description
   description: null
@@ -239,7 +216,7 @@ columns:
   is_active: true
   is_dttm: false
   python_date_format: null
-  type: TEXT
+  type: BLOB
   verbose_name: Description
 - advanced_data_type: null
   column_name: params
@@ -251,8 +228,80 @@ columns:
   is_active: true
   is_dttm: false
   python_date_format: null
-  type: TEXT
+  type: BLOB
   verbose_name: Parameters
+- advanced_data_type: null
+  column_name: uuid
+  description: null
+  expression: ''
+  extra: {}
+  filterable: true
+  groupby: true
+  is_active: true
+  is_dttm: false
+  python_date_format: null
+  type: STRING
+  verbose_name: UUID
+- advanced_data_type: null
+  column_name: id
+  description: null
+  expression: ''
+  extra: {}
+  filterable: true
+  groupby: true
+  is_active: true
+  is_dttm: false
+  python_date_format: null
+  type: LONG
+  verbose_name: ID
+- advanced_data_type: null
+  column_name: external_url
+  description: null
+  expression: null
+  extra: null
+  filterable: true
+  groupby: true
+  is_active: true
+  is_dttm: false
+  python_date_format: null
+  type: BLOB
+  verbose_name: null
+- advanced_data_type: null
+  column_name: druid_datasource_id
+  description: null
+  expression: null
+  extra: null
+  filterable: true
+  groupby: true
+  is_active: true
+  is_dttm: false
+  python_date_format: null
+  type: LONG
+  verbose_name: null
+- advanced_data_type: null
+  column_name: table_id
+  description: null
+  expression: null
+  extra: null
+  filterable: true
+  groupby: true
+  is_active: true
+  is_dttm: false
+  python_date_format: null
+  type: LONG
+  verbose_name: null
+- advanced_data_type: null
+  column_name: is_managed_externally
+  description: null
+  expression: null
+  extra: null
+  filterable: true
+  groupby: true
+  is_active: true
+  is_dttm: false
+  python_date_format: null
+  type: TINY
+  verbose_name: null
 database_uuid: 06cd566f-e22a-4a79-b0e0-4c947de93ee0
 default_endpoint: null
 description: null

--- a/tutoraspects/templates/aspects/build/aspects-superset/openedx-assets/assets/datasets/slowest_clickhouse_queries.yaml
+++ b/tutoraspects/templates/aspects/build/aspects-superset/openedx-assets/assets/datasets/slowest_clickhouse_queries.yaml
@@ -1,10 +1,11 @@
 _file_name: slowest_clickhouse_queries.yaml
+always_filter_main_dttm: false
 cache_timeout: null
 columns:
 - advanced_data_type: null
   column_name: memory_usage_kb
   description: null
-  expression: null
+  expression: ''
   extra: {}
   filterable: true
   groupby: true
@@ -16,7 +17,7 @@ columns:
 - advanced_data_type: null
   column_name: duration_secs
   description: null
-  expression: null
+  expression: ''
   extra: {}
   filterable: true
   groupby: true
@@ -28,7 +29,7 @@ columns:
 - advanced_data_type: null
   column_name: read_rows
   description: null
-  expression: null
+  expression: ''
   extra: {}
   filterable: true
   groupby: true
@@ -40,7 +41,7 @@ columns:
 - advanced_data_type: null
   column_name: event_time
   description: null
-  expression: null
+  expression: ''
   extra: {}
   filterable: true
   groupby: true
@@ -52,7 +53,7 @@ columns:
 - advanced_data_type: null
   column_name: query
   description: null
-  expression: null
+  expression: ''
   extra: {}
   filterable: true
   groupby: true

--- a/tutoraspects/templates/aspects/build/aspects-superset/openedx-assets/assets/datasets/slowest_clickhouse_queries.yaml
+++ b/tutoraspects/templates/aspects/build/aspects-superset/openedx-assets/assets/datasets/slowest_clickhouse_queries.yaml
@@ -81,7 +81,7 @@ metrics:
 normalize_columns: false
 offset: 0
 params: null
-schema: main
+schema: system
 sql: |-
   {% filter indent(width=2) %}{% include 'openedx-assets/queries/slowest_clickhouse_queries.sql' %}{% endfilter %}
 table_name: slowest_clickhouse_queries

--- a/tutoraspects/templates/aspects/build/aspects-superset/openedx-assets/assets/datasets/superset_action_log.yaml
+++ b/tutoraspects/templates/aspects/build/aspects-superset/openedx-assets/assets/datasets/superset_action_log.yaml
@@ -190,7 +190,7 @@ metrics:
 normalize_columns: false
 offset: 0
 params: null
-schema: {{ SUPERSET_DB_NAME }}
+schema: '{{ SUPERSET_DB_NAME }}'
 sql: |-
   {% filter indent(width=2) %}{% include 'openedx-assets/queries/superset_action_log.sql' %}{% endfilter %}
 table_name: superset_action_log

--- a/tutoraspects/templates/aspects/build/aspects-superset/openedx-assets/assets/datasets/superset_action_log.yaml
+++ b/tutoraspects/templates/aspects/build/aspects-superset/openedx-assets/assets/datasets/superset_action_log.yaml
@@ -1,10 +1,11 @@
 _file_name: superset_action_log.yaml
+always_filter_main_dttm: false
 cache_timeout: null
 columns:
 - advanced_data_type: null
   column_name: user_registration_date
   description: null
-  expression: null
+  expression: ''
   extra: {}
   filterable: true
   groupby: true
@@ -16,7 +17,7 @@ columns:
 - advanced_data_type: null
   column_name: action_date
   description: null
-  expression: null
+  expression: ''
   extra: {}
   filterable: true
   groupby: true
@@ -28,146 +29,146 @@ columns:
 - advanced_data_type: null
   column_name: action_count
   description: null
-  expression: null
+  expression: ''
   extra: {}
   filterable: true
   groupby: true
   is_active: true
   is_dttm: false
   python_date_format: null
-  type: INT
+  type: LONGLONG
   verbose_name: Action Count
-- advanced_data_type: null
-  column_name: dashboard_id
-  description: null
-  expression: null
-  extra: {}
-  filterable: true
-  groupby: true
-  is_active: true
-  is_dttm: false
-  python_date_format: null
-  type: INT
-  verbose_name: Dashboard ID
 - advanced_data_type: null
   column_name: dashboard_status
   description: null
-  expression: null
+  expression: ''
   extra: {}
   filterable: true
   groupby: true
   is_active: true
   is_dttm: false
   python_date_format: null
-  type: STRING
+  type: VAR_STRING
   verbose_name: Dashboard Status
 - advanced_data_type: null
   column_name: dashboard_title
   description: null
-  expression: null
+  expression: ''
   extra: {}
   filterable: true
   groupby: true
   is_active: true
   is_dttm: false
   python_date_format: null
-  type: STRING
+  type: VAR_STRING
   verbose_name: Dashboard Title
-- advanced_data_type: null
-  column_name: slice_id
-  description: null
-  expression: null
-  extra: {}
-  filterable: true
-  groupby: true
-  is_active: true
-  is_dttm: false
-  python_date_format: null
-  type: INT
-  verbose_name: Slice ID
-- advanced_data_type: null
-  column_name: user_id
-  description: null
-  expression: null
-  extra: {}
-  filterable: true
-  groupby: true
-  is_active: true
-  is_dttm: false
-  python_date_format: null
-  type: INT
-  verbose_name: User ID
-- advanced_data_type: null
-  column_name: user_name
-  description: null
-  expression: null
-  extra: {}
-  filterable: true
-  groupby: true
-  is_active: true
-  is_dttm: false
-  python_date_format: null
-  type: STRING
-  verbose_name: User Name
-- advanced_data_type: null
-  column_name: datasource_id
-  description: null
-  expression: null
-  extra: {}
-  filterable: true
-  groupby: true
-  is_active: true
-  is_dttm: false
-  python_date_format: null
-  type: null
-  verbose_name: Datasource ID
 - advanced_data_type: null
   column_name: datasource_name
   description: null
-  expression: null
+  expression: ''
   extra: {}
   filterable: true
   groupby: true
   is_active: true
   is_dttm: null
   python_date_format: null
-  type: null
+  type: VAR_STRING
   verbose_name: Datasource Name
 - advanced_data_type: null
   column_name: datasource_type
   description: null
-  expression: null
+  expression: ''
   extra: {}
   filterable: true
   groupby: true
   is_active: true
   is_dttm: null
   python_date_format: null
-  type: null
+  type: VAR_STRING
   verbose_name: Datasource Type
 - advanced_data_type: null
-  column_name: slice_name
+  column_name: user_name
   description: null
-  expression: null
-  extra: {}
-  filterable: true
-  groupby: true
-  is_active: true
-  is_dttm: null
-  python_date_format: null
-  type: null
-  verbose_name: Slice Name
-- advanced_data_type: null
-  column_name: action
-  description: null
-  expression: null
+  expression: ''
   extra: {}
   filterable: true
   groupby: true
   is_active: true
   is_dttm: false
   python_date_format: null
-  type: STRING
+  type: VAR_STRING
+  verbose_name: User Name
+- advanced_data_type: null
+  column_name: slice_name
+  description: null
+  expression: ''
+  extra: {}
+  filterable: true
+  groupby: true
+  is_active: true
+  is_dttm: null
+  python_date_format: null
+  type: VAR_STRING
+  verbose_name: Slice Name
+- advanced_data_type: null
+  column_name: dashboard_id
+  description: null
+  expression: ''
+  extra: {}
+  filterable: true
+  groupby: true
+  is_active: true
+  is_dttm: false
+  python_date_format: null
+  type: LONG
+  verbose_name: Dashboard ID
+- advanced_data_type: null
+  column_name: datasource_id
+  description: null
+  expression: ''
+  extra: {}
+  filterable: true
+  groupby: true
+  is_active: true
+  is_dttm: false
+  python_date_format: null
+  type: LONG
+  verbose_name: Datasource ID
+- advanced_data_type: null
+  column_name: slice_id
+  description: null
+  expression: ''
+  extra: {}
+  filterable: true
+  groupby: true
+  is_active: true
+  is_dttm: false
+  python_date_format: null
+  type: LONG
+  verbose_name: Slice ID
+- advanced_data_type: null
+  column_name: user_id
+  description: null
+  expression: ''
+  extra: {}
+  filterable: true
+  groupby: true
+  is_active: true
+  is_dttm: false
+  python_date_format: null
+  type: LONG
+  verbose_name: User ID
+- advanced_data_type: null
+  column_name: action
+  description: null
+  expression: ''
+  extra: {}
+  filterable: true
+  groupby: true
+  is_active: true
+  is_dttm: false
+  python_date_format: null
+  type: VAR_STRING
   verbose_name: Action
 database_uuid: 06cd566f-e22a-4a79-b0e0-4c947de93ee0
 default_endpoint: null
@@ -175,7 +176,7 @@ description: null
 extra: {}
 fetch_values_predicate: null
 filter_select_enabled: false
-main_dttm_col: null
+main_dttm_col: action_date
 metrics:
 - currency: null
   d3format: null

--- a/tutoraspects/templates/aspects/build/aspects-superset/openedx-assets/assets/datasets/superset_action_log.yaml
+++ b/tutoraspects/templates/aspects/build/aspects-superset/openedx-assets/assets/datasets/superset_action_log.yaml
@@ -190,7 +190,7 @@ metrics:
 normalize_columns: false
 offset: 0
 params: null
-schema: superset
+schema: {{ SUPERSET_DB_NAME }}
 sql: |-
   {% filter indent(width=2) %}{% include 'openedx-assets/queries/superset_action_log.sql' %}{% endfilter %}
 table_name: superset_action_log

--- a/tutoraspects/templates/aspects/build/aspects-superset/openedx-assets/assets/datasets/user_pii.yaml
+++ b/tutoraspects/templates/aspects/build/aspects-superset/openedx-assets/assets/datasets/user_pii.yaml
@@ -6,7 +6,7 @@ default_endpoint: null
 offset: 0
 cache_timeout: null
 schema: main
-sql: 'select * from event_sink.user_pii'
+sql: 'select * from {{ ASPECTS_EVENT_SINK_DATABASE }}.user_pii'
 params: null
 template_params: null
 filter_select_enabled: true

--- a/tutoraspects/templates/aspects/build/aspects-superset/openedx-assets/assets/datasets/user_pii.yaml
+++ b/tutoraspects/templates/aspects/build/aspects-superset/openedx-assets/assets/datasets/user_pii.yaml
@@ -5,7 +5,7 @@ description: null
 default_endpoint: null
 offset: 0
 cache_timeout: null
-schema: main
+schema: {{ ASPECTS_EVENT_SINK_DATABASE }}
 sql: 'select * from {{ ASPECTS_EVENT_SINK_DATABASE }}.user_pii'
 params: null
 template_params: null

--- a/tutoraspects/templates/aspects/build/aspects-superset/openedx-assets/assets/datasets/user_pii.yaml
+++ b/tutoraspects/templates/aspects/build/aspects-superset/openedx-assets/assets/datasets/user_pii.yaml
@@ -5,7 +5,7 @@ description: null
 default_endpoint: null
 offset: 0
 cache_timeout: null
-schema: {{ ASPECTS_EVENT_SINK_DATABASE }}
+schema: '{{ ASPECTS_EVENT_SINK_DATABASE }}'
 sql: 'select * from {{ ASPECTS_EVENT_SINK_DATABASE }}.user_pii'
 params: null
 template_params: null

--- a/tutoraspects/templates/aspects/build/aspects-superset/openedx-assets/assets/datasets/xapi_events_all_parsed.yaml
+++ b/tutoraspects/templates/aspects/build/aspects-superset/openedx-assets/assets/datasets/xapi_events_all_parsed.yaml
@@ -1,4 +1,5 @@
 _file_name: xapi_events_all_parsed.yaml
+always_filter_main_dttm: false
 cache_timeout: null
 columns:
 - advanced_data_type: null
@@ -67,9 +68,21 @@ columns:
   type: null
   verbose_name: Course Key
 - advanced_data_type: null
+  column_name: emission_time
+  description: null
+  expression: ''
+  extra: {}
+  filterable: true
+  groupby: true
+  is_active: true
+  is_dttm: true
+  python_date_format: null
+  type: DateTime64(6)
+  verbose_name: Emission Time
+- advanced_data_type: null
   column_name: actor_id
   description: null
-  expression: null
+  expression: ''
   extra: {}
   filterable: true
   groupby: true
@@ -81,7 +94,7 @@ columns:
 - advanced_data_type: null
   column_name: course_id
   description: null
-  expression: null
+  expression: ''
   extra: {}
   filterable: true
   groupby: true
@@ -93,7 +106,7 @@ columns:
 - advanced_data_type: null
   column_name: event_id
   description: null
-  expression: null
+  expression: ''
   extra: {}
   filterable: true
   groupby: true
@@ -103,21 +116,9 @@ columns:
   type: UUID
   verbose_name: Event ID
 - advanced_data_type: null
-  column_name: emission_time
-  description: null
-  expression: null
-  extra: {}
-  filterable: true
-  groupby: true
-  is_active: true
-  is_dttm: true
-  python_date_format: null
-  type: DateTime
-  verbose_name: Emission Time
-- advanced_data_type: null
   column_name: object_id
   description: null
-  expression: null
+  expression: ''
   extra: {}
   filterable: true
   groupby: true
@@ -129,7 +130,7 @@ columns:
 - advanced_data_type: null
   column_name: verb_id
   description: null
-  expression: null
+  expression: ''
   extra: {}
   filterable: true
   groupby: true
@@ -139,21 +140,9 @@ columns:
   type: String
   verbose_name: Verb ID
 - advanced_data_type: null
-  column_name: event_str
-  description: null
-  expression: null
-  extra: {}
-  filterable: true
-  groupby: true
-  is_active: true
-  is_dttm: false
-  python_date_format: null
-  type: String
-  verbose_name: Event String
-- advanced_data_type: null
   column_name: org
   description: null
-  expression: null
+  expression: ''
   extra: {}
   filterable: true
   groupby: true
@@ -162,6 +151,18 @@ columns:
   python_date_format: null
   type: String
   verbose_name: Organization
+- advanced_data_type: null
+  column_name: event
+  description: null
+  expression: null
+  extra: null
+  filterable: true
+  groupby: true
+  is_active: true
+  is_dttm: false
+  python_date_format: null
+  type: String
+  verbose_name: null
 database_uuid: 21174b6c-4d40-4958-8161-d6c3cf5e77b6
 default_endpoint: null
 description: null

--- a/tutoraspects/templates/aspects/build/aspects-superset/openedx-assets/assets/datasets/xapi_events_all_parsed.yaml
+++ b/tutoraspects/templates/aspects/build/aspects-superset/openedx-assets/assets/datasets/xapi_events_all_parsed.yaml
@@ -183,7 +183,7 @@ metrics:
 normalize_columns: true
 offset: 0
 params: null
-schema: main
+schema: {{ ASPECTS_XAPI_DATABASE }}
 sql: SELECT * FROM {{ASPECTS_XAPI_DATABASE}}.xapi_events_all_parsed
 table_name: xapi_events_all_parsed
 template_params: null

--- a/tutoraspects/templates/aspects/build/aspects-superset/openedx-assets/assets/datasets/xapi_events_all_parsed.yaml
+++ b/tutoraspects/templates/aspects/build/aspects-superset/openedx-assets/assets/datasets/xapi_events_all_parsed.yaml
@@ -183,7 +183,7 @@ metrics:
 normalize_columns: true
 offset: 0
 params: null
-schema: {{ ASPECTS_XAPI_DATABASE }}
+schema: '{{ ASPECTS_XAPI_DATABASE }}'
 sql: SELECT * FROM {{ASPECTS_XAPI_DATABASE}}.xapi_events_all_parsed
 table_name: xapi_events_all_parsed
 template_params: null

--- a/tutoraspects/templates/aspects/jobs/init/superset/init-superset.sh
+++ b/tutoraspects/templates/aspects/jobs/init/superset/init-superset.sh
@@ -76,10 +76,3 @@ echo_step "4" "Starting" "Importing assets"
 bash /app/scripts/import-assets.sh
 
 echo_step "4" "Complete" "Importing assets"
-
-# Set up a Row-Level Security filter to enforce course-based access restrictions.
-# Note: there are no cli commands or REST API endpoints to help us with this,
-# so we have to pipe python code directly into the superset shell. Yuck!
-echo_step "5" "Starting" "Setup row level security filters"
-python /app/pythonpath/create_row_level_security.py
-echo_step "5" "Complete" "Setup row level security filters"

--- a/tutoraspects/templates/openedx-assets/queries/indexed_events.sql
+++ b/tutoraspects/templates/openedx-assets/queries/indexed_events.sql
@@ -22,6 +22,6 @@ SELECT
   emission_time
 FROM events
 JOIN
-   event_sink.course_names courses
+   {{ ASPECTS_EVENT_SINK_DATABASE }}.course_names courses
 ON
   (events.course_key = courses.course_key)


### PR DESCRIPTION
### Description

This PR:

- Imports the new course dashboard V1.
- Update the dataset schema from 'main' to their corresponding variable.
- Corrects the `from_dttm` template for a dataset.
- Serialize the assets from the operator dashboard.
- Sets the colors for all the dashboards
- Automatically creates an RLSF for the instructor role for all existing datasets.