### PR TITLE
fix: show correct value on watched segments x-axis (FC-0051)

### DIFF
--- a/tutoraspects/templates/aspects/build/aspects-superset/openedx-assets/assets/charts/Watched_Video_Segments.yaml
+++ b/tutoraspects/templates/aspects/build/aspects-superset/openedx-assets/assets/charts/Watched_Video_Segments.yaml
@@ -43,25 +43,25 @@ params:
   truncate_metric: true
   viz_type: echarts_timeseries_bar
   xAxisForceCategorical: true
-  x_axis: start_position
+  xAxisLabelRotation: 45
+  x_axis: segment_start
   x_axis_sort_asc: true
   x_axis_sort_series: name
   x_axis_sort_series_ascending: true
   x_axis_time_format: smart_date
-  x_axis_title: Number of Views
-  x_axis_title_margin: 30
+  x_axis_title: Video Timestamp (in seconds)
+  x_axis_title_margin: 50
   y_axis_bounds:
   - null
   - null
   y_axis_format: SMART_NUMBER
-  y_axis_title: Video Timestamp (in seconds)
+  y_axis_title: Number of Views
   y_axis_title_margin: 30
   y_axis_title_position: Left
   zoomable: true
 query_context: '{"datasource":{"id":103,"type":"table"},"force":false,"queries":[{"filters":[{"col":"started_at","op":"TEMPORAL_RANGE","val":"No
-  filter"}],"extras":{"time_grain_sqla":"P1M","having":"","where":""},"applied_time_extras":{},"columns":[{"timeGrain":"P1M","columnType":"BASE_AXIS","sqlExpression":"start_position","label":"start_position","expressionType":"SQL"}],"metrics":["total_views","repeat_views"],"orderby":[["total_views",false]],"annotation_layers":[],"row_limit":10000,"series_columns":[],"series_limit":0,"order_desc":true,"url_params":{},"custom_params":{},"custom_form_data":{},"time_offsets":[],"post_processing":[{"operation":"pivot","options":{"index":["start_position"],"columns":[],"aggregates":{"total_views":{"operator":"mean"},"repeat_views":{"operator":"mean"}},"drop_missing_columns":false}},{"operation":"flatten"}]}],"form_data":{"datasource":"103__table","viz_type":"echarts_timeseries_bar","slice_id":186,"x_axis":"start_position","time_grain_sqla":"P1M","xAxisForceCategorical":true,"x_axis_sort_asc":true,"x_axis_sort_series":"name","x_axis_sort_series_ascending":true,"metrics":["total_views","repeat_views"],"groupby":[],"adhoc_filters":[{"expressionType":"SIMPLE","subject":"started_at","operator":"TEMPORAL_RANGE","comparator":"No
-  filter","clause":"WHERE","sqlExpression":null,"isExtra":false,"isNew":false,"datasourceWarning":false,"filterOptionName":"filter_kpkhcnms3c_m156a9ez5ga"}],"order_desc":true,"row_limit":10000,"truncate_metric":true,"show_empty_columns":true,"comparison_type":"values","annotation_layers":[],"forecastPeriods":10,"forecastInterval":0.8,"orientation":"vertical","x_axis_title":"Number
-  of Views","x_axis_title_margin":30,"y_axis_title":"Video Timestamp (in seconds)","y_axis_title_margin":30,"y_axis_title_position":"Left","sort_series_type":"sum","color_scheme":"supersetColors","stack":"Stack","only_total":true,"zoomable":true,"show_legend":true,"legendType":"scroll","legendOrientation":"top","x_axis_time_format":"smart_date","y_axis_format":"SMART_NUMBER","truncateXAxis":true,"y_axis_bounds":[null,null],"rich_tooltip":true,"tooltipTimeFormat":"smart_date","extra_form_data":{},"dashboards":[43,42],"force":false,"result_format":"json","result_type":"full"},"result_format":"json","result_type":"full"}'
+  filter"}],"extras":{"time_grain_sqla":"P1M","having":"","where":""},"applied_time_extras":{},"columns":[{"timeGrain":"P1M","columnType":"BASE_AXIS","sqlExpression":"segment_start","label":"segment_start","expressionType":"SQL"}],"metrics":["total_views","repeat_views"],"orderby":[["total_views",false]],"annotation_layers":[],"row_limit":10000,"series_columns":[],"series_limit":0,"order_desc":true,"url_params":{},"custom_params":{},"custom_form_data":{},"time_offsets":[],"post_processing":[{"operation":"pivot","options":{"index":["segment_start"],"columns":[],"aggregates":{"total_views":{"operator":"mean"},"repeat_views":{"operator":"mean"}},"drop_missing_columns":false}},{"operation":"flatten"}]}],"form_data":{"datasource":"103__table","viz_type":"echarts_timeseries_bar","slice_id":186,"x_axis":"segment_start","time_grain_sqla":"P1M","xAxisForceCategorical":true,"x_axis_sort_asc":true,"x_axis_sort_series":"name","x_axis_sort_series_ascending":true,"metrics":["total_views","repeat_views"],"groupby":[],"adhoc_filters":[{"expressionType":"SIMPLE","subject":"started_at","operator":"TEMPORAL_RANGE","comparator":"No
+  filter","clause":"WHERE","sqlExpression":null,"isExtra":false,"isNew":false,"datasourceWarning":false,"filterOptionName":"filter_kpkhcnms3c_m156a9ez5ga"}],"order_desc":true,"row_limit":10000,"truncate_metric":true,"show_empty_columns":true,"comparison_type":"values","annotation_layers":[],"forecastPeriods":10,"forecastInterval":0.8,"orientation":"vertical","x_axis_title":"Video Timestamp (in seconds)","x_axis_title_margin":50,"y_axis_title":"Number of Views","y_axis_title_margin":30,"y_axis_title_position":"Left","sort_series_type":"sum","color_scheme":"supersetColors","stack":"Stack","only_total":true,"zoomable":true,"show_legend":true,"legendType":"scroll","legendOrientation":"top","x_axis_time_format":"smart_date","xAxisLabelRotation":45,"y_axis_format":"SMART_NUMBER","truncateXAxis":true,"y_axis_bounds":[null,null],"rich_tooltip":true,"tooltipTimeFormat":"smart_date","extra_form_data":{},"dashboards":[43,42],"force":false,"result_format":"json","result_type":"full"},"result_format":"json","result_type":"full"}'
 slice_name: Watched Video Segments
 uuid: 2985a9db-c338-4008-af52-2930b81ee2e5
 version: 1.0.0

--- a/tutoraspects/templates/aspects/build/aspects-superset/openedx-assets/assets/charts/Watched_Video_Segments_at-risk.yaml
+++ b/tutoraspects/templates/aspects/build/aspects-superset/openedx-assets/assets/charts/Watched_Video_Segments_at-risk.yaml
@@ -36,22 +36,25 @@ params:
   truncateXAxis: true
   truncate_metric: true
   viz_type: echarts_timeseries_bar
+  xAxisForceCategorical: true
   xAxisLabelRotation: 45
   x_axis: segment_start
   x_axis_sort_asc: true
   x_axis_sort_series: name
   x_axis_sort_series_ascending: true
   x_axis_time_format: smart_date
-  x_axis_title_margin: 15
+  x_axis_title: Video Timestamp (in seconds)
+  x_axis_title_margin: 50
   y_axis_bounds:
   - null
   - null
   y_axis_format: SMART_NUMBER
-  y_axis_title_margin: 15
+  y_axis_title: Number of Views
+  y_axis_title_margin: 30
   y_axis_title_position: Left
 query_context: '{"datasource":{"id":1299,"type":"table"},"force":false,"queries":[{"filters":[{"col":"started_at","op":"TEMPORAL_RANGE","val":"No
-  filter"}],"extras":{"time_grain_sqla":"P1D","having":"","where":""},"applied_time_extras":{},"columns":[{"timeGrain":"P1D","columnType":"BASE_AXIS","sqlExpression":"segment_start","label":"segment_start","expressionType":"SQL"}],"metrics":["unique_viewers","repeat_views"],"orderby":[["unique_viewers",false]],"annotation_layers":[],"row_limit":10000,"series_columns":[],"series_limit":0,"order_desc":true,"url_params":{},"custom_params":{},"custom_form_data":{},"time_offsets":[],"post_processing":[{"operation":"pivot","options":{"index":["segment_start"],"columns":[],"aggregates":{"unique_viewers":{"operator":"mean"},"repeat_views":{"operator":"mean"}},"drop_missing_columns":false}},{"operation":"flatten"}]}],"form_data":{"datasource":"1299__table","viz_type":"echarts_timeseries_bar","slice_id":2708,"x_axis":"segment_start","time_grain_sqla":"P1D","x_axis_sort_asc":true,"x_axis_sort_series":"name","x_axis_sort_series_ascending":true,"metrics":["unique_viewers","repeat_views"],"groupby":[],"adhoc_filters":[{"clause":"WHERE","comparator":"No
-  filter","expressionType":"SIMPLE","operator":"TEMPORAL_RANGE","subject":"started_at"}],"order_desc":true,"row_limit":10000,"truncate_metric":true,"show_empty_columns":true,"comparison_type":"values","annotation_layers":[],"forecastPeriods":10,"forecastInterval":0.8,"orientation":"vertical","x_axis_title_margin":15,"y_axis_title_margin":15,"y_axis_title_position":"Left","sort_series_type":"sum","color_scheme":"supersetColors","only_total":true,"show_legend":true,"legendType":"scroll","legendOrientation":"top","x_axis_time_format":"smart_date","xAxisLabelRotation":45,"y_axis_format":"SMART_NUMBER","truncateXAxis":true,"y_axis_bounds":[null,null],"rich_tooltip":true,"tooltipTimeFormat":"smart_date","extra_form_data":{},"dashboards":[6096],"force":false,"result_format":"json","result_type":"full"},"result_format":"json","result_type":"full"}'
+  filter"}],"extras":{"time_grain_sqla":"P1D","having":"","where":""},"applied_time_extras":{},"columns":[{"timeGrain":"P1D","columnType":"BASE_AXIS","sqlExpression":"segment_start","label":"segment_start","expressionType":"SQL"}],"metrics":["unique_viewers","repeat_views"],"orderby":[["unique_viewers",false]],"annotation_layers":[],"row_limit":10000,"series_columns":[],"series_limit":0,"order_desc":true,"url_params":{},"custom_params":{},"custom_form_data":{},"time_offsets":[],"post_processing":[{"operation":"pivot","options":{"index":["segment_start"],"columns":[],"aggregates":{"unique_viewers":{"operator":"mean"},"repeat_views":{"operator":"mean"}},"drop_missing_columns":false}},{"operation":"flatten"}]}],"form_data":{"datasource":"1299__table","viz_type":"echarts_timeseries_bar","slice_id":2708,"x_axis":"segment_start","time_grain_sqla":"P1D","xAxisForceCategorical":true,"x_axis_sort_asc":true,"x_axis_sort_series":"name","x_axis_sort_series_ascending":true,"metrics":["unique_viewers","repeat_views"],"groupby":[],"adhoc_filters":[{"clause":"WHERE","comparator":"No
+  filter","expressionType":"SIMPLE","operator":"TEMPORAL_RANGE","subject":"started_at"}],"order_desc":true,"row_limit":10000,"truncate_metric":true,"show_empty_columns":true,"comparison_type":"values","annotation_layers":[],"forecastPeriods":10,"forecastInterval":0.8,"orientation":"vertical","x_axis_title":"Video Timestamp (in seconds)","x_axis_title_margin":50,"y_axis_title":"Number of Views","y_axis_title_margin":30,"y_axis_title_position":"Left","sort_series_type":"sum","color_scheme":"supersetColors","only_total":true,"show_legend":true,"legendType":"scroll","legendOrientation":"top","x_axis_time_format":"smart_date","xAxisLabelRotation":45,"y_axis_format":"SMART_NUMBER","truncateXAxis":true,"y_axis_bounds":[null,null],"rich_tooltip":true,"tooltipTimeFormat":"smart_date","extra_form_data":{},"dashboards":[6096],"force":false,"result_format":"json","result_type":"full"},"result_format":"json","result_type":"full"}'
 slice_name: Watched Video Segments (at-risk)
 uuid: a7947bdb-65a2-49ed-815e-850423bfeacc
 version: 1.0.0

--- a/tutoraspects/templates/aspects/build/aspects-superset/openedx-assets/assets/datasets/fact_watched_video_segments.yaml
+++ b/tutoraspects/templates/aspects/build/aspects-superset/openedx-assets/assets/datasets/fact_watched_video_segments.yaml
@@ -124,6 +124,18 @@ columns:
   type: String
   verbose_name: Segment Range
 - advanced_data_type: null
+  column_name: segment_start
+  description: null
+  expression: ''
+  extra: {}
+  filterable: true
+  groupby: true
+  is_active: true
+  is_dttm: false
+  python_date_format: null
+  type: String
+  verbose_name: Segment Start
+- advanced_data_type: null
   column_name: start_position
   description: null
   expression: null


### PR DESCRIPTION
This change prefers the `segment_start` field, which is the start time of the video segment watched by a learner.

Here is a screenshot, which also includes the new axis labels:
![Screenshot from 2024-05-09 17-02-04](https://github.com/openedx/tutor-contrib-aspects/assets/2566242/a3f3ad9a-eadd-4d58-9638-36c7d0b8cb10)

Before this change, the chart would have grouped each segment under "0"