### PR TITLE
fix: force major version bump

### DIFF
--- a/.github/workflows/bump-version.yaml
+++ b/.github/workflows/bump-version.yaml
@@ -22,6 +22,7 @@ jobs:
           default_bump: false
           default_prerelease_bump: false
           dry_run: true
+          custom_release_rules: feat:major,fix:major
       - name: Set up Python 3.12
         uses: actions/setup-python@v5
         with:

--- a/.github/workflows/bump-version.yaml
+++ b/.github/workflows/bump-version.yaml
@@ -22,7 +22,7 @@ jobs:
           default_bump: false
           default_prerelease_bump: false
           dry_run: true
-          custom_release_rules: feat:major,fix:major
+          custom_release_rules: feat:major,fix:major # remove this line when commit_analyzer_preset is an accepted setting
       - name: Set up Python 3.12
         uses: actions/setup-python@v5
         with:


### PR DESCRIPTION
A note on this - the current code for [github-tag-action](https://github.com/mathieudutour/github-tag-action) does not support conventionalcommit analyzer (only angular) so our commit messages are not interpreted correctly which means using the 'bump version' action in GitHub only bumps minor releases, not major.

There is a [PR](https://github.com/mathieudutour/github-tag-action/pull/227) that will change this, but it needs to be merged/compiled into the [workplace action](https://github.com/marketplace/actions/github-tag) before we can use it.

So for now, we will force the action to do a major version bump, and hope that the PR gets reviewed soon so we can remove this line and instead specify `commit_analyzer_preset: conventionalcommit`