### PR TITLE
fix: increase gunicorn keep alive to 5

### DIFF
--- a/tutoraspects/patches/k8s-deployments
+++ b/tutoraspects/patches/k8s-deployments
@@ -195,6 +195,8 @@ spec:
               value: "{{ REDIS_PASSWORD }}"
             - name: FLASK_ENV
               value: "production"
+            - name: GUNICORN_KEEPALIVE
+              value: '5'
             - name: SUPERSET_ENV
               value: "production"
             - name: SUPERSET_HOST


### PR DESCRIPTION
### Description

Some requests of superset in the dashboard UI were failing with the following caddy log:

`readfrom tcp 172.18.0.9:60208->172.18.0.8:8088: write tcp 172.18.0.9:60208->172.18.0.8:8088: use of closed network connection`

Keep in mind that this happening on HTTP 2 with Caddy which is the default tutor configuration. After further research/testing the solution was to increase `GUNICORN_KEEPALIVE` from 2 to 5, which is an environment variable that the default Superset deployment script supports: https://github.com/apache/superset/blob/26df7b4ad5c6c48bd1cc4a015c80cea56cb4d493/docker/run-server.sh#L30

After this change, all requests are successful to the Superset API.

