### PR TITLE
fix: add instructor role to operators too

### DIFF
--- a/tutoraspects/templates/aspects/apps/superset/pythonpath/openedx_sso_security_manager.py
+++ b/tutoraspects/templates/aspects/apps/superset/pythonpath/openedx_sso_security_manager.py
@@ -173,7 +173,7 @@ class OpenEdxSsoSecurityManager(SupersetSecurityManager):
         if decoded_access_token.get("superuser", False):
             return ["admin", f"admin-{locale}"]
         elif decoded_access_token.get("administrator", False):
-            return ["alpha", "operator", f"operator-{locale}"]
+            return ["alpha", "operator", f"operator-{locale}", "instructor", f"instructor-{locale}"]
         else:
             # User has to have staff access to one or more courses to view any content
             # here. Since this is only called on login, we take the opportunity


### PR DESCRIPTION
Allows Django staff users to see the course-level dashboards, currently they never get that permission.

Note: This behavior will give Django staff users access to all course data for all courses in Aspects.

Closes: https://github.com/openedx/openedx-aspects/issues/291