### PR TITLE
fix: Use enrolled date if last visited is not set

### DIFF
--- a/tutoraspects/templates/openedx-assets/queries/fact_learner_summary.sql
+++ b/tutoraspects/templates/openedx-assets/queries/fact_learner_summary.sql
@@ -31,7 +31,8 @@ with
             fss.grade_bucket as grade_bucket,
             fss.username as username,
             fss.name as name,
-            fss.email as email
+            fss.email as email,
+            fss.enrolled_at as enrolled_at
         from {{DBT_PROFILE_TARGET_DATABASE}}.fact_student_status fss
         where
         1=1
@@ -53,7 +54,7 @@ select
     fss.name as name,
     fss.email as email,
     fes.max_emission_time as emission_time,
-    let.last_visited as last_visited
+    GREATEST(let.last_visited, fss.enrolled_at) as last_visited
 from student_status fss
 left join
     enrollment_status fes


### PR DESCRIPTION
Change SQL to user greater of enrolled at date or last visited - 'last visited' defaults to 1970/1/1 on creation.


Closes: https://github.com/openedx/platform-plugin-aspects/issues/55
