### PR TITLE
fix: point aspects docs to the right service

### DIFF
--- a/tutoraspects/patches/caddyfile
+++ b/tutoraspects/patches/caddyfile
@@ -13,6 +13,6 @@
 
 {% if RUN_ASPECTS_DOCS %}
 {{ DBT_HOST }}{$default_site_port} {
-    import proxy "aspects-documentation:8090"
+    import proxy "aspects:7000"
 }
 {% endif%}


### PR DESCRIPTION
### Description

This fixes the DBT docs hosting by updating the service Caddy was pointing to