### PR TITLE
feat(metrics): sort metrics by clickhouse query time

### DIFF
--- a/tutoraspects/commands_v1.py
+++ b/tutoraspects/commands_v1.py
@@ -173,7 +173,7 @@ def init_clickhouse() -> list[tuple[str, str]]:
 @click.option(
     "--fail_on_error", is_flag=True, default=False, help="Allow errors to fail the run."
 )
-def performance_metrics(
+def performance_metrics(  # pylint: disable=too-many-arguments
     org, course_name, dashboard_slug, slice_name, print_sql, fail_on_error
 ) -> (list)[tuple[str, str]]:
     """

--- a/tutoraspects/commands_v1.py
+++ b/tutoraspects/commands_v1.py
@@ -149,6 +149,11 @@ def init_clickhouse() -> list[tuple[str, str]]:
 # Ex: "tutor local do performance-metrics "
 @click.command(context_settings={"ignore_unknown_options": True})
 @click.option(
+    "--org",
+    default="",
+    help="An organization to apply as a filter.",
+)
+@click.option(
     "--course_name",
     default="",
     help="A course_name to apply as a filter.",
@@ -169,12 +174,14 @@ def init_clickhouse() -> list[tuple[str, str]]:
     "--fail_on_error", is_flag=True, default=False, help="Allow errors to fail the run."
 )
 def performance_metrics(
-    course_name, dashboard_slug, slice_name, print_sql, fail_on_error
+    org, course_name, dashboard_slug, slice_name, print_sql, fail_on_error
 ) -> (list)[tuple[str, str]]:
     """
     Job to measure performance metrics of charts and its queries in Superset and ClickHouse.
     """
-    options = f"--course_name '{course_name}'" if course_name else ""
+    options = ""
+    options += f"--org '{org}' " if org else ""
+    options += f"--course_name '{course_name}' " if course_name else ""
     options += f" --dashboard_slug {dashboard_slug}" if dashboard_slug else ""
     options += f' --slice_name "{slice_name}"' if slice_name else ""
     options += " --print_sql" if print_sql else ""

--- a/tutoraspects/commands_v1.py
+++ b/tutoraspects/commands_v1.py
@@ -149,9 +149,9 @@ def init_clickhouse() -> list[tuple[str, str]]:
 # Ex: "tutor local do performance-metrics "
 @click.command(context_settings={"ignore_unknown_options": True})
 @click.option(
-    "--course_key",
+    "--course_name",
     default="",
-    help="A course_key to apply as a filter, you must include the 'course-v1:'.",
+    help="A course_name to apply as a filter.",
 )
 @click.option(
     "--dashboard_slug", default="", help="Only run charts for the given dashboard."
@@ -169,12 +169,12 @@ def init_clickhouse() -> list[tuple[str, str]]:
     "--fail_on_error", is_flag=True, default=False, help="Allow errors to fail the run."
 )
 def performance_metrics(
-    course_key, dashboard_slug, slice_name, print_sql, fail_on_error
+    course_name, dashboard_slug, slice_name, print_sql, fail_on_error
 ) -> (list)[tuple[str, str]]:
     """
     Job to measure performance metrics of charts and its queries in Superset and ClickHouse.
     """
-    options = f"--course_key {course_key}" if course_key else ""
+    options = f"--course_name '{course_name}'" if course_name else ""
     options += f" --dashboard_slug {dashboard_slug}" if dashboard_slug else ""
     options += f' --slice_name "{slice_name}"' if slice_name else ""
     options += " --print_sql" if print_sql else ""

--- a/tutoraspects/commands_v1.py
+++ b/tutoraspects/commands_v1.py
@@ -173,7 +173,7 @@ def init_clickhouse() -> list[tuple[str, str]]:
 @click.option(
     "--fail_on_error", is_flag=True, default=False, help="Allow errors to fail the run."
 )
-def performance_metrics(  # pylint: disable=too-many-arguments
+def performance_metrics(  # pylint: disable=too-many-arguments,too-many-positional-arguments
     org, course_name, dashboard_slug, slice_name, print_sql, fail_on_error
 ) -> (list)[tuple[str, str]]:
     """

--- a/tutoraspects/templates/aspects/apps/superset/pythonpath/performance_metrics.py
+++ b/tutoraspects/templates/aspects/apps/superset/pythonpath/performance_metrics.py
@@ -50,6 +50,10 @@ query_format = (
 
 @click.command()
 @click.option(
+    "--org",
+    default="",
+    help="An organization to apply as a filter.")
+@click.option(
     "--course_name",
     default="",
     help="A course_name to apply as a filter, you must include the 'course-v1:'.")
@@ -71,7 +75,7 @@ query_format = (
 @click.option(
     "--fail_on_error", is_flag=True, default=False, help="Allow errors to fail the run."
 )
-def performance_metrics(course_name, dashboard_slug, slice_name, print_sql,
+def performance_metrics(org, course_name, dashboard_slug, slice_name, print_sql,
                         fail_on_error):
     """
     Measure the performance of the dashboard.
@@ -81,6 +85,8 @@ def performance_metrics(course_name, dashboard_slug, slice_name, print_sql,
     extra_filters = []
     if course_name:
         extra_filters += [{"col": "course_name", "op": "IN", "val": course_name}]
+    if org:
+        extra_filters += [{"col": "org", "op": "IN", "val": org}]
 
     with patch("clickhouse_connect.common.build_client_name") as mock_build_client_name:
         mock_build_client_name.return_value = RUN_ID

--- a/tutoraspects/templates/aspects/apps/superset/pythonpath/performance_metrics.py
+++ b/tutoraspects/templates/aspects/apps/superset/pythonpath/performance_metrics.py
@@ -50,9 +50,9 @@ query_format = (
 
 @click.command()
 @click.option(
-    "--course_key",
+    "--course_name",
     default="",
-    help="A course_key to apply as a filter, you must include the 'course-v1:'.")
+    help="A course_name to apply as a filter, you must include the 'course-v1:'.")
 @click.option(
     "--dashboard_slug",
     default="",
@@ -71,7 +71,7 @@ query_format = (
 @click.option(
     "--fail_on_error", is_flag=True, default=False, help="Allow errors to fail the run."
 )
-def performance_metrics(course_key, dashboard_slug, slice_name, print_sql,
+def performance_metrics(course_name, dashboard_slug, slice_name, print_sql,
                         fail_on_error):
     """
     Measure the performance of the dashboard.
@@ -79,8 +79,8 @@ def performance_metrics(course_key, dashboard_slug, slice_name, print_sql,
     # Mock the client name to identify the queries in the clickhouse system.query_log
     # table by by the http_user_agent field.
     extra_filters = []
-    if course_key:
-        extra_filters += [{"col": "course_key", "op": "==", "val": course_key}]
+    if course_name:
+        extra_filters += [{"col": "course_name", "op": "IN", "val": course_name}]
 
     with patch("clickhouse_connect.common.build_client_name") as mock_build_client_name:
         mock_build_client_name.return_value = RUN_ID

--- a/tutoraspects/templates/aspects/apps/superset/pythonpath/performance_metrics.py
+++ b/tutoraspects/templates/aspects/apps/superset/pythonpath/performance_metrics.py
@@ -174,6 +174,10 @@ def get_slice_query_context(slice, query_contexts, extra_filters=None):
         "filters": extra_filters
     }
 
+    if extra_filters:
+        for query in query_context["queries"]:
+            query["filters"] += extra_filters
+
     return query_context
 
 

--- a/tutoraspects/templates/aspects/apps/superset/pythonpath/performance_metrics.py
+++ b/tutoraspects/templates/aspects/apps/superset/pythonpath/performance_metrics.py
@@ -228,10 +228,6 @@ def get_query_log_from_clickhouse(report, query_contexts, print_sql, fail_on_err
             parsed_sql = str(sqlparse.parse(row.pop("query"))[0])
             clickhouse_queries[parsed_sql] = row
 
-            if print_sql:
-                logger.info("ClickHouse SQL: ")
-                logger.info(parsed_sql)
-
 
     for k, chart_result in enumerate(report):
         for query in chart_result["queries"]:

--- a/tutoraspects/templates/aspects/apps/superset/pythonpath/performance_metrics.py
+++ b/tutoraspects/templates/aspects/apps/superset/pythonpath/performance_metrics.py
@@ -174,10 +174,6 @@ def get_slice_query_context(slice, query_contexts, extra_filters=None):
         "filters": extra_filters
     }
 
-    if extra_filters:
-        for query in query_context["queries"]:
-            query["filters"] += extra_filters
-
     return query_context
 
 
@@ -273,7 +269,7 @@ def get_query_log_from_clickhouse(report, query_contexts, print_sql, fail_on_err
                     result_rows=chart_result.get("result_rows"),
                     rowcount=query["rowcount"],
                     filters=query["applied_filters"],
-                    sql=chart_result['sql'] if print_sql else '',                    
+                    sql=chart_result['sql'] if print_sql else '',
                 )
             )
     logger.info(report_str)


### PR DESCRIPTION
### Description

This PR brings improvements to the performance metrics script by ordering them by clickhouse query time, and adds the filter as if the charts were loaded from the Superset UI