### PR TITLE
chore: Update automation for new default branch

### DIFF
--- a/.github/workflows/bump-version.yaml
+++ b/.github/workflows/bump-version.yaml
@@ -67,7 +67,7 @@ jobs:
           title: "chore: preparing release ${{ steps.tag_version.outputs.new_version }}"
           commit-message: "chore: preparing release ${{ steps.tag_version.outputs.new_version }}"
           branch: "bot/v${{steps.tag_version.outputs.new_version}}"
-          base: main
+          base: nightly
           body: |
             Automated version bump for release ${{ steps.tag_version.outputs.new_version }}.
 

--- a/.github/workflows/pull-translations.yaml
+++ b/.github/workflows/pull-translations.yaml
@@ -45,7 +45,7 @@ jobs:
           branch: "bot/translations/${{ steps.date.outputs.date }}"
           add-paths: |
             tutoraspects/
-          base: main
+          base: nightly
           body: |
             Automated update of translations for assets on ${{ steps.date.outputs.date }}.
 

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -4,7 +4,7 @@ on:
     types:
       - closed
     branches:
-      - main
+      - nightly
 
 env:
   TUTOR_ROOT: ./.ci/

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -2,9 +2,9 @@ name: Run all tests & checks
 
 on:
   push:
-    branches: [ main ]
+    branches: [ nightly ]
   pull_request:
-    branches: [ main ]
+    branches: [ nightly ]
 
 jobs:
   tests:

--- a/.github/workflows/upgrade-python-requirements.yml
+++ b/.github/workflows/upgrade-python-requirements.yml
@@ -8,13 +8,13 @@ on:
       branch:
         description: "Target branch against which to create requirements PR"
         required: true
-        default: 'main'
+        default: 'nightly'
 
 jobs:
   call-upgrade-python-requirements-workflow:
     uses: openedx/.github/.github/workflows/upgrade-python-requirements.yml@master
     with:
-      branch: ${{ github.event.inputs.branch || 'main' }}
+      branch: ${{ github.event.inputs.branch || 'nightly' }}
       # optional parameters below; fill in if you'd like github or email notifications
       # user_reviewers: ""
       # team_reviewers: ""

--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -14,7 +14,7 @@ metadata:
     # names that might be interested in changes to the architecture of this
     # component.
     openedx.org/arch-interest-groups: "group:openedx/tutor-contrib-aspects-maintainers,"
-    openedx.org/release: "main"
+    openedx.org/release: "nightly"
 spec:
 
   # (Required) This can be a group (`group:<github_group_name>`) or a user (`user:<github_username>`).


### PR DESCRIPTION
We moved from "main" to "nightly" to better match Tutor standard release branch naming conventions.