### PR TITLE
fix: deletes openedx-dev-dockerfile-post-python-requirements

### DIFF
--- a/tutoraspects/patches/openedx-dev-dockerfile-post-python-requirements
+++ b/tutoraspects/patches/openedx-dev-dockerfile-post-python-requirements
@@ -1,4 +1,0 @@
-RUN --mount=type=cache,target=/openedx/.cache/pip,sharing=shared \
-    pip install "platform-plugin-aspects==v0.6.0"
-RUN --mount=type=cache,target=/openedx/.cache/pip,sharing=shared \
-    pip install "edx-event-routing-backends==v9.0.0"


### PR DESCRIPTION
The `openedx-dockerfile-post-python-requirements` patch is sufficient to get these requirements installed on the openedx or openedx-dev image.

Having them duplicated in `openedx-dev-dockerfile-post-python-requirements` causes these requirements to be installed twice, and when the dev version applies at the end of the `tutor images build openedx-dev` process, it overwrites any mounted dependencies, making dev impossible.