### PR TITLE
fix: new strings for translation

### DIFF
--- a/tutoraspects/translations/translate_utils.py
+++ b/tutoraspects/translations/translate_utils.py
@@ -45,14 +45,14 @@ class TranslatableAsset:
         """
         if not content or isinstance(content, str):
             return []
-        
+
         # if content is a list, run method for each list item
         if isinstance(content, list):
             strings = []
             for item in content:
                 strings.extend(self.translate_var(item, var_path))
             return strings
-        
+
         if isinstance(content, dict):
             # if var_path is wild, run method on every value in dict
             if var_path[0] == "*":
@@ -69,7 +69,7 @@ class TranslatableAsset:
                 return strings
             # otherwise, run method again 1 level deeper
             return self.translate_var(content.get(var_path[0], " "), var_path[1:])
-        
+
         print("Could not translate var_path: ", var_path, content)
         return []
 


### PR DESCRIPTION
Closes #840 

Add 2 new strings for translation
Reconfigure method for easier reading
Fix 'could not translate' errors

New strings:
![image](https://github.com/openedx/tutor-contrib-aspects/assets/170115515/25f2d57a-926f-4d10-8202-1bf60177b5c1)


Logs before:
![image](https://github.com/openedx/tutor-contrib-aspects/assets/170115515/8fcd2ac0-adce-4bbd-8ab1-fa72933b3002)

Logs After:
![image](https://github.com/openedx/tutor-contrib-aspects/assets/170115515/986ae7a2-e43c-4bc5-be75-390d7792a94c)
