### PR TITLE
revert: chore: Update automation for new default branch

### DIFF
--- a/.github/workflows/bump-version.yaml
+++ b/.github/workflows/bump-version.yaml
@@ -67,7 +67,7 @@ jobs:
           title: "chore: preparing release ${{ steps.tag_version.outputs.new_version }}"
           commit-message: "chore: preparing release ${{ steps.tag_version.outputs.new_version }}"
           branch: "bot/v${{steps.tag_version.outputs.new_version}}"
-          base: nightly
+          base: main
           body: |
             Automated version bump for release ${{ steps.tag_version.outputs.new_version }}.
 

--- a/.github/workflows/pull-translations.yaml
+++ b/.github/workflows/pull-translations.yaml
@@ -45,7 +45,7 @@ jobs:
           branch: "bot/translations/${{ steps.date.outputs.date }}"
           add-paths: |
             tutoraspects/
-          base: nightly
+          base: main
           body: |
             Automated update of translations for assets on ${{ steps.date.outputs.date }}.
 

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -4,7 +4,7 @@ on:
     types:
       - closed
     branches:
-      - nightly
+      - main
 
 env:
   TUTOR_ROOT: ./.ci/

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -2,9 +2,9 @@ name: Run all tests & checks
 
 on:
   push:
-    branches: [ nightly ]
+    branches: [ main ]
   pull_request:
-    branches: [ nightly ]
+    branches: [ main ]
 
 jobs:
   tests:

--- a/.github/workflows/upgrade-python-requirements.yml
+++ b/.github/workflows/upgrade-python-requirements.yml
@@ -8,13 +8,13 @@ on:
       branch:
         description: "Target branch against which to create requirements PR"
         required: true
-        default: 'nightly'
+        default: 'main'
 
 jobs:
   call-upgrade-python-requirements-workflow:
     uses: openedx/.github/.github/workflows/upgrade-python-requirements.yml@master
     with:
-      branch: ${{ github.event.inputs.branch || 'nightly' }}
+      branch: ${{ github.event.inputs.branch || 'main' }}
       # optional parameters below; fill in if you'd like github or email notifications
       # user_reviewers: ""
       # team_reviewers: ""

--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -14,7 +14,7 @@ metadata:
     # names that might be interested in changes to the architecture of this
     # component.
     openedx.org/arch-interest-groups: "group:openedx/tutor-contrib-aspects-maintainers,"
-    openedx.org/release: "nightly"
+    openedx.org/release: "main"
 spec:
 
   # (Required) This can be a group (`group:<github_group_name>`) or a user (`user:<github_username>`).


### PR DESCRIPTION
@bmtcril and I and the rest of Axim eng talked more. Brian would rather not use the nightly/master branch convention from Tutor since it's confusing for contributors, honestly it's confusing for everyone involved really. We also figured that it's not important that Aspects follows that pattern, as long as it has some way of documenting which Aspects releases map to which Tutor versions. The team also generally agreed that this repo shouldn't be branched or tagged in the release process.

I've changed the name of `nightly` back to `main`, and this PR will put the automation back to the way it was.

Brian, I figure you'll want to change `master` (formely `open-release/redwood.master`) to something else, but I don't know what, so I'll leave that to you.

Reverts openedx/tutor-contrib-aspects#809