### PR TITLE
feat: add video plays table to course dashboard (FC-0051)

### DIFF
--- a/tutoraspects/plugin.py
+++ b/tutoraspects/plugin.py
@@ -334,7 +334,7 @@ hooks.Filters.CONFIG_DEFAULTS.add_items(
         # For now we are pulling this from github, which should allow maximum
         # flexibility for forking, running branches, specific versions, etc.
         ("DBT_REPOSITORY", "https://github.com/openedx/aspects-dbt"),
-        ("DBT_BRANCH", "v3.17.0"),
+        ("DBT_BRANCH", "v3.19.0"),
         ("DBT_SSH_KEY", ""),
         ("DBT_STATE_DIR", "/app/aspects/dbt_state/"),
         # This is the name of the database dbt will write to

--- a/tutoraspects/templates/aspects/build/aspects-superset/openedx-assets/assets/charts/Video_views_by_section_subsection.yaml
+++ b/tutoraspects/templates/aspects/build/aspects-superset/openedx-assets/assets/charts/Video_views_by_section_subsection.yaml
@@ -1,0 +1,51 @@
+_file_name: Video_views_by_section_subsection.yaml
+cache_timeout: null
+certification_details: null
+certified_by: null
+dataset_uuid: 6ec360a5-e247-42e7-b301-fa8275fc93f9
+description: null
+params:
+  adhoc_filters:
+  - clause: WHERE
+    comparator: No filter
+    expressionType: SIMPLE
+    operator: TEMPORAL_RANGE
+    subject: emission_time
+  all_columns: []
+  color_pn: true
+  conditional_formatting: []
+  extra_form_data: {}
+  groupby:
+  - expressionType: SQL
+    label: Section Name
+    sqlExpression: section_with_name
+  - expressionType: SQL
+    label: Subsection Name
+    sqlExpression: subsection_with_name
+  - video_name_with_location
+  metrics:
+  - unique_watchers
+  - total_plays
+  order_by_cols: []
+  order_desc: true
+  percent_metrics: []
+  query_mode: aggregate
+  row_limit: 1000
+  server_page_length: 10
+  show_cell_bars: true
+  table_timestamp_format: smart_date
+  temporal_columns_lookup:
+    emission_time: true
+  time_grain_sqla: P1M
+  viz_type: table
+query_context: '{"datasource":{"id":77,"type":"table"},"force":false,"queries":[{"filters":[{"col":"emission_time","op":"TEMPORAL_RANGE","val":"No
+  filter"}],"extras":{"time_grain_sqla":"P1M","having":"","where":""},"applied_time_extras":{},"columns":[{"expressionType":"SQL","label":"Section
+  Name","sqlExpression":"section_with_name"},{"expressionType":"SQL","label":"Subsection
+  Name","sqlExpression":"subsection_with_name"},"video_name_with_location"],"metrics":["unique_watchers","total_plays"],"orderby":[["unique_watchers",false]],"annotation_layers":[],"row_limit":1000,"series_limit":0,"order_desc":true,"url_params":{},"custom_params":{},"custom_form_data":{},"post_processing":[]}],"form_data":{"datasource":"77__table","viz_type":"table","slice_id":1962,"query_mode":"aggregate","groupby":[{"expressionType":"SQL","label":"Section
+  Name","sqlExpression":"section_with_name"},{"expressionType":"SQL","label":"Subsection
+  Name","sqlExpression":"subsection_with_name"},"video_name_with_location"],"time_grain_sqla":"P1M","temporal_columns_lookup":{"emission_time":true},"metrics":["unique_watchers","total_plays"],"all_columns":[],"percent_metrics":[],"adhoc_filters":[{"clause":"WHERE","comparator":"No
+  filter","expressionType":"SIMPLE","operator":"TEMPORAL_RANGE","subject":"emission_time"}],"order_by_cols":[],"row_limit":1000,"server_page_length":10,"order_desc":true,"table_timestamp_format":"smart_date","show_cell_bars":true,"color_pn":true,"conditional_formatting":[],"extra_form_data":{},"dashboards":[2649],"force":false,"result_format":"json","result_type":"full"},"result_format":"json","result_type":"full"}'
+slice_name: Video views by section/subsection
+uuid: c8c363f8-8dbc-4a78-841d-4976f4404884
+version: 1.0.0
+viz_type: table

--- a/tutoraspects/templates/aspects/build/aspects-superset/openedx-assets/assets/dashboards/Course_Dashboard_V1.yaml
+++ b/tutoraspects/templates/aspects/build/aspects-superset/openedx-assets/assets/dashboards/Course_Dashboard_V1.yaml
@@ -27,6 +27,7 @@ metadata:
         - 1901
         - 1921
         - 1941
+        - 1962
         scope: global
       id: 1589
     '1611':
@@ -48,6 +49,7 @@ metadata:
         - 1901
         - 1921
         - 1941
+        - 1962
         scope: global
       id: 1611
     '1613':
@@ -69,6 +71,7 @@ metadata:
         - 1901
         - 1921
         - 1941
+        - 1962
         scope: global
       id: 1613
     '1768':
@@ -90,6 +93,7 @@ metadata:
         - 1901
         - 1921
         - 1941
+        - 1962
         scope: global
       id: 1768
     '1783':
@@ -111,6 +115,7 @@ metadata:
         - 1901
         - 1921
         - 1941
+        - 1962
         scope: global
       id: 1783
     '1792':
@@ -132,6 +137,7 @@ metadata:
         - 1901
         - 1921
         - 1941
+        - 1962
         scope: global
       id: 1792
     '1805':
@@ -153,6 +159,7 @@ metadata:
         - 1901
         - 1921
         - 1941
+        - 1962
         scope: global
       id: 1805
     '1826':
@@ -174,6 +181,7 @@ metadata:
         - 1901
         - 1921
         - 1941
+        - 1962
         scope: global
       id: 1826
     '1839':
@@ -195,6 +203,7 @@ metadata:
         - 1901
         - 1921
         - 1941
+        - 1962
         scope: global
       id: 1839
     '1871':
@@ -216,6 +225,7 @@ metadata:
         - 1901
         - 1921
         - 1941
+        - 1962
         scope: global
       id: 1871
     '1901':
@@ -237,6 +247,7 @@ metadata:
         - 1871
         - 1921
         - 1941
+        - 1962
         scope: global
       id: 1901
     '1921':
@@ -258,6 +269,7 @@ metadata:
         - 1871
         - 1901
         - 1941
+        - 1962
         scope: global
       id: 1921
     '1941':
@@ -279,8 +291,31 @@ metadata:
         - 1871
         - 1901
         - 1921
+        - 1962
         scope: global
       id: 1941
+    '1962':
+      crossFilters:
+        chartsInScope:
+        - 682
+        - 1589
+        - 1611
+        - 1613
+        - 1655
+        - 1768
+        - 1783
+        - 1792
+        - 1805
+        - 1807
+        - 1826
+        - 1839
+        - 1846
+        - 1871
+        - 1901
+        - 1921
+        - 1941
+        scope: global
+      id: 1962
   color_scheme: supersetColors
   color_scheme_domain:
   - '#1FA8C9'
@@ -325,6 +360,7 @@ metadata:
     - 1901
     - 1921
     - 1941
+    - 1962
     scope:
       excluded: []
       rootPath:
@@ -624,12 +660,18 @@ metadata:
     type: NATIVE_FILTER
   refresh_frequency: 0
   shared_label_colors:
+    All pages viewed: '#8FD3E4'
     All videos viewed: '#5AC189'
+    At least one page viewed: '#3CCCCB'
     At least one video viewed: '#1FA8C9'
     Full views: '#454E7C'
+    Number of Learners: '#FCC700'
     Partial views: '#666666'
     Repeat Views: '#A868B7'
+    Total Learners: '#A38F79'
+    Total Views: '#ACE1C4'
     Unique Viewers: '#FF7F44'
+    audit: '#E04355'
   timed_refresh_immune_slices: []
 position:
   CHART-Q6nr6irIdz:
@@ -873,6 +915,20 @@ position:
     - ROW-sMfqRh00J
     - COLUMN-N18OE5OVho
     type: CHART
+  CHART-explore-1962-1:
+    children: []
+    id: CHART-explore-1962-1
+    meta:
+      chartId: 1962
+      height: 50
+      sliceName: Video views by section/subsection
+      uuid: c8c363f8-8dbc-4a78-841d-4976f4404884
+      width: 12
+    parents:
+    - ROOT_ID
+    - GRID_ID
+    - ROW-_A28qByD8
+    type: CHART
   CHART-explore-197-1:
     children: []
     id: CHART-explore-197-1
@@ -895,7 +951,7 @@ position:
     meta:
       chartId: 1613
       height: 50
-      sliceName: Problem Interactions
+      sliceName: Problem interactions
       uuid: ba14d2ea-8c53-4f79-aa1b-434011f3c725
       width: 5
     parents:
@@ -1135,6 +1191,20 @@ position:
     - TABS-nk8aeLmc5o
     - TAB-nqLFUR_Tg
     type: ROW
+  ROW-jK8rH2uIlm:
+    children:
+    - CHART-explore-1962-1
+    id: ROW-jK8rH2uIlm
+    meta:
+      background: BACKGROUND_TRANSPARENT
+    parents:
+    - ROOT_ID
+    - GRID_ID
+    - TABS-UDkdlBRw4n
+    - TAB-_Ey4nPhFr
+    - TABS-nk8aeLmc5o
+    - TAB-V5zNdxwhsP
+    type: ROW
   ROW-qDVwqO3bi4:
     children:
     - CHART-explore-185-1
@@ -1216,6 +1286,7 @@ position:
   TAB-V5zNdxwhsP:
     children:
     - ROW-TNGl9z7XZ
+    - ROW-jK8rH2uIlm
     - ROW-vpQpToPQb
     - ROW-ToSAm6kqA2
     id: TAB-V5zNdxwhsP

--- a/tutoraspects/templates/aspects/build/aspects-superset/openedx-assets/assets/datasets/fact_video_plays.yaml
+++ b/tutoraspects/templates/aspects/build/aspects-superset/openedx-assets/assets/datasets/fact_video_plays.yaml
@@ -159,6 +159,30 @@ columns:
   type: String
   verbose_name: Organization
 - advanced_data_type: null
+  column_name: subsection_with_name
+  description: null
+  expression: ''
+  extra: null
+  filterable: true
+  groupby: true
+  is_active: true
+  is_dttm: false
+  python_date_format: null
+  type: String
+  verbose_name: Subsection With Name
+- advanced_data_type: null
+  column_name: section_with_name
+  description: null
+  expression: ''
+  extra: null
+  filterable: true
+  groupby: true
+  is_active: true
+  is_dttm: false
+  python_date_format: null
+  type: String
+  verbose_name: Section With Name
+- advanced_data_type: null
   column_name: video_link
   description: null
   expression: ''


### PR DESCRIPTION
This change adds a table to the video engagement tab of the course dashboard. This table shows the number of views each video has, along with the videos section and subsection name. This is to give dashboard viewers more context as to which videos are included in the accompanying "video views per section/subsection" graph.

Here is a screenshot of the table:
![Screenshot from 2024-04-19 16-37-27](https://github.com/openedx/tutor-contrib-aspects/assets/2566242/c48e87ac-18ab-45da-a6fc-13f78ef4262d)
