### PR TITLE
docs: correct the transform-tracking-logs do command name

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -75,7 +75,7 @@ At this point you should have a working Tutor / Aspects environment, but with no
 
    #. Sink Historical event data to ClickHouse::
 
-       tutor [dev|local] do transform_tracking_logs \
+       tutor [dev|local] do transform-tracking-logs \
          --source_provider LOCAL --source_config '{"key": "/openedx/data", "container":
             "logs", "prefix": "tracking.log"}' \
          --transformer_type xapi


### PR DESCRIPTION
The `transform-tracking-logs` do command in the README was incorrectly spelled as `transform_tracking_logs`. I've updated this in the README.