### PR TITLE
build: Make CI force course_overviews dump

### DIFF
--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -73,7 +73,7 @@ jobs:
         run: tutor local do importdemocourse
       - name: Test commands
         run: |
-          tutor local do dump-data-to-clickhouse --options "--object course_overviews"
+          tutor local do dump-data-to-clickhouse --options "--object course_overviews --force"
           make extract_translations
           tutor local do import-assets
       - name: Performance metrics
@@ -139,7 +139,7 @@ jobs:
         run: tutor dev do importdemocourse
       - name: Test commands
         run: |
-          tutor dev do dump-data-to-clickhouse --options "--object course_overviews"
+          tutor dev do dump-data-to-clickhouse --options "--object course_overviews --force"
           make extract_translations
           tutor dev do import-assets
       - name: Performance metrics
@@ -225,7 +225,7 @@ jobs:
         run: tutor k8s do importdemocourse
       - name: Test commands
         run: |
-          tutor k8s do dump-data-to-clickhouse --options "--object course_overviews"
+          tutor k8s do dump-data-to-clickhouse --options "--object course_overviews --force"
           make extract_translations
           tutor k8s do import-assets
       - name: Performance metrics


### PR DESCRIPTION
In most cases dev/local were skipping trying to actually do the dump due to the course already existing in Clickhouse. This should force the code path to be run that we were expecting.