### PR TITLE
fix: use correct datasets for engagement charts (FC-0051)

### DIFF
--- a/tutoraspects/templates/aspects/build/aspects-superset/openedx-assets/assets/charts/Page_views_per_section_subsection.yaml
+++ b/tutoraspects/templates/aspects/build/aspects-superset/openedx-assets/assets/charts/Page_views_per_section_subsection.yaml
@@ -2,7 +2,7 @@ _file_name: Page_views_per_section_subsection.yaml
 cache_timeout: null
 certification_details: null
 certified_by: null
-dataset_uuid: 1c443466-300e-4f01-a690-3d9d1b934d9a
+dataset_uuid: 9febd6be-5102-4dbf-86b9-45ebd3cbbc45
 description: null
 params:
   adhoc_filters:
@@ -10,7 +10,7 @@ params:
     comparator: No filter
     expressionType: SIMPLE
     operator: TEMPORAL_RANGE
-    subject: emission_time
+    subject: visited_on
   annotation_layers: []
   color_scheme: supersetColors
   comparison_type: values
@@ -28,7 +28,8 @@ params:
     hasCustomLabel: true
     label: All pages viewed
     optionName: metric_79weo5uoij_22vrzytsx8v
-    sqlExpression: rand() % 10
+    sqlExpression: |-
+      countIf("section/subsection page engagement" = 'All pages viewed')
   - aggregate: null
     column: null
     datasourceWarning: false
@@ -36,7 +37,8 @@ params:
     hasCustomLabel: true
     label: At least one page viewed
     optionName: metric_oijxyr99vkc_bvobo3jivn
-    sqlExpression: rand() % 20
+    sqlExpression: |-
+      countIf("section/subsection page engagement" = 'At least one page viewed' or "section/subsection page engagement" = 'All pages viewed')
   only_total: true
   order_desc: true
   orientation: vertical
@@ -47,13 +49,11 @@ params:
   sort_series_type: sum
   time_grain_sqla: P1M
   tooltipTimeFormat: smart_date
+  truncateXAxis: true
   truncate_metric: true
   viz_type: echarts_timeseries_bar
   xAxisLabelRotation: 45
-  x_axis:
-    expressionType: SQL
-    label: section_with_name
-    sqlExpression: block_name_with_location
+  x_axis: section/subsection name
   x_axis_sort_asc: true
   x_axis_sort_series: name
   x_axis_sort_series_ascending: true
@@ -67,21 +67,9 @@ params:
   y_axis_title_margin: 30
   y_axis_title_position: Left
   zoomable: true
-query_context: '{"datasource":{"id":69,"type":"table"},"force":false,"queries":[{"filters":[{"col":"emission_time","op":"TEMPORAL_RANGE","val":"No
-  filter"}],"extras":{"having":"","where":""},"applied_time_extras":{},"columns":[{"timeGrain":"P1M","columnType":"BASE_AXIS","label":"section_with_name","sqlExpression":"block_name_with_location","expressionType":"SQL"}],"metrics":[{"aggregate":null,"column":null,"datasourceWarning":false,"expressionType":"SQL","hasCustomLabel":true,"label":"All
-  pages viewed","optionName":"metric_79weo5uoij_22vrzytsx8v","sqlExpression":"rand()
-  % 10"},{"aggregate":null,"column":null,"datasourceWarning":false,"expressionType":"SQL","hasCustomLabel":true,"label":"At
-  least one page viewed","optionName":"metric_oijxyr99vkc_bvobo3jivn","sqlExpression":"rand()
-  % 20"}],"orderby":[[{"aggregate":null,"column":null,"datasourceWarning":false,"expressionType":"SQL","hasCustomLabel":true,"label":"All
-  pages viewed","optionName":"metric_79weo5uoij_22vrzytsx8v","sqlExpression":"rand()
-  % 10"},false]],"annotation_layers":[],"row_limit":10000,"series_columns":[],"series_limit":0,"order_desc":true,"url_params":{},"custom_params":{},"custom_form_data":{},"time_offsets":[],"post_processing":[{"operation":"pivot","options":{"index":["section_with_name"],"columns":[],"aggregates":{"All
-  pages viewed":{"operator":"mean"},"At least one page viewed":{"operator":"mean"}},"drop_missing_columns":false}},{"operation":"flatten"}]}],"form_data":{"datasource":"69__table","viz_type":"echarts_timeseries_bar","slice_id":201,"x_axis":{"label":"section_with_name","sqlExpression":"block_name_with_location","expressionType":"SQL"},"time_grain_sqla":"P1M","x_axis_sort_asc":true,"x_axis_sort_series":"name","x_axis_sort_series_ascending":true,"metrics":[{"aggregate":null,"column":null,"datasourceWarning":false,"expressionType":"SQL","hasCustomLabel":true,"label":"All
-  pages viewed","optionName":"metric_79weo5uoij_22vrzytsx8v","sqlExpression":"rand()
-  % 10"},{"aggregate":null,"column":null,"datasourceWarning":false,"expressionType":"SQL","hasCustomLabel":true,"label":"At
-  least one page viewed","optionName":"metric_oijxyr99vkc_bvobo3jivn","sqlExpression":"rand()
-  % 20"}],"groupby":[],"adhoc_filters":[{"clause":"WHERE","comparator":"No filter","expressionType":"SIMPLE","operator":"TEMPORAL_RANGE","subject":"emission_time"}],"order_desc":true,"row_limit":10000,"truncate_metric":true,"show_empty_columns":true,"comparison_type":"values","annotation_layers":[],"forecastPeriods":10,"forecastInterval":0.8,"orientation":"vertical","x_axis_title_margin":15,"y_axis_title":"Number
-  of learners","y_axis_title_margin":30,"y_axis_title_position":"Left","sort_series_type":"sum","color_scheme":"supersetColors","only_total":true,"zoomable":true,"show_legend":true,"legendType":"scroll","legendOrientation":"top","x_axis_time_format":"smart_date","xAxisLabelRotation":45,"y_axis_format":"SMART_NUMBER","y_axis_bounds":[null,null],"rich_tooltip":true,"tooltipTimeFormat":"smart_date","extra_form_data":{},"dashboards":[16],"force":false,"result_format":"json","result_type":"full"},"result_format":"json","result_type":"full"}'
+query_context: |-
+  {"datasource":{"id":193,"type":"table"},"force":false,"queries":[{"filters":[{"col":"visited_on","op":"TEMPORAL_RANGE","val":"No filter"}],"extras":{"time_grain_sqla":"P1M","having":"","where":""},"applied_time_extras":{},"columns":[{"timeGrain":"P1M","columnType":"BASE_AXIS","sqlExpression":"section/subsection name","label":"section/subsection name","expressionType":"SQL"}],"metrics":[{"expressionType":"SQL","sqlExpression":"countIf(\"section/subsection page engagement\" = 'All pages viewed')","column":null,"aggregate":null,"datasourceWarning":false,"hasCustomLabel":true,"label":"All pages viewed","optionName":"metric_79weo5uoij_22vrzytsx8v"},{"expressionType":"SQL","sqlExpression":"countIf(\"section/subsection page engagement\" = 'At least one page viewed' or \"section/subsection page engagement\" = 'All pages viewed')","column":null,"aggregate":null,"datasourceWarning":false,"hasCustomLabel":true,"label":"At least one page viewed","optionName":"metric_oijxyr99vkc_bvobo3jivn"}],"orderby":[[{"expressionType":"SQL","sqlExpression":"countIf(\"section/subsection page engagement\" = 'All pages viewed')","column":null,"aggregate":null,"datasourceWarning":false,"hasCustomLabel":true,"label":"All pages viewed","optionName":"metric_79weo5uoij_22vrzytsx8v"},false]],"annotation_layers":[],"row_limit":10000,"series_columns":[],"series_limit":0,"order_desc":true,"url_params":{},"custom_params":{},"custom_form_data":{},"time_offsets":[],"post_processing":[{"operation":"pivot","options":{"index":["section/subsection name"],"columns":[],"aggregates":{"All pages viewed":{"operator":"mean"},"At least one page viewed":{"operator":"mean"}},"drop_missing_columns":false}},{"operation":"flatten"}]}],"form_data":{"datasource":"193__table","viz_type":"echarts_timeseries_bar","slice_id":1627,"x_axis":"section/subsection name","time_grain_sqla":"P1M","x_axis_sort_asc":true,"x_axis_sort_series":"name","x_axis_sort_series_ascending":true,"metrics":[{"expressionType":"SQL","sqlExpression":"countIf(\"section/subsection page engagement\" = 'All pages viewed')","column":null,"aggregate":null,"datasourceWarning":false,"hasCustomLabel":true,"label":"All pages viewed","optionName":"metric_79weo5uoij_22vrzytsx8v"},{"expressionType":"SQL","sqlExpression":"countIf(\"section/subsection page engagement\" = 'At least one page viewed' or \"section/subsection page engagement\" = 'All pages viewed')","column":null,"aggregate":null,"datasourceWarning":false,"hasCustomLabel":true,"label":"At least one page viewed","optionName":"metric_oijxyr99vkc_bvobo3jivn"}],"groupby":[],"adhoc_filters":[{"clause":"WHERE","subject":"visited_on","operator":"TEMPORAL_RANGE","comparator":"No filter","expressionType":"SIMPLE"}],"order_desc":true,"row_limit":10000,"truncate_metric":true,"show_empty_columns":true,"comparison_type":"values","annotation_layers":[],"forecastPeriods":10,"forecastInterval":0.8,"orientation":"vertical","x_axis_title_margin":15,"y_axis_title":"Number of learners","y_axis_title_margin":30,"y_axis_title_position":"Left","sort_series_type":"sum","color_scheme":"supersetColors","only_total":true,"zoomable":true,"show_legend":true,"legendType":"scroll","legendOrientation":"top","x_axis_time_format":"smart_date","xAxisLabelRotation":45,"y_axis_format":"SMART_NUMBER","truncateXAxis":true,"y_axis_bounds":[null,null],"rich_tooltip":true,"tooltipTimeFormat":"smart_date","extra_form_data":{},"dashboards":[2249],"force":false,"result_format":"json","result_type":"full"},"result_format":"json","result_type":"full"}
 slice_name: Page views per section/subsection
-uuid: 0538470d-0328-4f15-9e48-ffc9e84c4c06
+uuid: bf2d6219-d633-48c1-a9b5-742eac6a4c0a
 version: 1.0.0
 viz_type: echarts_timeseries_bar

--- a/tutoraspects/templates/aspects/build/aspects-superset/openedx-assets/assets/charts/Problems_attempted_per_section_subsection.yaml
+++ b/tutoraspects/templates/aspects/build/aspects-superset/openedx-assets/assets/charts/Problems_attempted_per_section_subsection.yaml
@@ -2,15 +2,10 @@ _file_name: Problems_attempted_per_section_subsection.yaml
 cache_timeout: null
 certification_details: null
 certified_by: null
-dataset_uuid: 1c443466-300e-4f01-a690-3d9d1b934d9a
+dataset_uuid: 171c88e5-fd4b-4aab-b287-361fa6fa5415
 description: null
 params:
-  adhoc_filters:
-  - clause: WHERE
-    comparator: No filter
-    expressionType: SIMPLE
-    operator: TEMPORAL_RANGE
-    subject: emission_time
+  adhoc_filters: []
   annotation_layers: []
   color_scheme: supersetColors
   comparison_type: values
@@ -28,7 +23,8 @@ params:
     hasCustomLabel: true
     label: Attempted at least one problem
     optionName: metric_0gasd9pjc5y_44f8wzc1g3q
-    sqlExpression: rand() % 20
+    sqlExpression: |-
+      countIf("section/subsection problem engagement" = 'At least one problem attempted' or "section/subsection problem engagement" = 'All problems attempted')
   - aggregate: null
     column: null
     datasourceWarning: false
@@ -36,7 +32,8 @@ params:
     hasCustomLabel: true
     label: Attempted all problems
     optionName: metric_6ibge21tuod_k3hhlneae8f
-    sqlExpression: rand() % 10
+    sqlExpression: |-
+      countIf("section/subsection problem engagement" = 'All problems attempted')
   only_total: true
   order_desc: true
   orientation: vertical
@@ -47,10 +44,11 @@ params:
   sort_series_type: sum
   time_grain_sqla: P1M
   tooltipTimeFormat: smart_date
+  truncateXAxis: true
   truncate_metric: true
   viz_type: echarts_timeseries_bar
   xAxisLabelRotation: 45
-  x_axis: block_name_with_location
+  x_axis: section/subsection name
   x_axis_sort_asc: true
   x_axis_sort_series: name
   x_axis_sort_series_ascending: true
@@ -64,21 +62,9 @@ params:
   y_axis_title_margin: 30
   y_axis_title_position: Left
   zoomable: true
-query_context: '{"datasource":{"id":69,"type":"table"},"force":false,"queries":[{"filters":[{"col":"emission_time","op":"TEMPORAL_RANGE","val":"No
-  filter"}],"extras":{"having":"","where":""},"applied_time_extras":{},"columns":[{"timeGrain":"P1M","columnType":"BASE_AXIS","sqlExpression":"block_name_with_location","label":"block_name_with_location","expressionType":"SQL"}],"metrics":[{"aggregate":null,"column":null,"datasourceWarning":false,"expressionType":"SQL","hasCustomLabel":true,"label":"Attempted
-  at least one problem","optionName":"metric_0gasd9pjc5y_44f8wzc1g3q","sqlExpression":"rand()
-  % 20"},{"aggregate":null,"column":null,"datasourceWarning":false,"expressionType":"SQL","hasCustomLabel":true,"label":"Attempted
-  all problems","optionName":"metric_6ibge21tuod_k3hhlneae8f","sqlExpression":"rand()
-  % 10"}],"orderby":[[{"aggregate":null,"column":null,"datasourceWarning":false,"expressionType":"SQL","hasCustomLabel":true,"label":"Attempted
-  at least one problem","optionName":"metric_0gasd9pjc5y_44f8wzc1g3q","sqlExpression":"rand()
-  % 20"},false]],"annotation_layers":[],"row_limit":10000,"series_columns":[],"series_limit":0,"order_desc":true,"url_params":{},"custom_params":{},"custom_form_data":{},"time_offsets":[],"post_processing":[{"operation":"pivot","options":{"index":["block_name_with_location"],"columns":[],"aggregates":{"Attempted
-  at least one problem":{"operator":"mean"},"Attempted all problems":{"operator":"mean"}},"drop_missing_columns":false}},{"operation":"flatten"}]}],"form_data":{"datasource":"69__table","viz_type":"echarts_timeseries_bar","slice_id":202,"x_axis":"block_name_with_location","time_grain_sqla":"P1M","x_axis_sort_asc":true,"x_axis_sort_series":"name","x_axis_sort_series_ascending":true,"metrics":[{"aggregate":null,"column":null,"datasourceWarning":false,"expressionType":"SQL","hasCustomLabel":true,"label":"Attempted
-  at least one problem","optionName":"metric_0gasd9pjc5y_44f8wzc1g3q","sqlExpression":"rand()
-  % 20"},{"aggregate":null,"column":null,"datasourceWarning":false,"expressionType":"SQL","hasCustomLabel":true,"label":"Attempted
-  all problems","optionName":"metric_6ibge21tuod_k3hhlneae8f","sqlExpression":"rand()
-  % 10"}],"groupby":[],"adhoc_filters":[{"clause":"WHERE","comparator":"No filter","expressionType":"SIMPLE","operator":"TEMPORAL_RANGE","subject":"emission_time"}],"order_desc":true,"row_limit":10000,"truncate_metric":true,"show_empty_columns":true,"comparison_type":"values","annotation_layers":[],"forecastPeriods":10,"forecastInterval":0.8,"orientation":"vertical","x_axis_title_margin":15,"y_axis_title":"Number
-  of learners","y_axis_title_margin":30,"y_axis_title_position":"Left","sort_series_type":"sum","color_scheme":"supersetColors","only_total":true,"zoomable":true,"show_legend":true,"legendType":"scroll","legendOrientation":"top","x_axis_time_format":"smart_date","xAxisLabelRotation":45,"y_axis_format":"SMART_NUMBER","y_axis_bounds":[null,null],"rich_tooltip":true,"tooltipTimeFormat":"smart_date","extra_form_data":{},"dashboards":[16],"force":false,"result_format":"json","result_type":"full"},"result_format":"json","result_type":"full"}'
+query_context: |-
+  {"datasource":{"id":537,"type":"table"},"force":false,"queries":[{"filters":[],"extras":{"time_grain_sqla":"P1M","having":"","where":""},"applied_time_extras":{},"columns":[{"timeGrain":"P1M","columnType":"BASE_AXIS","sqlExpression":"section/subsection name","label":"section/subsection name","expressionType":"SQL"}],"metrics":[{"expressionType":"SQL","sqlExpression":"countIf(\"section/subsection problem engagement\" = 'At least one problem attempted' or \"section/subsection problem engagement\" = 'All problems attempted')","column":null,"aggregate":null,"datasourceWarning":false,"hasCustomLabel":true,"label":"Attempted at least one problem","optionName":"metric_0gasd9pjc5y_44f8wzc1g3q"},{"expressionType":"SQL","sqlExpression":"countIf(\"section/subsection problem engagement\" = 'All problems attempted')","column":null,"aggregate":null,"datasourceWarning":false,"hasCustomLabel":true,"label":"Attempted all problems","optionName":"metric_6ibge21tuod_k3hhlneae8f"}],"orderby":[[{"expressionType":"SQL","sqlExpression":"countIf(\"section/subsection problem engagement\" = 'At least one problem attempted' or \"section/subsection problem engagement\" = 'All problems attempted')","column":null,"aggregate":null,"datasourceWarning":false,"hasCustomLabel":true,"label":"Attempted at least one problem","optionName":"metric_0gasd9pjc5y_44f8wzc1g3q"},false]],"annotation_layers":[],"row_limit":10000,"series_columns":[],"series_limit":0,"order_desc":true,"url_params":{},"custom_params":{},"custom_form_data":{},"time_offsets":[],"post_processing":[{"operation":"pivot","options":{"index":["section/subsection name"],"columns":[],"aggregates":{"Attempted at least one problem":{"operator":"mean"},"Attempted all problems":{"operator":"mean"}},"drop_missing_columns":false}},{"operation":"flatten"}]}],"form_data":{"datasource":"537__table","viz_type":"echarts_timeseries_bar","slice_id":1790,"x_axis":"section/subsection name","time_grain_sqla":"P1M","x_axis_sort_asc":true,"x_axis_sort_series":"name","x_axis_sort_series_ascending":true,"metrics":[{"expressionType":"SQL","sqlExpression":"countIf(\"section/subsection problem engagement\" = 'At least one problem attempted' or \"section/subsection problem engagement\" = 'All problems attempted')","column":null,"aggregate":null,"datasourceWarning":false,"hasCustomLabel":true,"label":"Attempted at least one problem","optionName":"metric_0gasd9pjc5y_44f8wzc1g3q"},{"expressionType":"SQL","sqlExpression":"countIf(\"section/subsection problem engagement\" = 'All problems attempted')","column":null,"aggregate":null,"datasourceWarning":false,"hasCustomLabel":true,"label":"Attempted all problems","optionName":"metric_6ibge21tuod_k3hhlneae8f"}],"groupby":[],"adhoc_filters":[],"order_desc":true,"row_limit":10000,"truncate_metric":true,"show_empty_columns":true,"comparison_type":"values","annotation_layers":[],"forecastPeriods":10,"forecastInterval":0.8,"orientation":"vertical","x_axis_title_margin":15,"y_axis_title":"Number of learners","y_axis_title_margin":30,"y_axis_title_position":"Left","sort_series_type":"sum","color_scheme":"supersetColors","only_total":true,"zoomable":true,"show_legend":true,"legendType":"scroll","legendOrientation":"top","x_axis_time_format":"smart_date","xAxisLabelRotation":45,"y_axis_format":"SMART_NUMBER","truncateXAxis":true,"y_axis_bounds":[null,null],"rich_tooltip":true,"tooltipTimeFormat":"smart_date","extra_form_data":{},"dashboards":[2329],"force":false,"result_format":"json","result_type":"full"},"result_format":"json","result_type":"full"}
 slice_name: Problems attempted per section/subsection
-uuid: 869edaf6-f911-4ca7-9e4b-28435bba2e82
+uuid: 8cdcd4aa-1fa2-41dc-b38d-f1112134592e
 version: 1.0.0
 viz_type: echarts_timeseries_bar

--- a/tutoraspects/templates/aspects/build/aspects-superset/openedx-assets/assets/charts/Video_views_per_section_subsection.yaml
+++ b/tutoraspects/templates/aspects/build/aspects-superset/openedx-assets/assets/charts/Video_views_per_section_subsection.yaml
@@ -2,15 +2,10 @@ _file_name: Video_views_per_section_subsection.yaml
 cache_timeout: null
 certification_details: null
 certified_by: null
-dataset_uuid: 1c443466-300e-4f01-a690-3d9d1b934d9a
+dataset_uuid: 247a55b3-d44e-442e-ba92-71bf7976b192
 description: null
 params:
-  adhoc_filters:
-  - clause: WHERE
-    comparator: No filter
-    expressionType: SIMPLE
-    operator: TEMPORAL_RANGE
-    subject: emission_time
+  adhoc_filters: []
   annotation_layers: []
   color_scheme: supersetColors
   comparison_type: values
@@ -28,7 +23,8 @@ params:
     hasCustomLabel: true
     label: At least one video viewed
     optionName: metric_pjnwyhoqed_98z4w1j60l
-    sqlExpression: rand() % 20
+    sqlExpression: |-
+      countIf("section/subsection video engagement" = 'At least one video viewed' or "section/subsection video engagement" = 'All videos viewed')
   - aggregate: null
     column: null
     datasourceWarning: false
@@ -36,7 +32,8 @@ params:
     hasCustomLabel: true
     label: All videos viewed
     optionName: metric_jo791jxqdd_ob1j1gmk0uh
-    sqlExpression: rand() % 10
+    sqlExpression: |-
+      countIf("section/subsection video engagement" = 'All videos viewed')
   only_total: true
   order_desc: true
   orientation: vertical
@@ -47,10 +44,11 @@ params:
   sort_series_type: sum
   time_grain_sqla: P1M
   tooltipTimeFormat: smart_date
+  truncateXAxis: true
   truncate_metric: true
   viz_type: echarts_timeseries_bar
   xAxisLabelRotation: 45
-  x_axis: block_name_with_location
+  x_axis: section/subsection name
   x_axis_sort_asc: true
   x_axis_sort_series: name
   x_axis_sort_series_ascending: true
@@ -64,21 +62,9 @@ params:
   y_axis_title_margin: 30
   y_axis_title_position: Left
   zoomable: true
-query_context: '{"datasource":{"id":69,"type":"table"},"force":false,"queries":[{"filters":[{"col":"emission_time","op":"TEMPORAL_RANGE","val":"No
-  filter"}],"extras":{"having":"","where":""},"applied_time_extras":{},"columns":[{"timeGrain":"P1M","columnType":"BASE_AXIS","sqlExpression":"block_name_with_location","label":"block_name_with_location","expressionType":"SQL"}],"metrics":[{"aggregate":null,"column":null,"datasourceWarning":false,"expressionType":"SQL","hasCustomLabel":true,"label":"At
-  least one video viewed","optionName":"metric_pjnwyhoqed_98z4w1j60l","sqlExpression":"rand()
-  % 20"},{"aggregate":null,"column":null,"datasourceWarning":false,"expressionType":"SQL","hasCustomLabel":true,"label":"All
-  videos viewed","optionName":"metric_jo791jxqdd_ob1j1gmk0uh","sqlExpression":"rand()
-  % 10"}],"orderby":[[{"aggregate":null,"column":null,"datasourceWarning":false,"expressionType":"SQL","hasCustomLabel":true,"label":"At
-  least one video viewed","optionName":"metric_pjnwyhoqed_98z4w1j60l","sqlExpression":"rand()
-  % 20"},false]],"annotation_layers":[],"row_limit":10000,"series_columns":[],"series_limit":0,"order_desc":true,"url_params":{},"custom_params":{},"custom_form_data":{},"time_offsets":[],"post_processing":[{"operation":"pivot","options":{"index":["block_name_with_location"],"columns":[],"aggregates":{"At
-  least one video viewed":{"operator":"mean"},"All videos viewed":{"operator":"mean"}},"drop_missing_columns":false}},{"operation":"flatten"}]}],"form_data":{"datasource":"69__table","viz_type":"echarts_timeseries_bar","slice_id":203,"x_axis":"block_name_with_location","time_grain_sqla":"P1M","x_axis_sort_asc":true,"x_axis_sort_series":"name","x_axis_sort_series_ascending":true,"metrics":[{"aggregate":null,"column":null,"datasourceWarning":false,"expressionType":"SQL","hasCustomLabel":true,"label":"At
-  least one video viewed","optionName":"metric_pjnwyhoqed_98z4w1j60l","sqlExpression":"rand()
-  % 20"},{"aggregate":null,"column":null,"datasourceWarning":false,"expressionType":"SQL","hasCustomLabel":true,"label":"All
-  videos viewed","optionName":"metric_jo791jxqdd_ob1j1gmk0uh","sqlExpression":"rand()
-  % 10"}],"groupby":[],"adhoc_filters":[{"clause":"WHERE","comparator":"No filter","expressionType":"SIMPLE","operator":"TEMPORAL_RANGE","subject":"emission_time"}],"order_desc":true,"row_limit":10000,"truncate_metric":true,"show_empty_columns":true,"comparison_type":"values","annotation_layers":[],"forecastPeriods":10,"forecastInterval":0.8,"orientation":"vertical","x_axis_title_margin":15,"y_axis_title":"Number
-  of learners","y_axis_title_margin":30,"y_axis_title_position":"Left","sort_series_type":"sum","color_scheme":"supersetColors","only_total":true,"zoomable":true,"show_legend":true,"legendType":"scroll","legendOrientation":"top","x_axis_time_format":"smart_date","xAxisLabelRotation":45,"y_axis_format":"SMART_NUMBER","y_axis_bounds":[null,null],"rich_tooltip":true,"tooltipTimeFormat":"smart_date","extra_form_data":{},"dashboards":[16],"force":false,"result_format":"json","result_type":"full"},"result_format":"json","result_type":"full"}'
+query_context: |-
+  {"datasource":{"id":226,"type":"table"},"force":false,"queries":[{"filters":[],"extras":{"time_grain_sqla":"P1M","having":"","where":""},"applied_time_extras":{},"columns":[{"timeGrain":"P1M","columnType":"BASE_AXIS","sqlExpression":"section/subsection name","label":"section/subsection name","expressionType":"SQL"}],"metrics":[{"expressionType":"SQL","sqlExpression":"countIf(\"section/subsection video engagement\" = 'At least one video viewed' or \"section/subsection video engagement\" = 'All videos viewed')","column":null,"aggregate":null,"datasourceWarning":false,"hasCustomLabel":true,"label":"At least one video viewed","optionName":"metric_pjnwyhoqed_98z4w1j60l"},{"expressionType":"SQL","sqlExpression":"countIf(\"section/subsection video engagement\" = 'All videos viewed')","column":null,"aggregate":null,"datasourceWarning":false,"hasCustomLabel":true,"label":"All videos viewed","optionName":"metric_jo791jxqdd_ob1j1gmk0uh"}],"orderby":[[{"expressionType":"SQL","sqlExpression":"countIf(\"section/subsection video engagement\" = 'At least one video viewed' or \"section/subsection video engagement\" = 'All videos viewed')","column":null,"aggregate":null,"datasourceWarning":false,"hasCustomLabel":true,"label":"At least one video viewed","optionName":"metric_pjnwyhoqed_98z4w1j60l"},false]],"annotation_layers":[],"row_limit":10000,"series_columns":[],"series_limit":0,"order_desc":true,"url_params":{},"custom_params":{},"custom_form_data":{},"time_offsets":[],"post_processing":[{"operation":"pivot","options":{"index":["section/subsection name"],"columns":[],"aggregates":{"At least one video viewed":{"operator":"mean"},"All videos viewed":{"operator":"mean"}},"drop_missing_columns":false}},{"operation":"flatten"}]}],"form_data":{"datasource":"226__table","viz_type":"echarts_timeseries_bar","slice_id":1600,"x_axis":"section/subsection name","time_grain_sqla":"P1M","x_axis_sort_asc":true,"x_axis_sort_series":"name","x_axis_sort_series_ascending":true,"metrics":[{"expressionType":"SQL","sqlExpression":"countIf(\"section/subsection video engagement\" = 'At least one video viewed' or \"section/subsection video engagement\" = 'All videos viewed')","column":null,"aggregate":null,"datasourceWarning":false,"hasCustomLabel":true,"label":"At least one video viewed","optionName":"metric_pjnwyhoqed_98z4w1j60l"},{"expressionType":"SQL","sqlExpression":"countIf(\"section/subsection video engagement\" = 'All videos viewed')","column":null,"aggregate":null,"datasourceWarning":false,"hasCustomLabel":true,"label":"All videos viewed","optionName":"metric_jo791jxqdd_ob1j1gmk0uh"}],"groupby":[],"adhoc_filters":[],"order_desc":true,"row_limit":10000,"truncate_metric":true,"show_empty_columns":true,"comparison_type":"values","annotation_layers":[],"forecastPeriods":10,"forecastInterval":0.8,"orientation":"vertical","x_axis_title_margin":15,"y_axis_title":"Number of learners","y_axis_title_margin":30,"y_axis_title_position":"Left","sort_series_type":"sum","color_scheme":"supersetColors","only_total":true,"zoomable":true,"show_legend":true,"legendType":"scroll","legendOrientation":"top","x_axis_time_format":"smart_date","xAxisLabelRotation":45,"y_axis_format":"SMART_NUMBER","truncateXAxis":true,"y_axis_bounds":[null,null],"rich_tooltip":true,"tooltipTimeFormat":"smart_date","extra_form_data":{},"dashboards":[2409],"force":false,"result_format":"json","result_type":"full"},"result_format":"json","result_type":"full"}
 slice_name: Video views per section/subsection
-uuid: 2c8072e7-44d1-4337-a843-aa2eb670b70e
+uuid: c1f77432-e55f-4473-b7d0-7a1c3976e6a8
 version: 1.0.0
 viz_type: echarts_timeseries_bar

--- a/tutoraspects/templates/aspects/build/aspects-superset/openedx-assets/assets/dashboards/Course_Dashboard_V1.yaml
+++ b/tutoraspects/templates/aspects/build/aspects-superset/openedx-assets/assets/dashboards/Course_Dashboard_V1.yaml
@@ -1,286 +1,286 @@
 _file_name: Course_Dashboard_V1.yaml
 _roles:
 - '{{ SUPERSET_ROLES_MAPPING.instructor }}'
-certification_details: null
-certified_by: null
+certification_details: ''
+certified_by: ''
 css: ''
 dashboard_title: Course Dashboard V1
 description: null
 metadata:
   chart_configuration:
-    '1':
+    '1589':
       crossFilters:
         chartsInScope:
-        - 6
-        - 7
-        - 56
-        - 62
-        - 71
-        - 72
-        - 74
-        - 79
-        - 89
-        - 105
-        - 112
-        - 116
-        - 129
-        - 132
-        - 134
-        - 147
+        - 682
+        - 1611
+        - 1613
+        - 1655
+        - 1768
+        - 1783
+        - 1792
+        - 1805
+        - 1807
+        - 1826
+        - 1839
+        - 1846
+        - 1871
+        - 1901
+        - 1921
+        - 1941
         scope: global
-      id: 1
-    '105':
+      id: 1589
+    '1611':
       crossFilters:
         chartsInScope:
-        - 1
-        - 6
-        - 7
-        - 56
-        - 62
-        - 71
-        - 72
-        - 74
-        - 79
-        - 89
-        - 112
-        - 116
-        - 129
-        - 132
-        - 134
-        - 147
+        - 682
+        - 1589
+        - 1613
+        - 1655
+        - 1768
+        - 1783
+        - 1792
+        - 1805
+        - 1807
+        - 1826
+        - 1839
+        - 1846
+        - 1871
+        - 1901
+        - 1921
+        - 1941
         scope: global
-      id: 105
-    '112':
+      id: 1611
+    '1613':
       crossFilters:
         chartsInScope:
-        - 1
-        - 6
-        - 7
-        - 56
-        - 62
-        - 71
-        - 72
-        - 74
-        - 79
-        - 89
-        - 105
-        - 116
-        - 129
-        - 132
-        - 134
-        - 147
+        - 682
+        - 1589
+        - 1611
+        - 1655
+        - 1768
+        - 1783
+        - 1792
+        - 1805
+        - 1807
+        - 1826
+        - 1839
+        - 1846
+        - 1871
+        - 1901
+        - 1921
+        - 1941
         scope: global
-      id: 112
-    '116':
+      id: 1613
+    '1768':
       crossFilters:
         chartsInScope:
-        - 1
-        - 6
-        - 7
-        - 56
-        - 62
-        - 71
-        - 72
-        - 74
-        - 79
-        - 89
-        - 105
-        - 112
-        - 129
-        - 132
-        - 134
-        - 147
+        - 682
+        - 1589
+        - 1611
+        - 1613
+        - 1655
+        - 1783
+        - 1792
+        - 1805
+        - 1807
+        - 1826
+        - 1839
+        - 1846
+        - 1871
+        - 1901
+        - 1921
+        - 1941
         scope: global
-      id: 116
-    '134':
+      id: 1768
+    '1783':
       crossFilters:
         chartsInScope:
-        - 1
-        - 6
-        - 7
-        - 56
-        - 62
-        - 71
-        - 72
-        - 74
-        - 79
-        - 89
-        - 105
-        - 112
-        - 116
-        - 129
-        - 132
-        - 147
+        - 682
+        - 1589
+        - 1611
+        - 1613
+        - 1655
+        - 1768
+        - 1792
+        - 1805
+        - 1807
+        - 1826
+        - 1839
+        - 1846
+        - 1871
+        - 1901
+        - 1921
+        - 1941
         scope: global
-      id: 134
-    '147':
+      id: 1783
+    '1792':
       crossFilters:
         chartsInScope:
-        - 1
-        - 6
-        - 7
-        - 56
-        - 62
-        - 71
-        - 72
-        - 74
-        - 79
-        - 89
-        - 105
-        - 112
-        - 116
-        - 129
-        - 132
-        - 134
+        - 682
+        - 1589
+        - 1611
+        - 1613
+        - 1655
+        - 1768
+        - 1783
+        - 1805
+        - 1807
+        - 1826
+        - 1839
+        - 1846
+        - 1871
+        - 1901
+        - 1921
+        - 1941
         scope: global
-      id: 147
-    '56':
+      id: 1792
+    '1805':
       crossFilters:
         chartsInScope:
-        - 1
-        - 6
-        - 7
-        - 62
-        - 71
-        - 72
-        - 74
-        - 79
-        - 89
-        - 105
-        - 112
-        - 116
-        - 129
-        - 132
-        - 134
-        - 147
+        - 682
+        - 1589
+        - 1611
+        - 1613
+        - 1655
+        - 1768
+        - 1783
+        - 1792
+        - 1807
+        - 1826
+        - 1839
+        - 1846
+        - 1871
+        - 1901
+        - 1921
+        - 1941
         scope: global
-      id: 56
-    '6':
+      id: 1805
+    '1826':
       crossFilters:
         chartsInScope:
-        - 1
-        - 7
-        - 56
-        - 62
-        - 71
-        - 72
-        - 74
-        - 79
-        - 89
-        - 105
-        - 112
-        - 116
-        - 129
-        - 132
-        - 134
-        - 147
+        - 682
+        - 1589
+        - 1611
+        - 1613
+        - 1655
+        - 1768
+        - 1783
+        - 1792
+        - 1805
+        - 1807
+        - 1839
+        - 1846
+        - 1871
+        - 1901
+        - 1921
+        - 1941
         scope: global
-      id: 6
-    '62':
+      id: 1826
+    '1839':
       crossFilters:
         chartsInScope:
-        - 1
-        - 6
-        - 7
-        - 56
-        - 71
-        - 72
-        - 74
-        - 79
-        - 89
-        - 105
-        - 112
-        - 116
-        - 129
-        - 132
-        - 134
-        - 147
+        - 682
+        - 1589
+        - 1611
+        - 1613
+        - 1655
+        - 1768
+        - 1783
+        - 1792
+        - 1805
+        - 1807
+        - 1826
+        - 1846
+        - 1871
+        - 1901
+        - 1921
+        - 1941
         scope: global
-      id: 62
-    '72':
+      id: 1839
+    '1871':
       crossFilters:
         chartsInScope:
-        - 1
-        - 6
-        - 7
-        - 56
-        - 62
-        - 71
-        - 74
-        - 79
-        - 89
-        - 105
-        - 112
-        - 116
-        - 129
-        - 132
-        - 134
-        - 147
+        - 682
+        - 1589
+        - 1611
+        - 1613
+        - 1655
+        - 1768
+        - 1783
+        - 1792
+        - 1805
+        - 1807
+        - 1826
+        - 1839
+        - 1846
+        - 1901
+        - 1921
+        - 1941
         scope: global
-      id: 72
-    '74':
+      id: 1871
+    '1901':
       crossFilters:
         chartsInScope:
-        - 1
-        - 6
-        - 7
-        - 56
-        - 62
-        - 71
-        - 72
-        - 79
-        - 89
-        - 105
-        - 112
-        - 116
-        - 129
-        - 132
-        - 134
-        - 147
+        - 682
+        - 1589
+        - 1611
+        - 1613
+        - 1655
+        - 1768
+        - 1783
+        - 1792
+        - 1805
+        - 1807
+        - 1826
+        - 1839
+        - 1846
+        - 1871
+        - 1921
+        - 1941
         scope: global
-      id: 74
-    '79':
+      id: 1901
+    '1921':
       crossFilters:
         chartsInScope:
-        - 1
-        - 6
-        - 7
-        - 56
-        - 62
-        - 71
-        - 72
-        - 74
-        - 89
-        - 105
-        - 112
-        - 116
-        - 129
-        - 132
-        - 134
-        - 147
+        - 682
+        - 1589
+        - 1611
+        - 1613
+        - 1655
+        - 1768
+        - 1783
+        - 1792
+        - 1805
+        - 1807
+        - 1826
+        - 1839
+        - 1846
+        - 1871
+        - 1901
+        - 1941
         scope: global
-      id: 79
-    '89':
+      id: 1921
+    '1941':
       crossFilters:
         chartsInScope:
-        - 1
-        - 6
-        - 7
-        - 56
-        - 62
-        - 71
-        - 72
-        - 74
-        - 79
-        - 105
-        - 112
-        - 116
-        - 129
-        - 132
-        - 134
-        - 147
+        - 682
+        - 1589
+        - 1611
+        - 1613
+        - 1655
+        - 1768
+        - 1783
+        - 1792
+        - 1805
+        - 1807
+        - 1826
+        - 1839
+        - 1846
+        - 1871
+        - 1901
+        - 1921
         scope: global
-      id: 89
+      id: 1941
   color_scheme: supersetColors
   color_scheme_domain:
   - '#1FA8C9'
@@ -308,23 +308,23 @@ metadata:
   expanded_slices: {}
   global_chart_configuration:
     chartsInScope:
-    - 1
-    - 6
-    - 7
-    - 56
-    - 62
-    - 71
-    - 72
-    - 74
-    - 79
-    - 89
-    - 105
-    - 112
-    - 116
-    - 129
-    - 132
-    - 134
-    - 147
+    - 682
+    - 1589
+    - 1611
+    - 1613
+    - 1655
+    - 1768
+    - 1783
+    - 1792
+    - 1805
+    - 1807
+    - 1826
+    - 1839
+    - 1846
+    - 1871
+    - 1901
+    - 1921
+    - 1941
     scope:
       excluded: []
       rootPath:
@@ -518,11 +518,11 @@ metadata:
     name: Date
     scope:
       excluded:
-      - 72
-      - 89
-      - 105
-      - 74
-      - 6
+      - 1783
+      - 1871
+      - 1589
+      - 1768
+      - 1792
       rootPath:
       - ROOT_ID
     tabsInScope:
@@ -562,9 +562,9 @@ metadata:
     name: Time Grain
     scope:
       excluded:
-      - 62
-      - 89
-      - 105
+      - 1826
+      - 1871
+      - 1589
       rootPath:
       - TAB-4ptSkqs5MS
       - TAB-_Ey4nPhFr
@@ -600,19 +600,17 @@ metadata:
     name: Video name
     scope:
       excluded:
-      - 56
-      - 1
-      - 129
-      - 72
-      - 62
-      - 134
-      - 89
-      - 105
-      - 74
-      - 6
-      - 132
-      - 7
-      - 116
+      - 1807
+      - 1783
+      - 1826
+      - 1839
+      - 1871
+      - 1589
+      - 1768
+      - 1792
+      - 1846
+      - 1655
+      - 1613
       rootPath:
       - ROOT_ID
     tabsInScope:
@@ -625,50 +623,20 @@ metadata:
       datasetUuid: 6ec360a5-e247-42e7-b301-fa8275fc93f9
     type: NATIVE_FILTER
   refresh_frequency: 0
-  shared_label_colors: {}
+  shared_label_colors:
+    All videos viewed: '#5AC189'
+    At least one video viewed: '#1FA8C9'
+    Full views: '#454E7C'
+    Partial views: '#666666'
+    Repeat Views: '#A868B7'
+    Unique Viewers: '#FF7F44'
   timed_refresh_immune_slices: []
 position:
-  CHART-8p_tmmvFsY:
-    children: []
-    id: CHART-8p_tmmvFsY
-    meta:
-      chartId: 56
-      height: 50
-      sliceName: Page views per section/subsection
-      uuid: 0538470d-0328-4f15-9e48-ffc9e84c4c06
-      width: 12
-    parents:
-    - ROOT_ID
-    - GRID_ID
-    - TABS-UDkdlBRw4n
-    - TAB-_Ey4nPhFr
-    - TABS-nk8aeLmc5o
-    - TAB-nqLFUR_Tg
-    - ROW-6oVc0KNyM1
-    type: CHART
-  CHART-LiY7tPJWZv:
-    children: []
-    id: CHART-LiY7tPJWZv
-    meta:
-      chartId: 1
-      height: 50
-      sliceName: Problems attempted per section/subsection
-      uuid: 869edaf6-f911-4ca7-9e4b-28435bba2e82
-      width: 12
-    parents:
-    - ROOT_ID
-    - GRID_ID
-    - TABS-UDkdlBRw4n
-    - TAB-_Ey4nPhFr
-    - TABS-nk8aeLmc5o
-    - TAB-vze5iq6jg
-    - ROW-iV463iCf2a
-    type: CHART
   CHART-Q6nr6irIdz:
     children: []
     id: CHART-Q6nr6irIdz
     meta:
-      chartId: 71
+      chartId: 682
       height: 50
       sliceName: Watched Video Segments
       uuid: 2985a9db-c338-4008-af52-2930b81ee2e5
@@ -686,8 +654,8 @@ position:
     children: []
     id: CHART-_BfZOEhMVM
     meta:
-      chartId: 147
-      height: 50
+      chartId: 1611
+      height: 71
       sliceName: Partial and full views per video
       uuid: 14c5cd80-cb50-4136-9911-d77da1737d69
       width: 12
@@ -704,7 +672,7 @@ position:
     children: []
     id: CHART-explore-185-1
     meta:
-      chartId: 129
+      chartId: 1807
       height: 28
       sliceName: Current Enrollees
       uuid: 00de2f72-b3ed-4994-b231-fd3cf29d758d
@@ -718,7 +686,7 @@ position:
     children: []
     id: CHART-explore-186-1
     meta:
-      chartId: 72
+      chartId: 1783
       height: 18
       sliceName: Course Information
       uuid: fa249dda-78da-4ccc-9ef3-39177e6aae0c
@@ -733,7 +701,7 @@ position:
     children: []
     id: CHART-explore-188-1
     meta:
-      chartId: 62
+      chartId: 1826
       height: 64
       sliceName: Enrollees per Enrollment Track
       uuid: e584199e-0ed6-42bf-afb9-db3b9fe4132b
@@ -749,7 +717,7 @@ position:
     children: []
     id: CHART-explore-189-1
     meta:
-      chartId: 134
+      chartId: 1839
       height: 51
       sliceName: Cumulative Enrollments by Track
       uuid: f207c896-030a-462b-b69f-6416230d50b6
@@ -762,11 +730,29 @@ position:
     - ROW-EpJDdqK8c
     - COLUMN-2jtUMCFWN3
     type: CHART
+  CHART-explore-1901-1:
+    children: []
+    id: CHART-explore-1901-1
+    meta:
+      chartId: 1901
+      height: 60
+      sliceName: Page views per section/subsection
+      uuid: bf2d6219-d633-48c1-a9b5-742eac6a4c0a
+      width: 12
+    parents:
+    - ROOT_ID
+    - GRID_ID
+    - TABS-UDkdlBRw4n
+    - TAB-_Ey4nPhFr
+    - TABS-nk8aeLmc5o
+    - TAB-nqLFUR_Tg
+    - ROW-tOgcIuB1-
+    type: CHART
   CHART-explore-191-1:
     children: []
     id: CHART-explore-191-1
     meta:
-      chartId: 89
+      chartId: 1871
       height: 50
       sliceName: Section Summary
       uuid: 47417136-acd1-44a1-b41e-644eb2c237c3
@@ -784,7 +770,7 @@ position:
     children: []
     id: CHART-explore-192-1
     meta:
-      chartId: 105
+      chartId: 1589
       height: 50
       sliceName: Subsection Summary
       uuid: 2a8d96be-687d-4918-98fe-ae9fbd599152
@@ -798,11 +784,29 @@ position:
     - TAB-nqLFUR_Tg
     - ROW-GlQl7V_ol
     type: CHART
+  CHART-explore-1921-1:
+    children: []
+    id: CHART-explore-1921-1
+    meta:
+      chartId: 1921
+      height: 59
+      sliceName: Problems attempted per section/subsection
+      uuid: 8cdcd4aa-1fa2-41dc-b38d-f1112134592e
+      width: 12
+    parents:
+    - ROOT_ID
+    - GRID_ID
+    - TABS-UDkdlBRw4n
+    - TAB-_Ey4nPhFr
+    - TABS-nk8aeLmc5o
+    - TAB-vze5iq6jg
+    - ROW-CHCrAJpP5
+    type: CHART
   CHART-explore-194-1:
     children: []
     id: CHART-explore-194-1
     meta:
-      chartId: 74
+      chartId: 1768
       height: 50
       sliceName: Evolution of engagement
       uuid: d3ae0546-37a8-4841-a57b-8087a6c33049
@@ -816,11 +820,29 @@ position:
     - TAB-nqLFUR_Tg
     - ROW-GlQl7V_ol
     type: CHART
+  CHART-explore-1941-1:
+    children: []
+    id: CHART-explore-1941-1
+    meta:
+      chartId: 1941
+      height: 69
+      sliceName: Video views per section/subsection
+      uuid: c1f77432-e55f-4473-b7d0-7a1c3976e6a8
+      width: 12
+    parents:
+    - ROOT_ID
+    - GRID_ID
+    - TABS-UDkdlBRw4n
+    - TAB-_Ey4nPhFr
+    - TABS-nk8aeLmc5o
+    - TAB-V5zNdxwhsP
+    - ROW-TNGl9z7XZ
+    type: CHART
   CHART-explore-195-1:
     children: []
     id: CHART-explore-195-1
     meta:
-      chartId: 6
+      chartId: 1792
       height: 50
       sliceName: Cumulative Interactions
       uuid: c44e43b5-ba69-4805-8d01-3b04dcbf2cb6
@@ -838,7 +860,7 @@ position:
     children: []
     id: CHART-explore-196-1
     meta:
-      chartId: 132
+      chartId: 1846
       height: 20
       sliceName: Learners with Passing Grade
       uuid: b40cdabc-b265-48d2-913d-a9dfee0b6ab1
@@ -855,7 +877,7 @@ position:
     children: []
     id: CHART-explore-197-1
     meta:
-      chartId: 7
+      chartId: 1655
       height: 50
       sliceName: Distribution of Current Course Grade
       uuid: ea565658-6796-40e8-9d1e-01ffd0778bc9
@@ -871,7 +893,7 @@ position:
     children: []
     id: CHART-explore-198-1
     meta:
-      chartId: 116
+      chartId: 1613
       height: 50
       sliceName: Problem Interactions
       uuid: ba14d2ea-8c53-4f79-aa1b-434011f3c725
@@ -889,7 +911,7 @@ position:
     children: []
     id: CHART-explore-205-1
     meta:
-      chartId: 112
+      chartId: 1805
       height: 50
       sliceName: Problem Results
       uuid: 6df96404-8c09-4a52-96c8-9a60a92cec29
@@ -897,25 +919,11 @@ position:
     parents:
     - ROOT_ID
     - GRID_ID
-    - ROW-fXap6bmp94
-    type: CHART
-  CHART-jsy_lFvqGu:
-    children: []
-    id: CHART-jsy_lFvqGu
-    meta:
-      chartId: 79
-      height: 50
-      sliceName: Video views per section/subsection
-      uuid: 2c8072e7-44d1-4337-a843-aa2eb670b70e
-      width: 12
-    parents:
-    - ROOT_ID
-    - GRID_ID
     - TABS-UDkdlBRw4n
     - TAB-_Ey4nPhFr
     - TABS-nk8aeLmc5o
-    - TAB-V5zNdxwhsP
-    - ROW-_dGQijoSEk
+    - TAB-vze5iq6jg
+    - ROW-7xndTh8hI
     type: CHART
   COLUMN-2jtUMCFWN3:
     children:
@@ -1026,10 +1034,12 @@ position:
     - GRID_ID
     id: ROOT_ID
     type: ROOT
-  ROW-6oVc0KNyM1:
+  ROW-7xndTh8hI:
     children:
-    - CHART-8p_tmmvFsY
-    id: ROW-6oVc0KNyM1
+    - CHART-explore-198-1
+    - CHART-explore-205-1
+    - MARKDOWN-30KBrMMImF
+    id: ROW-7xndTh8hI
     meta:
       background: BACKGROUND_TRANSPARENT
     parents:
@@ -1038,14 +1048,12 @@ position:
     - TABS-UDkdlBRw4n
     - TAB-_Ey4nPhFr
     - TABS-nk8aeLmc5o
-    - TAB-nqLFUR_Tg
+    - TAB-vze5iq6jg
     type: ROW
-  ROW-7xndTh8hI:
+  ROW-CHCrAJpP5:
     children:
-    - CHART-explore-198-1
-    - CHART-explore-205-1
-    - MARKDOWN-30KBrMMImF
-    id: ROW-7xndTh8hI
+    - CHART-explore-1921-1
+    id: ROW-CHCrAJpP5
     meta:
       background: BACKGROUND_TRANSPARENT
     parents:
@@ -1084,6 +1092,20 @@ position:
     - TABS-nk8aeLmc5o
     - TAB-nqLFUR_Tg
     type: ROW
+  ROW-TNGl9z7XZ:
+    children:
+    - CHART-explore-1941-1
+    id: ROW-TNGl9z7XZ
+    meta:
+      background: BACKGROUND_TRANSPARENT
+    parents:
+    - ROOT_ID
+    - GRID_ID
+    - TABS-UDkdlBRw4n
+    - TAB-_Ey4nPhFr
+    - TABS-nk8aeLmc5o
+    - TAB-V5zNdxwhsP
+    type: ROW
   ROW-ToSAm6kqA2:
     children:
     - CHART-Q6nr6irIdz
@@ -1113,34 +1135,6 @@ position:
     - TABS-nk8aeLmc5o
     - TAB-nqLFUR_Tg
     type: ROW
-  ROW-_dGQijoSEk:
-    children:
-    - CHART-jsy_lFvqGu
-    id: ROW-_dGQijoSEk
-    meta:
-      background: BACKGROUND_TRANSPARENT
-    parents:
-    - ROOT_ID
-    - GRID_ID
-    - TABS-UDkdlBRw4n
-    - TAB-_Ey4nPhFr
-    - TABS-nk8aeLmc5o
-    - TAB-V5zNdxwhsP
-    type: ROW
-  ROW-iV463iCf2a:
-    children:
-    - CHART-LiY7tPJWZv
-    id: ROW-iV463iCf2a
-    meta:
-      background: BACKGROUND_TRANSPARENT
-    parents:
-    - ROOT_ID
-    - GRID_ID
-    - TABS-UDkdlBRw4n
-    - TAB-_Ey4nPhFr
-    - TABS-nk8aeLmc5o
-    - TAB-vze5iq6jg
-    type: ROW
   ROW-qDVwqO3bi4:
     children:
     - CHART-explore-185-1
@@ -1164,6 +1158,20 @@ position:
     - GRID_ID
     - TABS-UDkdlBRw4n
     - TAB-5Guk2p9fd
+    type: ROW
+  ROW-tOgcIuB1-:
+    children:
+    - CHART-explore-1901-1
+    id: ROW-tOgcIuB1-
+    meta:
+      background: BACKGROUND_TRANSPARENT
+    parents:
+    - ROOT_ID
+    - GRID_ID
+    - TABS-UDkdlBRw4n
+    - TAB-_Ey4nPhFr
+    - TABS-nk8aeLmc5o
+    - TAB-nqLFUR_Tg
     type: ROW
   ROW-vpQpToPQb:
     children:
@@ -1207,7 +1215,7 @@ position:
     type: TAB
   TAB-V5zNdxwhsP:
     children:
-    - ROW-_dGQijoSEk
+    - ROW-TNGl9z7XZ
     - ROW-vpQpToPQb
     - ROW-ToSAm6kqA2
     id: TAB-V5zNdxwhsP
@@ -1237,7 +1245,7 @@ position:
     type: TAB
   TAB-nqLFUR_Tg:
     children:
-    - ROW-6oVc0KNyM1
+    - ROW-tOgcIuB1-
     - ROW-_KbR9wzEQb
     - ROW-GlQl7V_ol
     id: TAB-nqLFUR_Tg
@@ -1254,7 +1262,7 @@ position:
     type: TAB
   TAB-vze5iq6jg:
     children:
-    - ROW-iV463iCf2a
+    - ROW-CHCrAJpP5
     - ROW-7xndTh8hI
     id: TAB-vze5iq6jg
     meta:

--- a/tutoraspects/templates/aspects/build/aspects-superset/openedx-assets/assets/datasets/fact_problem_engagement.yaml
+++ b/tutoraspects/templates/aspects/build/aspects-superset/openedx-assets/assets/datasets/fact_problem_engagement.yaml
@@ -1,4 +1,5 @@
 _file_name: fact_problem_engagement.yaml
+always_filter_main_dttm: false
 cache_timeout: null
 columns:
 - advanced_data_type: null


### PR DESCRIPTION
This change updates the page view, problem, and video engagement charts to use the correct dataset for each. The existing charts used fake data for the purposes of mocking the expected design and behavior and needed to be updated to show accurate data.