### PR TITLE
chore: Bump platform-plugin-aspect to 0.9.1

### DIFF
--- a/tutoraspects/patches/openedx-dev-dockerfile-post-python-requirements
+++ b/tutoraspects/patches/openedx-dev-dockerfile-post-python-requirements
@@ -1,5 +1,5 @@
 RUN --mount=type=cache,target=/openedx/.cache/pip,sharing=shared \
-    pip install "platform-plugin-aspects==v0.9.0"
+    pip install "platform-plugin-aspects==v0.9.1"
 
 RUN --mount=type=cache,target=/openedx/.cache/pip,sharing=shared \
     pip install "edx-event-routing-backends==v9.0.1"

--- a/tutoraspects/patches/openedx-dockerfile-post-python-requirements
+++ b/tutoraspects/patches/openedx-dockerfile-post-python-requirements
@@ -1,5 +1,5 @@
 RUN --mount=type=cache,target=/openedx/.cache/pip,sharing=shared \
-    pip install "platform-plugin-aspects==v0.9.0"
+    pip install "platform-plugin-aspects==v0.9.1"
 
 RUN --mount=type=cache,target=/openedx/.cache/pip,sharing=shared \
     pip install "edx-event-routing-backends==v9.0.1"


### PR DESCRIPTION
This has a fix for xblock imports in pre-quince deployments.