### PR TITLE
feat: upgrade clickhouse to v24.4

### DIFF
--- a/tutoraspects/plugin.py
+++ b/tutoraspects/plugin.py
@@ -33,7 +33,7 @@ hooks.Filters.CONFIG_DEFAULTS.add_items(
         ("RUN_RALPH", True),
         ("RUN_SUPERSET", True),
         ("DOCKER_IMAGE_ASPECTS", "edunext/aspects:{{ ASPECTS_VERSION }}"),
-        ("DOCKER_IMAGE_CLICKHOUSE", "clickhouse/clickhouse-server:24.3"),
+        ("DOCKER_IMAGE_CLICKHOUSE", "clickhouse/clickhouse-server:24.4"),
         ("DOCKER_IMAGE_RALPH", "fundocker/ralph:4.1.0"),
         ("DOCKER_IMAGE_SUPERSET", "edunext/aspects-superset:{{ ASPECTS_VERSION }}"),
         ("DOCKER_IMAGE_VECTOR", "timberio/vector:0.30.0-alpine"),


### PR DESCRIPTION
### Description

This PR upgrades the clickhouse version to v24.4. This version includes support for Recursive CTEs, the `QUALIFY` clause, and join performance improvements. See more [information](https://clickhouse.com/blog/newsletter-may-2024?utm_source=clickhouse&utm_medium=email&utm_campaign=202405-newsletter#244-release).