### PR TITLE
fix: apply filters to course dashboard datasets (FC-0051)

### DIFF
--- a/tutoraspects/plugin.py
+++ b/tutoraspects/plugin.py
@@ -334,7 +334,7 @@ hooks.Filters.CONFIG_DEFAULTS.add_items(
         # For now we are pulling this from github, which should allow maximum
         # flexibility for forking, running branches, specific versions, etc.
         ("DBT_REPOSITORY", "https://github.com/openedx/aspects-dbt"),
-        ("DBT_BRANCH", "v3.19.0"),
+        ("DBT_BRANCH", "v3.19.2"),
         ("DBT_SSH_KEY", ""),
         ("DBT_STATE_DIR", "/app/aspects/dbt_state/"),
         # This is the name of the database dbt will write to

--- a/tutoraspects/templates/aspects/build/aspects-superset/openedx-assets/assets/charts/Partial_and_full_views_per_video.yaml
+++ b/tutoraspects/templates/aspects/build/aspects-superset/openedx-assets/assets/charts/Partial_and_full_views_per_video.yaml
@@ -2,15 +2,10 @@ _file_name: Partial_and_full_views_per_video.yaml
 cache_timeout: null
 certification_details: null
 certified_by: null
-dataset_uuid: 6ec360a5-e247-42e7-b301-fa8275fc93f9
+dataset_uuid: d0070c9a-5b1c-4e52-867b-79aa46a8cdcf
 description: null
 params:
-  adhoc_filters:
-  - clause: WHERE
-    comparator: No filter
-    expressionType: SIMPLE
-    operator: TEMPORAL_RANGE
-    subject: emission_time
+  adhoc_filters: []
   annotation_layers: []
   color_scheme: supersetColors
   comparison_type: values
@@ -28,7 +23,7 @@ params:
     hasCustomLabel: true
     label: Partial views
     optionName: metric_vw56yidojpl_5lfi6gz2u79
-    sqlExpression: rand() % 20
+    sqlExpression: countIf(not watched_entire_video)
   - aggregate: null
     column: null
     datasourceWarning: false
@@ -36,7 +31,7 @@ params:
     hasCustomLabel: true
     label: Full views
     optionName: metric_dwlfxsuu7da_ja3w75iht7
-    sqlExpression: rand() % 10
+    sqlExpression: countIf(watched_entire_video)
   only_total: true
   order_desc: true
   orientation: vertical
@@ -47,6 +42,7 @@ params:
   sort_series_type: sum
   time_grain_sqla: P1M
   tooltipTimeFormat: smart_date
+  truncateXAxis: true
   truncate_metric: true
   viz_type: echarts_timeseries_bar
   xAxisLabelRotation: 45
@@ -64,17 +60,18 @@ params:
   y_axis_title_margin: 30
   y_axis_title_position: Left
   zoomable: true
-query_context: '{"datasource":{"id":23,"type":"table"},"force":false,"queries":[{"filters":[{"col":"emission_time","op":"TEMPORAL_RANGE","val":"No
-  filter"}],"extras":{"having":"","where":""},"applied_time_extras":{},"columns":[{"timeGrain":"P1M","columnType":"BASE_AXIS","sqlExpression":"video_name_with_location","label":"video_name_with_location","expressionType":"SQL"}],"metrics":[{"aggregate":null,"column":null,"datasourceWarning":false,"expressionType":"SQL","hasCustomLabel":true,"label":"Partial
-  views","optionName":"metric_vw56yidojpl_5lfi6gz2u79","sqlExpression":"rand() % 20"},{"aggregate":null,"column":null,"datasourceWarning":false,"expressionType":"SQL","hasCustomLabel":true,"label":"Full
-  views","optionName":"metric_dwlfxsuu7da_ja3w75iht7","sqlExpression":"rand() % 10"}],"orderby":[[{"aggregate":null,"column":null,"datasourceWarning":false,"expressionType":"SQL","hasCustomLabel":true,"label":"Partial
-  views","optionName":"metric_vw56yidojpl_5lfi6gz2u79","sqlExpression":"rand() % 20"},false]],"annotation_layers":[],"row_limit":10000,"series_columns":[],"series_limit":0,"order_desc":true,"url_params":{},"custom_params":{},"custom_form_data":{},"time_offsets":[],"post_processing":[{"operation":"pivot","options":{"index":["video_name_with_location"],"columns":[],"aggregates":{"Partial
-  views":{"operator":"mean"},"Full views":{"operator":"mean"}},"drop_missing_columns":false}},{"operation":"flatten"}]}],"form_data":{"datasource":"23__table","viz_type":"echarts_timeseries_bar","slice_id":204,"x_axis":"video_name_with_location","time_grain_sqla":"P1M","x_axis_sort_asc":true,"x_axis_sort_series":"name","x_axis_sort_series_ascending":true,"metrics":[{"aggregate":null,"column":null,"datasourceWarning":false,"expressionType":"SQL","hasCustomLabel":true,"label":"Partial
-  views","optionName":"metric_vw56yidojpl_5lfi6gz2u79","sqlExpression":"rand() % 20"},{"aggregate":null,"column":null,"datasourceWarning":false,"expressionType":"SQL","hasCustomLabel":true,"label":"Full
-  views","optionName":"metric_dwlfxsuu7da_ja3w75iht7","sqlExpression":"rand() % 10"}],"groupby":[],"adhoc_filters":[{"clause":"WHERE","comparator":"No
-  filter","expressionType":"SIMPLE","operator":"TEMPORAL_RANGE","subject":"emission_time"}],"order_desc":true,"row_limit":10000,"truncate_metric":true,"show_empty_columns":true,"comparison_type":"values","annotation_layers":[],"forecastPeriods":10,"forecastInterval":0.8,"orientation":"vertical","x_axis_title_margin":15,"y_axis_title":"Number
-  of learners","y_axis_title_margin":30,"y_axis_title_position":"Left","sort_series_type":"sum","color_scheme":"supersetColors","only_total":true,"zoomable":true,"show_legend":true,"legendType":"scroll","legendOrientation":"top","x_axis_time_format":"smart_date","xAxisLabelRotation":45,"y_axis_format":"SMART_NUMBER","y_axis_bounds":[null,null],"rich_tooltip":true,"tooltipTimeFormat":"smart_date","extra_form_data":{},"dashboards":[16],"force":false,"result_format":"json","result_type":"full"},"result_format":"json","result_type":"full"}'
+query_context: '{"datasource":{"id":557,"type":"table"},"force":false,"queries":[{"filters":[],"extras":{"time_grain_sqla":"P1M","having":"","where":""},"applied_time_extras":{},"columns":[{"timeGrain":"P1M","columnType":"BASE_AXIS","sqlExpression":"video_name_with_location","label":"video_name_with_location","expressionType":"SQL"}],"metrics":[{"expressionType":"SQL","sqlExpression":"countIf(not
+  watched_entire_video)","column":null,"aggregate":null,"datasourceWarning":false,"hasCustomLabel":true,"label":"Partial
+  views","optionName":"metric_vw56yidojpl_5lfi6gz2u79"},{"expressionType":"SQL","sqlExpression":"countIf(watched_entire_video)","column":null,"aggregate":null,"datasourceWarning":false,"hasCustomLabel":true,"label":"Full
+  views","optionName":"metric_dwlfxsuu7da_ja3w75iht7"}],"orderby":[[{"expressionType":"SQL","sqlExpression":"countIf(not
+  watched_entire_video)","column":null,"aggregate":null,"datasourceWarning":false,"hasCustomLabel":true,"label":"Partial
+  views","optionName":"metric_vw56yidojpl_5lfi6gz2u79"},false]],"annotation_layers":[],"row_limit":10000,"series_columns":[],"series_limit":0,"order_desc":true,"url_params":{},"custom_params":{},"custom_form_data":{},"time_offsets":[],"post_processing":[{"operation":"pivot","options":{"index":["video_name_with_location"],"columns":[],"aggregates":{"Partial
+  views":{"operator":"mean"},"Full views":{"operator":"mean"}},"drop_missing_columns":false}},{"operation":"flatten"}]}],"form_data":{"datasource":"557__table","viz_type":"echarts_timeseries_bar","slice_id":1611,"x_axis":"video_name_with_location","time_grain_sqla":"P1M","x_axis_sort_asc":true,"x_axis_sort_series":"name","x_axis_sort_series_ascending":true,"metrics":[{"expressionType":"SQL","sqlExpression":"countIf(not
+  watched_entire_video)","column":null,"aggregate":null,"datasourceWarning":false,"hasCustomLabel":true,"label":"Partial
+  views","optionName":"metric_vw56yidojpl_5lfi6gz2u79"},{"expressionType":"SQL","sqlExpression":"countIf(watched_entire_video)","column":null,"aggregate":null,"datasourceWarning":false,"hasCustomLabel":true,"label":"Full
+  views","optionName":"metric_dwlfxsuu7da_ja3w75iht7"}],"groupby":[],"adhoc_filters":[],"order_desc":true,"row_limit":10000,"truncate_metric":true,"show_empty_columns":true,"comparison_type":"values","annotation_layers":[],"forecastPeriods":10,"forecastInterval":0.8,"orientation":"vertical","x_axis_title_margin":15,"y_axis_title":"Number
+  of learners","y_axis_title_margin":30,"y_axis_title_position":"Left","sort_series_type":"sum","color_scheme":"supersetColors","only_total":true,"zoomable":true,"show_legend":true,"legendType":"scroll","legendOrientation":"top","x_axis_time_format":"smart_date","xAxisLabelRotation":45,"y_axis_format":"SMART_NUMBER","truncateXAxis":true,"y_axis_bounds":[null,null],"rich_tooltip":true,"tooltipTimeFormat":"smart_date","extra_form_data":{},"dashboards":[3612],"force":false,"result_format":"json","result_type":"full"},"result_format":"json","result_type":"full"}'
 slice_name: Partial and full views per video
-uuid: 14c5cd80-cb50-4136-9911-d77da1737d69
+uuid: bfffb9fe-07bd-4b2f-b437-522d45f6cd2c
 version: 1.0.0
 viz_type: echarts_timeseries_bar

--- a/tutoraspects/templates/aspects/build/aspects-superset/openedx-assets/assets/charts/Video_views_by_section_subsection.yaml
+++ b/tutoraspects/templates/aspects/build/aspects-superset/openedx-assets/assets/charts/Video_views_by_section_subsection.yaml
@@ -12,6 +12,7 @@ params:
     operator: TEMPORAL_RANGE
     subject: emission_time
   all_columns: []
+  annotation_layers: []
   color_pn: true
   conditional_formatting: []
   extra_form_data: {}

--- a/tutoraspects/templates/aspects/build/aspects-superset/openedx-assets/assets/dashboards/Course_Dashboard_V1.yaml
+++ b/tutoraspects/templates/aspects/build/aspects-superset/openedx-assets/assets/dashboards/Course_Dashboard_V1.yaml
@@ -12,7 +12,6 @@ metadata:
       crossFilters:
         chartsInScope:
         - 682
-        - 1611
         - 1613
         - 1655
         - 1768
@@ -28,36 +27,14 @@ metadata:
         - 1921
         - 1941
         - 1962
+        - 1986
         scope: global
       id: 1589
-    '1611':
-      crossFilters:
-        chartsInScope:
-        - 682
-        - 1589
-        - 1613
-        - 1655
-        - 1768
-        - 1783
-        - 1792
-        - 1805
-        - 1807
-        - 1826
-        - 1839
-        - 1846
-        - 1871
-        - 1901
-        - 1921
-        - 1941
-        - 1962
-        scope: global
-      id: 1611
     '1613':
       crossFilters:
         chartsInScope:
         - 682
         - 1589
-        - 1611
         - 1655
         - 1768
         - 1783
@@ -72,6 +49,7 @@ metadata:
         - 1921
         - 1941
         - 1962
+        - 1986
         scope: global
       id: 1613
     '1768':
@@ -79,7 +57,6 @@ metadata:
         chartsInScope:
         - 682
         - 1589
-        - 1611
         - 1613
         - 1655
         - 1783
@@ -94,6 +71,7 @@ metadata:
         - 1921
         - 1941
         - 1962
+        - 1986
         scope: global
       id: 1768
     '1783':
@@ -101,7 +79,6 @@ metadata:
         chartsInScope:
         - 682
         - 1589
-        - 1611
         - 1613
         - 1655
         - 1768
@@ -116,6 +93,7 @@ metadata:
         - 1921
         - 1941
         - 1962
+        - 1986
         scope: global
       id: 1783
     '1792':
@@ -123,7 +101,6 @@ metadata:
         chartsInScope:
         - 682
         - 1589
-        - 1611
         - 1613
         - 1655
         - 1768
@@ -138,6 +115,7 @@ metadata:
         - 1921
         - 1941
         - 1962
+        - 1986
         scope: global
       id: 1792
     '1805':
@@ -145,7 +123,6 @@ metadata:
         chartsInScope:
         - 682
         - 1589
-        - 1611
         - 1613
         - 1655
         - 1768
@@ -160,6 +137,7 @@ metadata:
         - 1921
         - 1941
         - 1962
+        - 1986
         scope: global
       id: 1805
     '1826':
@@ -167,7 +145,6 @@ metadata:
         chartsInScope:
         - 682
         - 1589
-        - 1611
         - 1613
         - 1655
         - 1768
@@ -182,6 +159,7 @@ metadata:
         - 1921
         - 1941
         - 1962
+        - 1986
         scope: global
       id: 1826
     '1839':
@@ -189,7 +167,6 @@ metadata:
         chartsInScope:
         - 682
         - 1589
-        - 1611
         - 1613
         - 1655
         - 1768
@@ -204,6 +181,7 @@ metadata:
         - 1921
         - 1941
         - 1962
+        - 1986
         scope: global
       id: 1839
     '1871':
@@ -211,7 +189,6 @@ metadata:
         chartsInScope:
         - 682
         - 1589
-        - 1611
         - 1613
         - 1655
         - 1768
@@ -226,6 +203,7 @@ metadata:
         - 1921
         - 1941
         - 1962
+        - 1986
         scope: global
       id: 1871
     '1901':
@@ -233,7 +211,6 @@ metadata:
         chartsInScope:
         - 682
         - 1589
-        - 1611
         - 1613
         - 1655
         - 1768
@@ -248,6 +225,7 @@ metadata:
         - 1921
         - 1941
         - 1962
+        - 1986
         scope: global
       id: 1901
     '1921':
@@ -255,7 +233,6 @@ metadata:
         chartsInScope:
         - 682
         - 1589
-        - 1611
         - 1613
         - 1655
         - 1768
@@ -270,6 +247,7 @@ metadata:
         - 1901
         - 1941
         - 1962
+        - 1986
         scope: global
       id: 1921
     '1941':
@@ -277,7 +255,6 @@ metadata:
         chartsInScope:
         - 682
         - 1589
-        - 1611
         - 1613
         - 1655
         - 1768
@@ -292,6 +269,7 @@ metadata:
         - 1901
         - 1921
         - 1962
+        - 1986
         scope: global
       id: 1941
     '1962':
@@ -299,7 +277,6 @@ metadata:
         chartsInScope:
         - 682
         - 1589
-        - 1611
         - 1613
         - 1655
         - 1768
@@ -314,8 +291,31 @@ metadata:
         - 1901
         - 1921
         - 1941
+        - 1986
         scope: global
       id: 1962
+    '1986':
+      crossFilters:
+        chartsInScope:
+        - 682
+        - 1589
+        - 1613
+        - 1655
+        - 1768
+        - 1783
+        - 1792
+        - 1805
+        - 1807
+        - 1826
+        - 1839
+        - 1846
+        - 1871
+        - 1901
+        - 1921
+        - 1941
+        - 1962
+        scope: global
+      id: 1986
   color_scheme: supersetColors
   color_scheme_domain:
   - '#1FA8C9'
@@ -345,7 +345,6 @@ metadata:
     chartsInScope:
     - 682
     - 1589
-    - 1611
     - 1613
     - 1655
     - 1768
@@ -361,6 +360,7 @@ metadata:
     - 1921
     - 1941
     - 1962
+    - 1986
     scope:
       excluded: []
       rootPath:
@@ -660,18 +660,12 @@ metadata:
     type: NATIVE_FILTER
   refresh_frequency: 0
   shared_label_colors:
-    All pages viewed: '#8FD3E4'
     All videos viewed: '#5AC189'
-    At least one page viewed: '#3CCCCB'
     At least one video viewed: '#1FA8C9'
     Full views: '#454E7C'
-    Number of Learners: '#FCC700'
     Partial views: '#666666'
     Repeat Views: '#A868B7'
-    Total Learners: '#A38F79'
-    Total Views: '#ACE1C4'
     Unique Viewers: '#FF7F44'
-    audit: '#E04355'
   timed_refresh_immune_slices: []
 position:
   CHART-Q6nr6irIdz:
@@ -691,24 +685,6 @@ position:
     - TABS-nk8aeLmc5o
     - TAB-V5zNdxwhsP
     - ROW-ToSAm6kqA2
-    type: CHART
-  CHART-_BfZOEhMVM:
-    children: []
-    id: CHART-_BfZOEhMVM
-    meta:
-      chartId: 1611
-      height: 71
-      sliceName: Partial and full views per video
-      uuid: 14c5cd80-cb50-4136-9911-d77da1737d69
-      width: 12
-    parents:
-    - ROOT_ID
-    - GRID_ID
-    - TABS-UDkdlBRw4n
-    - TAB-_Ey4nPhFr
-    - TABS-nk8aeLmc5o
-    - TAB-V5zNdxwhsP
-    - ROW-vpQpToPQb
     type: CHART
   CHART-explore-185-1:
     children: []
@@ -920,14 +896,18 @@ position:
     id: CHART-explore-1962-1
     meta:
       chartId: 1962
-      height: 50
+      height: 41
       sliceName: Video views by section/subsection
       uuid: c8c363f8-8dbc-4a78-841d-4976f4404884
       width: 12
     parents:
     - ROOT_ID
     - GRID_ID
-    - ROW-_A28qByD8
+    - TABS-UDkdlBRw4n
+    - TAB-_Ey4nPhFr
+    - TABS-nk8aeLmc5o
+    - TAB-V5zNdxwhsP
+    - ROW-jK8rH2uIlm
     type: CHART
   CHART-explore-197-1:
     children: []
@@ -962,6 +942,20 @@ position:
     - TABS-nk8aeLmc5o
     - TAB-vze5iq6jg
     - ROW-7xndTh8hI
+    type: CHART
+  CHART-explore-1986-1:
+    children: []
+    id: CHART-explore-1986-1
+    meta:
+      chartId: 1986
+      height: 72
+      sliceName: Partial and full views per video
+      uuid: bfffb9fe-07bd-4b2f-b437-522d45f6cd2c
+      width: 12
+    parents:
+    - ROOT_ID
+    - GRID_ID
+    - ROW-RNW6Zgx_Nb
     type: CHART
   CHART-explore-205-1:
     children: []
@@ -1106,6 +1100,20 @@ position:
     - TABS-nk8aeLmc5o
     - TAB-vze5iq6jg
     type: ROW
+  ROW-9mTVb6PMP:
+    children:
+    - CHART-explore-1986-1
+    id: ROW-9mTVb6PMP
+    meta:
+      background: BACKGROUND_TRANSPARENT
+    parents:
+    - ROOT_ID
+    - GRID_ID
+    - TABS-UDkdlBRw4n
+    - TAB-_Ey4nPhFr
+    - TABS-nk8aeLmc5o
+    - TAB-V5zNdxwhsP
+    type: ROW
   ROW-CHCrAJpP5:
     children:
     - CHART-explore-1921-1
@@ -1243,20 +1251,6 @@ position:
     - TABS-nk8aeLmc5o
     - TAB-nqLFUR_Tg
     type: ROW
-  ROW-vpQpToPQb:
-    children:
-    - CHART-_BfZOEhMVM
-    id: ROW-vpQpToPQb
-    meta:
-      background: BACKGROUND_TRANSPARENT
-    parents:
-    - ROOT_ID
-    - GRID_ID
-    - TABS-UDkdlBRw4n
-    - TAB-_Ey4nPhFr
-    - TABS-nk8aeLmc5o
-    - TAB-V5zNdxwhsP
-    type: ROW
   TAB-4ptSkqs5MS:
     children:
     - ROW-EpJDdqK8c
@@ -1287,7 +1281,7 @@ position:
     children:
     - ROW-TNGl9z7XZ
     - ROW-jK8rH2uIlm
-    - ROW-vpQpToPQb
+    - ROW-9mTVb6PMP
     - ROW-ToSAm6kqA2
     id: TAB-V5zNdxwhsP
     meta:

--- a/tutoraspects/templates/aspects/build/aspects-superset/openedx-assets/assets/datasets/fact_pageview_engagement.yaml
+++ b/tutoraspects/templates/aspects/build/aspects-superset/openedx-assets/assets/datasets/fact_pageview_engagement.yaml
@@ -3,6 +3,30 @@ always_filter_main_dttm: false
 cache_timeout: null
 columns:
 - advanced_data_type: null
+  column_name: subsection_with_name
+  description: null
+  expression: ''
+  extra: null
+  filterable: true
+  groupby: true
+  is_active: true
+  is_dttm: false
+  python_date_format: null
+  type: String
+  verbose_name: Subsection With Name
+- advanced_data_type: null
+  column_name: section_with_name
+  description: null
+  expression: ''
+  extra: null
+  filterable: true
+  groupby: true
+  is_active: true
+  is_dttm: false
+  python_date_format: null
+  type: String
+  verbose_name: Section With Name
+- advanced_data_type: null
   column_name: section/subsection page engagement
   description: null
   expression: ''

--- a/tutoraspects/templates/aspects/build/aspects-superset/openedx-assets/assets/datasets/fact_video_engagement.yaml
+++ b/tutoraspects/templates/aspects/build/aspects-superset/openedx-assets/assets/datasets/fact_video_engagement.yaml
@@ -15,6 +15,30 @@ columns:
   type: String
   verbose_name: null
 - advanced_data_type: null
+  column_name: subsection_with_name
+  description: null
+  expression: null
+  extra: null
+  filterable: true
+  groupby: true
+  is_active: true
+  is_dttm: false
+  python_date_format: null
+  type: String
+  verbose_name: Subsection Name
+- advanced_data_type: null
+  column_name: section_with_name
+  description: null
+  expression: null
+  extra: null
+  filterable: true
+  groupby: true
+  is_active: true
+  is_dttm: false
+  python_date_format: null
+  type: String
+  verbose_name: Section Name
+- advanced_data_type: null
   column_name: section/subsection name
   description: null
   expression: null

--- a/tutoraspects/templates/aspects/build/aspects-superset/openedx-assets/assets/datasets/fact_video_plays.yaml
+++ b/tutoraspects/templates/aspects/build/aspects-superset/openedx-assets/assets/datasets/fact_video_plays.yaml
@@ -27,6 +27,30 @@ columns:
   type: Decimal(9, 2)
   verbose_name: Video Position
 - advanced_data_type: null
+  column_name: subsection_with_name
+  description: null
+  expression: ''
+  extra: null
+  filterable: true
+  groupby: true
+  is_active: true
+  is_dttm: false
+  python_date_format: null
+  type: String
+  verbose_name: Subsection With Name
+- advanced_data_type: null
+  column_name: section_with_name
+  description: null
+  expression: ''
+  extra: null
+  filterable: true
+  groupby: true
+  is_active: true
+  is_dttm: false
+  python_date_format: null
+  type: String
+  verbose_name: Section With Name
+- advanced_data_type: null
   column_name: video_duration
   description: null
   expression: ''
@@ -158,30 +182,6 @@ columns:
   python_date_format: null
   type: String
   verbose_name: Organization
-- advanced_data_type: null
-  column_name: subsection_with_name
-  description: null
-  expression: ''
-  extra: null
-  filterable: true
-  groupby: true
-  is_active: true
-  is_dttm: false
-  python_date_format: null
-  type: String
-  verbose_name: Subsection With Name
-- advanced_data_type: null
-  column_name: section_with_name
-  description: null
-  expression: ''
-  extra: null
-  filterable: true
-  groupby: true
-  is_active: true
-  is_dttm: false
-  python_date_format: null
-  type: String
-  verbose_name: Section With Name
 - advanced_data_type: null
   column_name: video_link
   description: null

--- a/tutoraspects/templates/aspects/build/aspects-superset/openedx-assets/assets/datasets/fact_video_watches.yaml
+++ b/tutoraspects/templates/aspects/build/aspects-superset/openedx-assets/assets/datasets/fact_video_watches.yaml
@@ -1,4 +1,5 @@
 _file_name: fact_video_watches.yaml
+always_filter_main_dttm: false
 cache_timeout: null
 columns:
 - advanced_data_type: null
@@ -97,6 +98,30 @@ columns:
   python_date_format: null
   type: String
   verbose_name: Video Name
+- advanced_data_type: null
+  column_name: subsection_with_name
+  description: null
+  expression: null
+  extra: null
+  filterable: true
+  groupby: true
+  is_active: true
+  is_dttm: false
+  python_date_format: null
+  type: String
+  verbose_name: Subsection Name
+- advanced_data_type: null
+  column_name: section_with_name
+  description: null
+  expression: null
+  extra: null
+  filterable: true
+  groupby: true
+  is_active: true
+  is_dttm: false
+  python_date_format: null
+  type: String
+  verbose_name: Section Name
 - advanced_data_type: null
   column_name: org
   description: null

--- a/tutoraspects/templates/openedx-assets/queries/fact_pageview_engagement.sql
+++ b/tutoraspects/templates/openedx-assets/queries/fact_pageview_engagement.sql
@@ -8,7 +8,7 @@ with
             subsection_with_name,
             actor_id,
             page_count,
-            COUNT(DISTINCT block_id) as pages_visited,
+            count(distinct block_id) as pages_visited,
             case
                 when pages_visited = 0
                 then 'No pages viewed yet'
@@ -20,12 +20,8 @@ with
         where
             1 = 1
             {% raw %}
-            {% if from_dttm %}
-                and visited_on > date('{{ from_dttm }}')
-            {% endif %}
-            {% if to_dttm %}
-                and visited_on < date('{{ to_dttm }}')
-            {% endif %}
+            {% if from_dttm %} and visited_on > date('{{ from_dttm }}') {% endif %}
+            {% if to_dttm %} and visited_on < date('{{ to_dttm }}') {% endif %}
             {% endraw %}
             {% include 'openedx-assets/queries/common_filters.sql' %}
         group by
@@ -43,6 +39,7 @@ with
             course_key,
             course_run,
             section_with_name,
+            '' as subsection_with_name,
             actor_id,
             sum(page_count) as page_count,
             sum(pages_visited) as pages_visited,
@@ -54,13 +51,21 @@ with
                 else 'At least one page viewed'
             end as engagement_level
         from subsection_counts
-        group by org, course_key, course_run, section_with_name, actor_id
+        group by
+            org,
+            course_key,
+            course_run,
+            section_with_name,
+            subsection_with_name,
+            actor_id
     )
 
 select
     org,
     course_key,
     course_run,
+    section_with_name as section_with_name,
+    subsection_with_name as subsection_with_name,
     subsection_with_name as `section/subsection name`,
     'subsection' as `content level`,
     actor_id as actor_id,
@@ -71,6 +76,8 @@ select
     org,
     course_key,
     course_run,
+    section_with_name as section_with_name,
+    subsection_with_name as subsection_with_name,
     section_with_name as `section/subsection name`,
     'section' as `content level`,
     actor_id as actor_id,

--- a/tutoraspects/templates/openedx-assets/queries/fact_video_watches.sql
+++ b/tutoraspects/templates/openedx-assets/queries/fact_video_watches.sql
@@ -1,12 +1,15 @@
-with watched_segments as (
-    {% include 'openedx-assets/queries/fact_watched_video_segments.sql' %}
-)
+with
+    watched_segments as (
+        {% include 'openedx-assets/queries/fact_watched_video_segments.sql' %}
+    )
 
 select
     org,
     course_key,
     course_name,
     course_run,
+    section_with_name,
+    subsection_with_name,
     video_name,
     video_name_with_location,
     actor_id,
@@ -14,11 +17,23 @@ select
     (video_duration - 10) / 5 as video_segment_count,
     video_segment_count <= watched_segment_count as watched_entire_video
 from watched_segments
+where
+    1 = 1
+    {% raw %}
+    {% if filter_values("Section Name") != [] %}
+        and section_with_name in {{ filter_values("Section Name") | where_in }}
+    {% endif %}
+    {% if filter_values("Subsection Name") != [] %}
+        and subsection_with_name in {{ filter_values("Subsection Name") | where_in }}
+    {% endif %}
+    {% endraw %}
 group by
     org,
     course_key,
     course_name,
     course_run,
+    section_with_name,
+    subsection_with_name,
     video_name,
     video_name_with_location,
     actor_id,

--- a/tutoraspects/templates/openedx-assets/queries/fact_watched_video_segments.sql
+++ b/tutoraspects/templates/openedx-assets/queries/fact_watched_video_segments.sql
@@ -1,75 +1,87 @@
-with video_events as (
-    select
-        emission_time,
-        org,
-        course_key,
-        splitByString('/xblock/', object_id)[-1] as video_id,
-        actor_id,
-        verb_id,
-        video_position,
-        video_duration
-    from {{ ASPECTS_XAPI_DATABASE }}.video_playback_events
-    where 1=1
-    {% include 'openedx-assets/queries/common_filters.sql' %}
-), starts as (
-    select *
-    from video_events
-    where verb_id = 'https://w3id.org/xapi/video/verbs/played'
-), ends as (
-    select *
-    from video_events
-    where
-        verb_id in (
-            'http://adlnet.gov/expapi/verbs/completed',
-            'https://w3id.org/xapi/video/verbs/seeked',
-            'https://w3id.org/xapi/video/verbs/paused',
-            'http://adlnet.gov/expapi/verbs/terminated'
-        )
-), segments as(
-    select
-        starts.org as org,
-        starts.course_key as course_key,
-        starts.video_id as video_id,
-        starts.actor_id,
-        cast(starts.video_position as Int32) as start_position,
-        cast(ends.video_position as Int32) as end_position,
-        starts.emission_time as started_at,
-        ends.emission_time as ended_at,
-        ends.verb_id as end_type,
-        starts.video_duration as video_duration
-    from
-        starts
-        left asof join ends
-            on (starts.org = ends.org
+with
+    video_events as (
+        select
+            emission_time,
+            org,
+            course_key,
+            splitbystring('/xblock/', object_id)[-1] as video_id,
+            actor_id,
+            verb_id,
+            video_position,
+            video_duration
+        from {{ ASPECTS_XAPI_DATABASE }}.video_playback_events
+        where 1 = 1 {% include 'openedx-assets/queries/common_filters.sql' %}
+    ),
+    starts as (
+        select *
+        from video_events
+        where verb_id = 'https://w3id.org/xapi/video/verbs/played'
+    ),
+    ends as (
+        select *
+        from video_events
+        where
+            verb_id in (
+                'http://adlnet.gov/expapi/verbs/completed',
+                'https://w3id.org/xapi/video/verbs/seeked',
+                'https://w3id.org/xapi/video/verbs/paused',
+                'http://adlnet.gov/expapi/verbs/terminated'
+            )
+    ),
+    segments as (
+        select
+            starts.org as org,
+            starts.course_key as course_key,
+            starts.video_id as video_id,
+            starts.actor_id,
+            cast(starts.video_position as int32) as start_position,
+            cast(ends.video_position as int32) as end_position,
+            starts.emission_time as started_at,
+            ends.emission_time as ended_at,
+            ends.verb_id as end_type,
+            starts.video_duration as video_duration
+        from starts left
+        asof join
+            ends
+            on (
+                starts.org = ends.org
                 and starts.course_key = ends.course_key
                 and starts.video_id = ends.video_id
                 and starts.actor_id = ends.actor_id
-                and starts.emission_time < ends.emission_time)
-), enriched_segments as (
-    select
-        segments.org as org,
-        segments.course_key as course_key,
-        blocks.course_name as course_name,
-        blocks.course_run as course_run,
-        blocks.block_name as video_name,
-        blocks.display_name_with_location as video_name_with_location,
-        segments.actor_id as actor_id,
-        segments.started_at as started_at,
-        segments.start_position - (segments.start_position % 5) as start_position,
-        segments.end_position - (segments.end_position % 5) as end_position,
-        segments.video_duration as video_duration
-    from
-        segments
-        join {{ DBT_PROFILE_TARGET_DATABASE }}.dim_course_blocks blocks
-            on (segments.course_key = blocks.course_key
-                and segments.video_id = blocks.block_id)
-)
+                and starts.emission_time < ends.emission_time
+            )
+    ),
+    enriched_segments as (
+        select
+            segments.org as org,
+            segments.course_key as course_key,
+            blocks.course_name as course_name,
+            blocks.course_run as course_run,
+            blocks.section_with_name as section_with_name,
+            blocks.subsection_with_name as subsection_with_name,
+            blocks.block_name as video_name,
+            blocks.display_name_with_location as video_name_with_location,
+            segments.actor_id as actor_id,
+            segments.started_at as started_at,
+            segments.start_position - (segments.start_position % 5) as start_position,
+            segments.end_position - (segments.end_position % 5) as end_position,
+            segments.video_duration as video_duration
+        from segments
+        join
+            {{ DBT_PROFILE_TARGET_DATABASE }}.dim_course_blocks_extended blocks
+            on (
+                segments.course_key = blocks.course_key
+                and segments.video_id = blocks.block_id
+            )
+    )
 
 select
     org,
     course_key,
     course_name,
     course_run,
+    section_with_name,
+    subsection_with_name,
     video_name,
     video_name_with_location,
     actor_id,
@@ -77,13 +89,3 @@ select
     arrayJoin(range(start_position, end_position, 5)) as segment_start,
     video_duration
 from enriched_segments
-where
-    {% raw %}
-    {% if get_filters('video_name_with_location', remove_filter=True) == [] %}
-    1=1
-    {% elif filter_values('video_name_with_location') != [] %}
-    video_name_with_location in {{ filter_values('video_name_with_location') | where_in }}
-    {% else %}
-    1=0
-    {% endif %}
-    {% endraw %}


### PR DESCRIPTION
This change ensures that charts display the expected behavior for various filters applied in the course dashboard. This includes:
- all video charts responding to section and subsection filters
- the page view engagement chart applies section and subsection filters
- the partial and full video views chart uses the correct dataset in addition to using the appropriate filters

This change also includes edits made by running `sqlfmt` on changed SQL files.