### PR TITLE
feat: add init clickhouse job

### DIFF
--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -56,6 +56,8 @@ jobs:
         run: |
           tutor local do alembic -c "downgrade base"
           tutor local do alembic -c "upgrade head"
+      - name: Init clickhouse
+        run: tutor local do init-clickhouse
       # This should:
       # 1. Find no models on the first run, since state should be up to date
       # 2. Force run all models
@@ -120,6 +122,8 @@ jobs:
         run: |
           tutor dev do alembic -c "downgrade base"
           tutor dev do alembic -c "upgrade head"
+      - name: Init clickhouse
+        run: tutor dev do init-clickhouse
       # This should:
       # 1. Find no models on the first run, since state should be up to date
       # 2. Force run all models
@@ -204,6 +208,8 @@ jobs:
         run: |
           tutor k8s do alembic -c "downgrade base"
           tutor k8s do alembic -c "upgrade head"
+      - name: Init clickhouse
+        run: tutor k8s do init-clickhouse
       # This should:
       # 1. Find no models on the first run, since state should be up to date
       # 2. Force run all models

--- a/tutoraspects/commands_v0.py
+++ b/tutoraspects/commands_v0.py
@@ -141,6 +141,23 @@ def import_assets(context) -> None:
     runner.run_job("superset", command)
 
 
+@click.command(context_settings={"ignore_unknown_options": True})
+@click.pass_obj
+def init_clickhouse(context) -> None:
+    """
+    Job to import Superset assets.
+    """
+    config = tutor_config.load(context.root)
+    runner = context.job_runner(config)
+
+    runner.run_job(
+        "clickhouse",
+        env.read_template_file(
+            "aspects", "jobs", "init", "clickhouse", "init-clickhouse.sh"
+        ),
+    )
+
+
 @click.command(help="Dump data to ClickHouse.")
 @click.option("--service", default="lms", help="The service to run the command on.")
 @click.option("--options", default="")
@@ -263,4 +280,5 @@ COMMANDS = (
     transform_tracking_logs,
     import_assets,
     performance_metrics,
+    init_clickhouse,
 )

--- a/tutoraspects/commands_v1.py
+++ b/tutoraspects/commands_v1.py
@@ -130,6 +130,21 @@ def import_assets() -> list[tuple[str, str]]:
     ]
 
 
+@click.command(context_settings={"ignore_unknown_options": True})
+def init_clickhouse() -> list[tuple[str, str]]:
+    """
+    Job to run ClickHouse initialization tasks.
+    """
+    return [
+        (
+            "clickhouse",
+            env.read_template_file(
+                "aspects", "jobs", "init", "clickhouse", "init-clickhouse.sh"
+            ),
+        )
+    ]
+
+
 # Ex: "tutor local do performance-metrics "
 @click.command(context_settings={"ignore_unknown_options": True})
 @click.option(
@@ -359,6 +374,7 @@ DO_COMMANDS = (
     transform_tracking_logs,
     import_assets,
     performance_metrics,
+    init_clickhouse,
 )
 
 COMMANDS = (aspects,)


### PR DESCRIPTION
### Description

This PR adds a command to only run init tasks for ClickHouse.