### PR TITLE
fix: Remove query context after asset import

### DIFF
--- a/tutoraspects/patches/openedx-dev-dockerfile-post-python-requirements
+++ b/tutoraspects/patches/openedx-dev-dockerfile-post-python-requirements
@@ -1,4 +1,4 @@
 RUN --mount=type=cache,target=/openedx/.cache/pip,sharing=shared \
-    pip install "platform-plugin-aspects==v0.7.0"
+    pip install "platform-plugin-aspects==v0.7.2"
 RUN --mount=type=cache,target=/openedx/.cache/pip,sharing=shared \
     pip install "edx-event-routing-backends==v9.0.0"

--- a/tutoraspects/templates/aspects/apps/superset/pythonpath/create_assets.py
+++ b/tutoraspects/templates/aspects/apps/superset/pythonpath/create_assets.py
@@ -1,13 +1,13 @@
 """Import a list of assets from a yaml file and create them in the superset assets folder."""
 import os
-import uuid
-
-import yaml
 from superset.app import create_app
 
 app = create_app()
 app.app_context().push()
 
+import logging
+import uuid
+import yaml
 from copy import deepcopy
 from pathlib import Path
 

--- a/tutoraspects/templates/aspects/apps/superset/pythonpath/create_assets.py
+++ b/tutoraspects/templates/aspects/apps/superset/pythonpath/create_assets.py
@@ -21,6 +21,10 @@ from superset.utils.database import get_or_create_db
 from superset.models.embedded_dashboard import EmbeddedDashboard
 from pythonpath.localization import get_translation
 from pythonpath.create_row_level_security import create_rls_filters
+
+
+logger = logging.getLogger("create_assets")
+
 BASE_DIR = "/app/assets/superset"
 
 ASSET_FOLDER_MAPPING = {

--- a/tutoraspects/templates/aspects/apps/superset/pythonpath/create_assets.py
+++ b/tutoraspects/templates/aspects/apps/superset/pythonpath/create_assets.py
@@ -264,7 +264,7 @@ def update_dashboard_roles(roles):
 
     for dashboard_uuid, role_ids in roles.items():
         dashboard = db.session.query(Dashboard).filter_by(uuid=dashboard_uuid).one()
-        logger.info("Importing dashboard roles", dashboard_uuid, role_ids)
+        logger.info(f"Importing dashboard roles: {dashboard_uuid} - {role_ids}")
         dashboard.roles = role_ids
         if owners:
             dashboard.owners = owners


### PR DESCRIPTION
Fixes an issue where dashboards do not load in the LMS instructor dashboard due to query_context containing database primary keys from the database it was exported from. Performance metrics uses the query_context, so now it pulls that directly from the asset files on disk instead.