### PR TITLE
fix: Set Clickhouse data dir permissions

### DIFF
--- a/tutoraspects/patches/local-docker-compose-permissions-command
+++ b/tutoraspects/patches/local-docker-compose-permissions-command
@@ -1,0 +1,1 @@
+{% if RUN_CLICKHOUSE %}setowner 101 /mounts/clickhouse{% endif %}

--- a/tutoraspects/patches/local-docker-compose-permissions-volumes
+++ b/tutoraspects/patches/local-docker-compose-permissions-volumes
@@ -1,0 +1,1 @@
+{% if RUN_CLICKHOUSE %}- ../../data/clickhouse:/mounts/clickhouse/{% endif %}


### PR DESCRIPTION
On the Sumac sandbox we've seen errors regarding the ability of ClickHouse to write to its bind mounted data directory. This hasn't seemed to have impacted usability, and hasn't appeared elsewhere that we have seen. This fix was suggested by Régis, and doesn't seem to break anything in local testing but we have no ability to reproduce the issue so it's speculative.

Original thread: https://github.com/overhangio/openedx-release-demo/pull/72#issuecomment-2515038220

Patches are here, for reference: 
- https://github.com/overhangio/tutor/blob/release/tutor/templates/apps/permissions/setowners.sh
- https://github.com/overhangio/tutor/blob/release/tutor/templates/local/docker-compose.yml#L22