### PR TITLE
fix: add key for memoized_func

### DIFF
--- a/tutoraspects/templates/aspects/apps/superset/pythonpath/superset_config_docker.py
+++ b/tutoraspects/templates/aspects/apps/superset/pythonpath/superset_config_docker.py
@@ -104,7 +104,7 @@ def can_view_courses_wrapper(*args, **kwargs):
     from superset.utils.cache import memoized_func
 
     kwargs["cache_timeout"] = {{ SUPERSET_USER_PERMISSIONS_CACHE_TIMEOUT }}
-    return memoized_func()(can_view_courses)(*args, **kwargs)
+    return memoized_func("{username}:{field_name}")(can_view_courses)(*args, **kwargs)
 
 
 JINJA_CONTEXT_ADDONS = {


### PR DESCRIPTION
### Description

This PR fixes an issue with the `can_view_courses` filter:
```bash
  File "/app/pythonpath/superset_config_docker.py", line 107, in can_view_courses_wrapper
    return memoized_func()(can_view_courses)(*args, **kwargs)
TypeError: memoized_func() missing 1 required positional argument: 'key'
```
The key format is now necessary by Superset 4.0.0 and was changed on this PR: https://github.com/apache/superset/pull/25900