### PR TITLE
fix: Performance testing script updates

### DIFF
--- a/tutoraspects/templates/aspects/apps/superset/pythonpath/performance_metrics.py
+++ b/tutoraspects/templates/aspects/apps/superset/pythonpath/performance_metrics.py
@@ -232,8 +232,9 @@ def get_query_log_from_clickhouse(report, query_contexts, print_sql, fail_on_err
     # Run CH query until results for all slices are returned
     ch_count = 6
     while ch_count > 0:
-        if ch_chart_result["queries"][0]["rowcount"] < chart_count:
-            logger.info("Waiting for clickhouse log...")
+        missing_rows = chart_count - ch_chart_result["queries"][0]["rowcount"]
+        if missing_rows > 0:
+            logger.info(f"Waiting for {missing_rows} clickhouse logs...")
             time.sleep(5)
             ch_chart_result = measure_chart(slice, query_context, fail_on_error)
             ch_count -= 1

--- a/tutoraspects/templates/aspects/apps/superset/pythonpath/performance_metrics.py
+++ b/tutoraspects/templates/aspects/apps/superset/pythonpath/performance_metrics.py
@@ -116,9 +116,9 @@ def performance_metrics(
                     slice, query_contexts, extra_filters
                 )
                 result = measure_chart(slice, query_context, fail_on_error)
-                chart_count += 1
                 if not result:
                     continue
+                chart_count += 1
                 for query in result["queries"]:
                     # Remove the data from the query to avoid memory issues on large
                     # datasets.

--- a/tutoraspects/templates/aspects/build/aspects-superset/openedx-assets/assets/datasets/query_log.yaml
+++ b/tutoraspects/templates/aspects/build/aspects-superset/openedx-assets/assets/datasets/query_log.yaml
@@ -118,7 +118,7 @@ sql: |
       query,
       http_user_agent
   FROM system.query_log
-  WHERE (has(databases, '{{ASPECTS_XAPI_DATABASE}}') OR has(databases, '{{ASPECTS_EVENT_SINK_DATABASE}}') OR has(databases, '{{DBT_PROFILE_TARGET_DATABASE}}')) AND (http_user_agent LIKE 'aspects-%') AND (type = 'QueryFinish')
+  WHERE databases <> ['system'] AND (http_user_agent LIKE 'aspects-%') AND (type <> 'QueryStart')
   ORDER BY event_time DESC
 table_name: query_log
 template_params: null

--- a/tutoraspects/templates/aspects/build/aspects-superset/openedx-assets/assets/datasets/query_log.yaml
+++ b/tutoraspects/templates/aspects/build/aspects-superset/openedx-assets/assets/datasets/query_log.yaml
@@ -118,7 +118,7 @@ sql: |
       query,
       http_user_agent
   FROM system.query_log
-  WHERE databases <> ['system'] AND (http_user_agent LIKE 'aspects-%') AND (type <> 'QueryStart')
+  WHERE databases <> ['system'] AND (http_user_agent LIKE 'aspects-%') AND (type = 'QueryFinish')
   ORDER BY event_time DESC
 table_name: query_log
 template_params: null

--- a/tutoraspects/templates/aspects/build/aspects-superset/openedx-assets/assets/datasets/query_log.yaml
+++ b/tutoraspects/templates/aspects/build/aspects-superset/openedx-assets/assets/datasets/query_log.yaml
@@ -118,7 +118,7 @@ sql: |
       query,
       http_user_agent
   FROM system.query_log
-  WHERE databases <> ['system'] AND (http_user_agent LIKE 'aspects-%') AND (type = 'QueryFinish')
+  WHERE (has(databases, '{{ASPECTS_XAPI_DATABASE}}') OR has(databases, '{{ASPECTS_EVENT_SINK_DATABASE}}') OR has(databases, '{{DBT_PROFILE_TARGET_DATABASE}}')) AND (http_user_agent LIKE 'aspects-%') AND (type = 'QueryFinish')
   ORDER BY event_time DESC
 table_name: query_log
 template_params: null


### PR DESCRIPTION
1. Add check to compare count of slices to rowcount from clickhouse to ensure data for all slices has been returned
2. Add 'strip' to remove whitespace that caused memory=none issues
3. Simplify ch query