### PR TITLE
feat: add bind and compose mount settings for superset

### DIFF
--- a/tutoraspects/plugin.py
+++ b/tutoraspects/plugin.py
@@ -480,6 +480,34 @@ except AttributeError:
     pass
 
 
+@hooks.Filters.IMAGES_BUILD_MOUNTS.add()
+def _mount_superset_on_build(
+    mounts: list[tuple[str, str]], host_path: str
+) -> list[tuple[str, str]]:
+    """
+    Automatically add superset repo from the host to the build context whenever
+    it is added to the `MOUNTS` setting.
+    """
+    if os.path.basename(host_path) == "superset":
+        mounts += [
+            ("aspects-superset", "superset"),
+        ]
+    return mounts
+
+
+@hooks.Filters.COMPOSE_MOUNTS.add()
+def _mount_superset_compose(
+    volumes: list[tuple[str, str]], name: str
+) -> list[tuple[str, str]]:
+    """
+    When mounting superset with `tutor mounts add /path/to/superset"
+    bind-mount the host repo in the superset container.
+    """
+    if name == "superset":
+        volumes += [("superset", "/app")]
+    return volumes
+
+
 ########################################
 # INITIALIZATION TASKS
 ########################################

--- a/tutoraspects/templates/base-docker-compose-services
+++ b/tutoraspects/templates/base-docker-compose-services
@@ -7,6 +7,9 @@ image: {{ DOCKER_IMAGE_SUPERSET }}
     - ../../env/plugins/aspects/apps/superset/superset_home:/app/superset_home
     - ../../env/plugins/aspects/apps/superset/scripts:/app/scripts
     - ../../env/plugins/aspects/build/aspects-superset/openedx-assets:/app/openedx-assets
+    {%- for mount in iter_mounts(MOUNTS, "superset") %}
+    - {{ mount }}
+    {%- endfor %}        
   restart: unless-stopped
   environment:
     DATABASE_DIALECT: {{ SUPERSET_DB_DIALECT }}


### PR DESCRIPTION
### Description

Adds `IMAGES_BUILD_MOUNTS` and  `COMPOSE_MOUNTS` support for development on Superset within Aspects.

Preliminary step to work on https://github.com/openedx/openedx-aspects/issues/299

### Testing instructions

1. Install this plugin's branch to your tutor virtualenv.
2. Clone the Superset repo to your local environment: `git clone https://github.com/apache/superset.git`
3. Add a mount for where you cloned superset, e.g. `tutor dev mounts add /dev/superset`
4. Check that the mount shows up in the list, e.g `tutor dev mounts list` should have:
   ```
   - name: /dev/superset
     build_mounts:
     - image: aspects-superset
       context: superset
     compose_mounts:
     - service: superset
       container_path: /app
   ```
5. Rebuild your superset image: `tutor dev images build aspects-superset`
6. Stop `superset` and run a shell to check that your `superset` repo is mounted under `/app`.