### PR TITLE
chore: Upgrade Superset to version 4.0.1

### DIFF
--- a/tutoraspects/templates/aspects/build/aspects-superset/Dockerfile
+++ b/tutoraspects/templates/aspects/build/aspects-superset/Dockerfile
@@ -3,7 +3,7 @@
 # https://github.com/apache/superset/releases
 # https://github.com/apache/superset/blob/master/Dockerfile
 # https://superset.apache.org/docs/databases/installing-database-drivers
-FROM apache/superset:4.0.0
+FROM apache/superset:4.0.1
 
 USER root
 


### PR DESCRIPTION
closes #835 

Tested as Superuser and Instructor (non-superuser). All local dashboards work correctly, no new errors in lms/superset logs.