### PR TITLE
feat: add chart for full and partial video views (FC-0051)

### DIFF
--- a/tutoraspects/templates/aspects/build/aspects-superset/openedx-assets/assets/charts/Partial_and_full_views_per_video.yaml
+++ b/tutoraspects/templates/aspects/build/aspects-superset/openedx-assets/assets/charts/Partial_and_full_views_per_video.yaml
@@ -1,0 +1,72 @@
+_file_name: Partial_and_full_views_per_video.yaml
+cache_timeout: null
+certification_details: null
+certified_by: null
+dataset_uuid: d0070c9a-5b1c-4e52-867b-79aa46a8cdcf
+description: null
+params:
+  adhoc_filters: []
+  annotation_layers: []
+  color_scheme: supersetColors
+  comparison_type: values
+  extra_form_data: {}
+  forecastInterval: 0.8
+  forecastPeriods: 10
+  groupby: []
+  legendOrientation: top
+  legendType: scroll
+  metrics:
+  - aggregate: null
+    column: null
+    datasourceWarning: false
+    expressionType: SQL
+    hasCustomLabel: true
+    label: Full view
+    optionName: metric_9xymoehul6n_han197f2mfn
+    sqlExpression: countIf(watched_entire_video)
+  - aggregate: null
+    column: null
+    datasourceWarning: false
+    expressionType: SQL
+    hasCustomLabel: true
+    label: Partial view
+    optionName: metric_19eyr91cqyh_xj9dhjmv0qr
+    sqlExpression: countIf(not(watched_entire_video))
+  only_total: true
+  order_desc: true
+  orientation: vertical
+  rich_tooltip: true
+  row_limit: 10000
+  show_empty_columns: true
+  show_legend: true
+  sort_series_type: sum
+  time_grain_sqla: P1D
+  tooltipTimeFormat: smart_date
+  truncate_metric: true
+  viz_type: echarts_timeseries_bar
+  xAxisLabelRotation: 45
+  x_axis: video_name_with_location
+  x_axis_sort_asc: true
+  x_axis_sort_series: name
+  x_axis_sort_series_ascending: true
+  x_axis_time_format: smart_date
+  x_axis_title_margin: '0'
+  y_axis_bounds:
+  - null
+  - null
+  y_axis_format: SMART_NUMBER
+  y_axis_title: Number of learners
+  y_axis_title_margin: 30
+  y_axis_title_position: Left
+query_context: '{"datasource":{"id":557,"type":"table"},"force":false,"queries":[{"filters":[],"extras":{"having":"","where":""},"applied_time_extras":{},"columns":[{"timeGrain":"P1D","columnType":"BASE_AXIS","sqlExpression":"video_name_with_location","label":"video_name_with_location","expressionType":"SQL"}],"metrics":[{"aggregate":null,"column":null,"datasourceWarning":false,"expressionType":"SQL","hasCustomLabel":true,"label":"Full
+  view","optionName":"metric_9xymoehul6n_han197f2mfn","sqlExpression":"countIf(watched_entire_video)"},{"aggregate":null,"column":null,"datasourceWarning":false,"expressionType":"SQL","hasCustomLabel":true,"label":"Partial
+  view","optionName":"metric_19eyr91cqyh_xj9dhjmv0qr","sqlExpression":"countIf(not(watched_entire_video))"}],"orderby":[[{"aggregate":null,"column":null,"datasourceWarning":false,"expressionType":"SQL","hasCustomLabel":true,"label":"Full
+  view","optionName":"metric_9xymoehul6n_han197f2mfn","sqlExpression":"countIf(watched_entire_video)"},false]],"annotation_layers":[],"row_limit":10000,"series_columns":[],"series_limit":0,"order_desc":true,"url_params":{},"custom_params":{},"custom_form_data":{},"time_offsets":[],"post_processing":[{"operation":"pivot","options":{"index":["video_name_with_location"],"columns":[],"aggregates":{"Full
+  view":{"operator":"mean"},"Partial view":{"operator":"mean"}},"drop_missing_columns":false}},{"operation":"flatten"}]}],"form_data":{"datasource":"557__table","viz_type":"echarts_timeseries_bar","slice_id":921,"x_axis":"video_name_with_location","time_grain_sqla":"P1D","x_axis_sort_asc":true,"x_axis_sort_series":"name","x_axis_sort_series_ascending":true,"metrics":[{"aggregate":null,"column":null,"datasourceWarning":false,"expressionType":"SQL","hasCustomLabel":true,"label":"Full
+  view","optionName":"metric_9xymoehul6n_han197f2mfn","sqlExpression":"countIf(watched_entire_video)"},{"aggregate":null,"column":null,"datasourceWarning":false,"expressionType":"SQL","hasCustomLabel":true,"label":"Partial
+  view","optionName":"metric_19eyr91cqyh_xj9dhjmv0qr","sqlExpression":"countIf(not(watched_entire_video))"}],"groupby":[],"adhoc_filters":[],"order_desc":true,"row_limit":10000,"truncate_metric":true,"show_empty_columns":true,"comparison_type":"values","annotation_layers":[],"forecastPeriods":10,"forecastInterval":0.8,"orientation":"vertical","x_axis_title_margin":"0","y_axis_title":"Number
+  of learners","y_axis_title_margin":30,"y_axis_title_position":"Left","sort_series_type":"sum","color_scheme":"supersetColors","only_total":true,"show_legend":true,"legendType":"scroll","legendOrientation":"top","x_axis_time_format":"smart_date","xAxisLabelRotation":45,"y_axis_format":"SMART_NUMBER","y_axis_bounds":[null,null],"rich_tooltip":true,"tooltipTimeFormat":"smart_date","extra_form_data":{},"dashboards":[2042],"force":false,"result_format":"json","result_type":"full"},"result_format":"json","result_type":"full"}'
+slice_name: Partial and full views per video
+uuid: 5052449a-424c-41bf-b8b0-d920424c4784
+version: 1.0.0
+viz_type: echarts_timeseries_bar

--- a/tutoraspects/templates/aspects/build/aspects-superset/openedx-assets/assets/dashboards/Instructor_Dashboard.yaml
+++ b/tutoraspects/templates/aspects/build/aspects-superset/openedx-assets/assets/dashboards/Instructor_Dashboard.yaml
@@ -25,6 +25,7 @@ metadata:
         - 783
         - 816
         - 901
+        - 921
         scope: global
       id: 114
     '156':
@@ -46,6 +47,7 @@ metadata:
         - 783
         - 816
         - 901
+        - 921
         scope: global
       id: 156
     '325':
@@ -67,6 +69,7 @@ metadata:
         - 783
         - 816
         - 901
+        - 921
         scope: global
       id: 325
     '816':
@@ -88,6 +91,7 @@ metadata:
         - 770
         - 783
         - 901
+        - 921
         scope: global
       id: 816
     '901':
@@ -109,8 +113,31 @@ metadata:
         - 770
         - 783
         - 816
+        - 921
         scope: global
       id: 901
+    '921':
+      crossFilters:
+        chartsInScope:
+        - 114
+        - 154
+        - 156
+        - 229
+        - 325
+        - 327
+        - 339
+        - 516
+        - 597
+        - 625
+        - 682
+        - 695
+        - 701
+        - 770
+        - 783
+        - 816
+        - 901
+        scope: global
+      id: 921
   color_scheme: ''
   color_scheme_domain: []
   cross_filters_enabled: false
@@ -135,6 +162,7 @@ metadata:
     - 783
     - 816
     - 901
+    - 921
     scope:
       excluded: []
       rootPath:
@@ -380,8 +408,12 @@ metadata:
     type: NATIVE_FILTER
   refresh_frequency: 0
   shared_label_colors:
-    audit: '#454E7C'
-    registered: '#1FA8C9'
+    All videos viewed: '#E04355'
+    At least one video viewed: '#3CCCCB'
+    Full view: '#A868B7'
+    Partial view: '#8FD3E4'
+    Total plays: '#FF7F44'
+    Unique Watchers: '#FCC700'
   timed_refresh_immune_slices: []
 position:
   CHART-AZZnl_lpMv:
@@ -504,6 +536,21 @@ position:
     - TAB-NR4UTAs9K
     - ROW-GWTTmZ2jDJ
     type: CHART
+  CHART-VwIFwB80km:
+    children: []
+    id: CHART-VwIFwB80km
+    meta:
+      chartId: 921
+      height: 64
+      sliceName: Partial and full views per video
+      uuid: 5052449a-424c-41bf-b8b0-d920424c4784
+      width: 12
+    parents:
+    - ROOT_ID
+    - TABS-SNeKAJcjhd
+    - TAB-7PGDduCA7
+    - ROW-lnHZ40DjeR
+    type: CHART
   CHART-evjVO-ZSSd:
     children: []
     id: CHART-evjVO-ZSSd
@@ -539,7 +586,7 @@ position:
     id: CHART-jfm-20qPKn
     meta:
       chartId: 816
-      height: 50
+      height: 55
       sliceName: Video engagement by section/subsection
       uuid: 21861f47-9e8b-4715-b1ff-e7f4aa595c14
       width: 12
@@ -925,6 +972,17 @@ position:
     - TABS-SNeKAJcjhd
     - TAB-eE0OQxuju
     type: ROW
+  ROW-lnHZ40DjeR:
+    children:
+    - CHART-VwIFwB80km
+    id: ROW-lnHZ40DjeR
+    meta:
+      background: BACKGROUND_TRANSPARENT
+    parents:
+    - ROOT_ID
+    - TABS-SNeKAJcjhd
+    - TAB-7PGDduCA7
+    type: ROW
   ROW-nNEywSG0jX:
     children:
     - MARKDOWN-NaNsE4EBKf
@@ -964,6 +1022,7 @@ position:
     - ROW-nNEywSG0jX
     - ROW-BO2IHCiYF8
     - ROW-HPGIhOIs65
+    - ROW-lnHZ40DjeR
     id: TAB-7PGDduCA7
     meta:
       defaultText: Tab title

--- a/tutoraspects/templates/aspects/build/aspects-superset/openedx-assets/assets/datasets/fact_video_watches.yaml
+++ b/tutoraspects/templates/aspects/build/aspects-superset/openedx-assets/assets/datasets/fact_video_watches.yaml
@@ -1,0 +1,157 @@
+_file_name: fact_video_watches.yaml
+cache_timeout: null
+columns:
+- advanced_data_type: null
+  column_name: video_name_with_location
+  description: null
+  expression: null
+  extra: {}
+  filterable: true
+  groupby: true
+  is_active: true
+  is_dttm: false
+  python_date_format: null
+  type: String
+  verbose_name: Video Name With Location
+- advanced_data_type: null
+  column_name: watched_segment_count
+  description: null
+  expression: null
+  extra: {}
+  filterable: true
+  groupby: true
+  is_active: true
+  is_dttm: false
+  python_date_format: null
+  type: Int32
+  verbose_name: Watched Segment Count
+- advanced_data_type: null
+  column_name: watched_entire_video
+  description: null
+  expression: null
+  extra: {}
+  filterable: true
+  groupby: true
+  is_active: true
+  is_dttm: false
+  python_date_format: null
+  type: Boolean
+  verbose_name: Watched Entire Video
+- advanced_data_type: null
+  column_name: actor_id
+  description: null
+  expression: null
+  extra: {}
+  filterable: true
+  groupby: true
+  is_active: true
+  is_dttm: false
+  python_date_format: null
+  type: String
+  verbose_name: Actor ID
+- advanced_data_type: null
+  column_name: course_key
+  description: null
+  expression: null
+  extra: {}
+  filterable: true
+  groupby: true
+  is_active: true
+  is_dttm: false
+  python_date_format: null
+  type: String
+  verbose_name: Course Key
+- advanced_data_type: null
+  column_name: course_name
+  description: null
+  expression: null
+  extra: {}
+  filterable: true
+  groupby: true
+  is_active: true
+  is_dttm: false
+  python_date_format: null
+  type: String
+  verbose_name: Course Name
+- advanced_data_type: null
+  column_name: course_run
+  description: null
+  expression: null
+  extra: {}
+  filterable: true
+  groupby: true
+  is_active: true
+  is_dttm: false
+  python_date_format: null
+  type: String
+  verbose_name: Course Run
+- advanced_data_type: null
+  column_name: video_name
+  description: null
+  expression: null
+  extra: {}
+  filterable: true
+  groupby: true
+  is_active: true
+  is_dttm: false
+  python_date_format: null
+  type: String
+  verbose_name: Video Name
+- advanced_data_type: null
+  column_name: org
+  description: null
+  expression: null
+  extra: {}
+  filterable: true
+  groupby: true
+  is_active: true
+  is_dttm: false
+  python_date_format: null
+  type: String
+  verbose_name: Organization
+database_uuid: 21174b6c-4d40-4958-8161-d6c3cf5e77b6
+default_endpoint: null
+description: null
+extra: {}
+fetch_values_predicate: null
+filter_select_enabled: false
+main_dttm_col: null
+metrics:
+- currency: null
+  d3format: null
+  description: null
+  expression: count(*) - count(distinct actor_id)
+  extra: {}
+  metric_name: repeat_views
+  metric_type: null
+  verbose_name: Repeat Views
+  warning_text: null
+- currency: null
+  d3format: null
+  description: null
+  expression: count(*)
+  extra:
+    warning_markdown: ''
+  metric_name: count
+  metric_type: null
+  verbose_name: Total Views
+  warning_text: null
+- currency: null
+  d3format: null
+  description: null
+  expression: count(distinct actor_id)
+  extra: {}
+  metric_name: unique_viewers
+  metric_type: null
+  verbose_name: Unique Viewers
+  warning_text: null
+normalize_columns: true
+offset: 0
+params: null
+schema: main
+sql: |-
+  {% filter indent(width=2) %}{% include 'openedx-assets/queries/fact_video_watches.sql' %}{% endfilter %}
+table_name: fact_video_watches
+template_params: null
+uuid: d0070c9a-5b1c-4e52-867b-79aa46a8cdcf
+version: 1.0.0

--- a/tutoraspects/templates/openedx-assets/queries/fact_video_watches.sql
+++ b/tutoraspects/templates/openedx-assets/queries/fact_video_watches.sql
@@ -1,0 +1,25 @@
+with watched_segments as (
+    {% include 'openedx-assets/queries/fact_watched_video_segments.sql' %}
+)
+
+select
+    org,
+    course_key,
+    course_name,
+    course_run,
+    video_name,
+    video_name_with_location,
+    actor_id,
+    count(distinct segment_start) as watched_segment_count,
+    (video_duration - 10) / 5 as video_segment_count,
+    video_segment_count <= watched_segment_count as watched_entire_video
+from watched_segments
+group by
+    org,
+    course_key,
+    course_name,
+    course_run,
+    video_name,
+    video_name_with_location,
+    actor_id,
+    video_segment_count


### PR DESCRIPTION
This adds a chart to show the number of full and partial views of course videos. This builds on the watched video segments query and compares the number of segments viewed by a learner to the expected number of segments in the video. The number of segments is calculated by first taking ten seconds off the video duration and then calculating the number of segments based on that shortened duration. This is to account for learners who, say, watch the entire video but skip the end credits.

Here is a screenshot of the chart:
![Screenshot from 2024-04-08 10-39-30](https://github.com/openedx/tutor-contrib-aspects/assets/2566242/95fa28aa-8305-4527-861b-fd94813890bc)
