### PR TITLE
Remove JSON column from migrations

### DIFF
--- a/tutoraspects/templates/aspects/apps/aspects/migrations/alembic/versions/0002_raw_xapi_table.py
+++ b/tutoraspects/templates/aspects/apps/aspects/migrations/alembic/versions/0002_raw_xapi_table.py
@@ -11,11 +11,6 @@ engine = "ReplicatedMergeTree" if "{{CLICKHOUSE_CLUSTER_NAME}}" else "MergeTree"
 
 def upgrade():
     op.execute(
-        """
-        SET allow_experimental_object_type=1;
-        """
-    )
-    op.execute(
         f"""
         -- Raw table that Ralph writes to
         CREATE TABLE IF NOT EXISTS {{ ASPECTS_XAPI_DATABASE }}.{{ ASPECTS_RAW_XAPI_TABLE }}
@@ -23,7 +18,7 @@ def upgrade():
         (      
             event_id UUID NOT NULL,
             emission_time DateTime64(6) NOT NULL,
-            event JSON NOT NULL,
+            event String NOT NULL,
             event_str String NOT NULL
         ) ENGINE {engine}
         ORDER BY (emission_time, event_id)

--- a/tutoraspects/templates/aspects/apps/aspects/migrations/alembic/versions/0029_drop_json_column.py
+++ b/tutoraspects/templates/aspects/apps/aspects/migrations/alembic/versions/0029_drop_json_column.py
@@ -15,12 +15,8 @@ engine = "ReplicatedReplacingMergeTree" if "{{CLICKHOUSE_CLUSTER_NAME}}" else "R
 # Only used in downgrade, where we have to move data
 upgraded_table_name = "{{ASPECTS_XAPI_DATABASE}}.old_{{ASPECTS_RAW_XAPI_TABLE}}"
 
+
 def upgrade():
-    op.execute(
-        """
-        SET allow_experimental_object_type=1;
-        """
-    )
     op.execute(
         f"""
         DROP VIEW IF EXISTS {{ ASPECTS_XAPI_DATABASE }}.xapi_events_all_parsed_mv;
@@ -36,11 +32,6 @@ def upgrade():
 
 
 def downgrade():
-    op.execute(
-        """
-        SET allow_experimental_object_type=1;
-        """
-    )
     # 0. Remove the MV that may be pointing at the table we're changing
     op.execute(
         f"""
@@ -66,7 +57,7 @@ def downgrade():
         (      
             event_id UUID NOT NULL,
             emission_time DateTime64(6) NOT NULL,
-            event JSON NOT NULL,
+            event String NOT NULL,
             event_str String NOT NULL
         ) ENGINE {engine}
         ORDER BY (emission_time, event_id)

--- a/tutoraspects/templates/aspects/apps/aspects/migrations/alembic/versions/0030_rename_vector_json_column.py
+++ b/tutoraspects/templates/aspects/apps/aspects/migrations/alembic/versions/0030_rename_vector_json_column.py
@@ -1,5 +1,9 @@
 """
 As part of the Ralph 4.0 upgrade, we need to rename "event_json" to "event".
+
+Later we've removed all references to the JSON columns and
+allow_experimental_object_type since they have been removed from ClickHouse and cause
+various errors.
 """
 from alembic import op
 


### PR DESCRIPTION
The JSON column has been deprecated from ClickHouse. We briefly used it, but removed it some time ago and the old migrations break on some newer versions of ClickHouse, so this PR removes all references to that column.