### PR TITLE
fix: restart clickhouse and ralph automatically

### DIFF
--- a/tutoraspects/patches/local-docker-compose-services
+++ b/tutoraspects/patches/local-docker-compose-services
@@ -1,6 +1,7 @@
 {% if RUN_CLICKHOUSE %}
 clickhouse:
     image: {{DOCKER_IMAGE_CLICKHOUSE}}
+    restart: unless-stopped
     environment:
         CLICKHOUSE_DB: "{{ ASPECTS_XAPI_DATABASE }}"
         CLICKHOUSE_USER: "{{ CLICKHOUSE_ADMIN_USER }}"
@@ -22,6 +23,7 @@ clickhouse:
 {% if RUN_RALPH %}
 ralph:
     image: {{ DOCKER_IMAGE_RALPH }}
+    restart: unless-stopped
     {% if RUN_CLICKHOUSE %}depends_on:
       - clickhouse{% endif %}
     env_file:


### PR DESCRIPTION
The clickhouse and ralph containers should restart automatically similar to the [superset containers](https://github.com/openedx/tutor-contrib-aspects/blob/1da0fcfcd245223e5e95ca1f0df68251cff8c819/tutoraspects/templates/base-docker-compose-services#L13).

This is a recurring issue we have faced where the clickhouse and ralph containers would just randomly stop and we would only find out after debugging why we are missing some data.

Unfortunately, we didn't find the logs to find out why the containers stopped or crashed. If we ever do, I'll make sure to edit this PR description and add them here.