### PR TITLE
feat: set the session locale from the Open edX preferred language

### DIFF
--- a/tutoraspects/templates/aspects/apps/superset/pythonpath/openedx_sso_security_manager.py
+++ b/tutoraspects/templates/aspects/apps/superset/pythonpath/openedx_sso_security_manager.py
@@ -70,9 +70,21 @@ class OpenEdxSsoSecurityManager(SupersetSecurityManager):
 
         if locale_preference not in current_app.config["DASHBOARD_LOCALES"]:
             log.warning(
-                f"Language {locale_preference} is not supported by Superset"
+                f"Locale {locale_preference} is not supported by Superset DASHBOARD_LOCALES"
             )
-            return locale_preference
+
+        # Use the full locale if it's supported
+        if locale_preference in current_app.config["LANGUAGES"]:
+            session["locale"] = locale_preference
+        else:
+            # Otherwise, try just the language part of the locale
+            lang_preference = locale_preference.split('_')[0]
+            if lang_preference in current_app.config["LANGUAGES"]:
+                session["locale"] = lang_preference
+            else:
+                log.warning(
+                    f"Locale {locale_preference} and language {lang_preference} are not supported by Superset LANGUAGES"
+                )
 
         return locale_preference
 


### PR DESCRIPTION
### Description

If the full language locale is supported, use it in the session locale.
Otherwise, use the language part of the locale, if that is supported.

Falls back to `"en"` as the current default.

Closes https://github.com/openedx/openedx-aspects/issues/298

### Testing instructions

1. Login to the LMS.
2. From the Account settings, e.g http://apps.local.openedx.io:1997/account/ , update your preferred language to one of your configured [`SUPERSET_SUPPORTED_LANGUAGES'](https://github.com/openedx/tutor-contrib-aspects/blob/4288654a976d78f0e55a9fc859694cbe74281ab6/tutoraspects/plugin.py#L319-L334).
4. Login to superset, e.g. http://superset.local.openedx.io:8088/login
   Note that the language used in the Superset UI matches your chosen preferred language.
   There may be missing translations -- Superset's translation coverage is not 100%.
6. From the Account settings, e.g http://apps.local.openedx.io:1997/account/ , update your preferred language to a language that is only partially-supported in Superset, e.g. Español (España) ('es-es').
7. Logout of Superset, and log back in.
   Note that your default language in Superset is now Spanish ('es').

### Author Notes & Concerns

1. Is falling back to the "language" part of a given locale always OK?
2. Should we also pass our django `LANGUAGE_CODE` through to the `BABEL_DEFAULT_LOCALE` (if it's one of the supported languages)?
   This would allow Aspects site operators to use a default other than `"en"`.