### PR TITLE
perf: improve init lms task time by using settings instead of waffle flags

### DIFF
--- a/tutoraspects/patches/openedx-common-settings
+++ b/tutoraspects/patches/openedx-common-settings
@@ -59,3 +59,10 @@ EVENT_BUS_PRODUCER_CONFIG.update(
 if not "openedx_events" in INSTALLED_APPS:
 	INSTALLED_APPS.append("openedx_events")
 {% endif %}
+
+
+{% for model in EVENT_SINK_MODELS_ENABLED %}
+EVENT_SINK_CLICKHOUSE_{{model.upper()}}_ENABLED = True{% endfor %}
+{% if ASPECTS_ENABLE_PII %}# User PII models
+{% for model in EVENT_SINK_PII_MODELS %}EVENT_SINK_CLICKHOUSE_{{model.upper()}}_ENABLED = True
+{% endfor %}{% endif %}

--- a/tutoraspects/plugin.py
+++ b/tutoraspects/plugin.py
@@ -40,7 +40,7 @@ hooks.Filters.CONFIG_DEFAULTS.add_items(
         ("DOCKER_IMAGE_VECTOR", "timberio/vector:0.30.0-alpine"),
         (
             "EVENT_SINK_MODELS_ENABLED",
-            ["course_overviews", "tag", "taxonomy", "object_tag"],
+            ["course_overviews", "tag", "taxonomy", "object_tag", "course_enrollment"],
         ),
         (
             "EVENT_SINK_PII_MODELS",

--- a/tutoraspects/templates/aspects/jobs/init/lms/init-lms.sh
+++ b/tutoraspects/templates/aspects/jobs/init/lms/init-lms.sh
@@ -36,13 +36,3 @@ EOF
 ./manage.py lms manage_user tutor-contrib-aspects aspects@axim --unusable-password
 ./manage.py lms populate_model -f /tmp/erb_config.json -u tutor-contrib-aspects
 {% endif %}
-
-{% for model in EVENT_SINK_MODELS_ENABLED %}
-(./manage.py lms waffle_flag --list | grep event_sink_clickhouse.{{model}}.enabled) || ./manage.py lms waffle_flag --create event_sink_clickhouse.{{model}}.enabled --everyone
-{% endfor %}
-
-{% if ASPECTS_ENABLE_PII %}
-  {% for model in EVENT_SINK_PII_MODELS %}
-(./manage.py lms waffle_flag --list | grep event_sink_clickhouse.{{model}}.enabled) || ./manage.py lms waffle_flag --create event_sink_clickhouse.{{model}}.enabled --everyone
-  {% endfor %}
-{% endif %}


### PR DESCRIPTION
### Description

This PR improves the init lms task time by using settings to enable the sinks instead of using waffle flags.

### Migration steps

Make sure to drop all `event_sink_clickhouse_*_enabled` records on the waffle flag admin in the LMS:
- Search `event_sink_clickhouse` in the admin for the waffle flag model.
- Select all records.
- In the action menu, select the `Delete all records` action and proceed with the deletion.