### PR TITLE
fix: Bump event-routing-backends to v9.2.1

### DIFF
--- a/tutoraspects/patches/openedx-dev-dockerfile-post-python-requirements
+++ b/tutoraspects/patches/openedx-dev-dockerfile-post-python-requirements
@@ -2,4 +2,4 @@ RUN --mount=type=cache,target=/openedx/.cache/pip,sharing=shared \
     pip install "platform-plugin-aspects==v0.9.4"
 
 RUN --mount=type=cache,target=/openedx/.cache/pip,sharing=shared \
-    pip install "edx-event-routing-backends==v9.0.1"
+    pip install "edx-event-routing-backends==v9.2.1"

--- a/tutoraspects/patches/openedx-dockerfile-post-python-requirements
+++ b/tutoraspects/patches/openedx-dockerfile-post-python-requirements
@@ -2,4 +2,4 @@ RUN --mount=type=cache,target=/openedx/.cache/pip,sharing=shared \
     pip install "platform-plugin-aspects==v0.9.4"
 
 RUN --mount=type=cache,target=/openedx/.cache/pip,sharing=shared \
-    pip install "edx-event-routing-backends==v9.0.1"
+    pip install "edx-event-routing-backends==v9.2.1"


### PR DESCRIPTION
This includes a fix to allow backfill to work with the new ERB config format.

Full list of changes: https://github.com/openedx/event-routing-backends/compare/v9.0.1...v9.2.1