### PR TITLE
fix: do not add mysql as a dependency when RUN_MYSQL=False

### DIFF
--- a/tutoraspects/patches/local-docker-compose-dev-services
+++ b/tutoraspects/patches/local-docker-compose-dev-services
@@ -8,7 +8,7 @@ superset:
   ports:
     - 8088:{{ SUPERSET_PORT }}
   depends_on:
-    - mysql
+    {% if RUN_MYSQL %}- mysql{% endif %}
     - redis
     - superset-worker
     - superset-worker-beat
@@ -22,7 +22,7 @@ superset-worker:
   healthcheck:
     test: ["CMD-SHELL", "celery inspect ping -A superset.tasks.celery_app:app -d celery@$$HOSTNAME"]
   depends_on:
-    - mysql
+    {% if RUN_MYSQL %}- mysql{% endif %}
     - redis
 
 superset-worker-beat:
@@ -34,7 +34,7 @@ superset-worker-beat:
   healthcheck:
     disable: true
   depends_on:
-    - mysql
+    {% if RUN_MYSQL %}- mysql{% endif %}
     - redis
 {% endif %}
 

--- a/tutoraspects/patches/local-docker-compose-jobs-services
+++ b/tutoraspects/patches/local-docker-compose-jobs-services
@@ -32,6 +32,6 @@ superset-job:
     OPENEDX_LMS_ROOT_URL: "{% if ENABLE_HTTPS %}https{% else %}http{% endif %}://{{ LMS_HOST }}"
     OAUTH2_CLIENT_ID: {{ SUPERSET_OAUTH2_CLIENT_ID }}
   depends_on:
-    - mysql
+    {% if RUN_MYSQL %}- mysql{% endif %}
     - redis
 {% endif %}

--- a/tutoraspects/patches/local-docker-compose-services
+++ b/tutoraspects/patches/local-docker-compose-services
@@ -53,7 +53,7 @@ superset:
   ports:
     - 8088:{{ SUPERSET_PORT }}
   depends_on:
-    - mysql
+    {% if RUN_MYSQL %}- mysql{% endif %}
     - redis
 
 superset-worker:
@@ -65,7 +65,7 @@ superset-worker:
   healthcheck:
     test: ["CMD-SHELL", "celery inspect ping -A superset.tasks.celery_app:app -d celery@$$HOSTNAME"]
   depends_on:
-    - mysql
+    {% if RUN_MYSQL %}- mysql{% endif %}
     - redis
 
 superset-worker-beat:
@@ -77,7 +77,7 @@ superset-worker-beat:
   healthcheck:
     disable: true
   depends_on:
-    - mysql
+    {% if RUN_MYSQL %}- mysql{% endif %}
     - redis
 {% endif %}
 


### PR DESCRIPTION
Aspects would fail if someone was using an external MySQL server
We now only add MySQL as a dependency to containers if RUN_MYSQL=True