### PR TITLE
fix: use end of block id for in-context filtering

### DIFF
--- a/tutoraspects/plugin.py
+++ b/tutoraspects/plugin.py
@@ -390,7 +390,7 @@ hooks.Filters.CONFIG_DEFAULTS.add_items(
         # For now we are pulling this from github, which should allow maximum
         # flexibility for forking, running branches, specific versions, etc.
         ("DBT_REPOSITORY", "https://github.com/openedx/aspects-dbt"),
-        ("DBT_BRANCH", "v4.0.1"),
+        ("DBT_BRANCH", "v4.0.2"),
         ("DBT_SSH_KEY", ""),
         ("DBT_STATE_DIR", "/app/aspects-dbt/state"),
         ("DBT_PROFILES_DIR", "/app/aspects/dbt/"),

--- a/tutoraspects/templates/openedx-assets/queries/graded_subsection_performance.sql
+++ b/tutoraspects/templates/openedx-assets/queries/graded_subsection_performance.sql
@@ -55,5 +55,11 @@ with
         from avg_actor
         join avg_total using (org, course_key, block_id)
     )
-select org, course_key, splitByChar('@',block_id)[3] as block_id, avg_score, total_avg, score_range
+select
+    org,
+    course_key,
+    splitByChar('@', block_id)[3] as block_id,
+    avg_score,
+    total_avg,
+    score_range
 from combine

--- a/tutoraspects/templates/openedx-assets/queries/graded_subsection_performance.sql
+++ b/tutoraspects/templates/openedx-assets/queries/graded_subsection_performance.sql
@@ -55,5 +55,5 @@ with
         from avg_actor
         join avg_total using (org, course_key, block_id)
     )
-select org, course_key, block_id, avg_score, total_avg, score_range
+select org, course_key, splitByChar('@',block_id)[3] as block_id, avg_score, total_avg, score_range
 from combine

--- a/tutoraspects/templates/openedx-assets/queries/graded_subsection_results.sql
+++ b/tutoraspects/templates/openedx-assets/queries/graded_subsection_results.sql
@@ -47,5 +47,10 @@ with
         where problem_blocks.graded
     )
 select
-    org, course_key, splitByChar('@',subsection_block_id)[3] as block_id, problem_number, actor_id, success
+    org,
+    course_key,
+    splitByChar('@', subsection_block_id)[3] as block_id,
+    problem_number,
+    actor_id,
+    success
 from final_results

--- a/tutoraspects/templates/openedx-assets/queries/graded_subsection_results.sql
+++ b/tutoraspects/templates/openedx-assets/queries/graded_subsection_results.sql
@@ -47,5 +47,5 @@ with
         where problem_blocks.graded
     )
 select
-    org, course_key, subsection_block_id as block_id, problem_number, actor_id, success
+    org, course_key, splitByChar('@',subsection_block_id)[3] as block_id, problem_number, actor_id, success
 from final_results

--- a/tutoraspects/templates/openedx-assets/queries/problem_responses.sql
+++ b/tutoraspects/templates/openedx-assets/queries/problem_responses.sql
@@ -62,5 +62,5 @@ select
     interaction_type,
     problem_number,
     problem_name_location,
-    block_id
+    splitByChar('@',block_id)[3] as block_id
 from first_response

--- a/tutoraspects/templates/openedx-assets/queries/problem_responses.sql
+++ b/tutoraspects/templates/openedx-assets/queries/problem_responses.sql
@@ -62,5 +62,5 @@ select
     interaction_type,
     problem_number,
     problem_name_location,
-    splitByChar('@',block_id)[3] as block_id
+    splitByChar('@', block_id)[3] as block_id
 from first_response

--- a/tutoraspects/templates/openedx-assets/queries/problem_results.sql
+++ b/tutoraspects/templates/openedx-assets/queries/problem_results.sql
@@ -48,5 +48,5 @@ select
     actor_id,
     problem_number,
     problem_name_location,
-    splitByChar('@',block_id)[3] as block_id
+    splitByChar('@', block_id)[3] as block_id
 from final_results

--- a/tutoraspects/templates/openedx-assets/queries/problem_results.sql
+++ b/tutoraspects/templates/openedx-assets/queries/problem_results.sql
@@ -48,5 +48,5 @@ select
     actor_id,
     problem_number,
     problem_name_location,
-    block_id
+    splitByChar('@',block_id)[3] as block_id
 from final_results

--- a/tutoraspects/templates/openedx-assets/queries/watched_video_segments.sql
+++ b/tutoraspects/templates/openedx-assets/queries/watched_video_segments.sql
@@ -125,7 +125,7 @@ with
                 ':'
             ) as video_number,
             concat(video_number, ' - ', _video_with_name[2]) as video_name_location,
-            splitByChar('@',block_id)[3] as block_id,
+            splitByChar('@', block_id)[3] as block_id,
             username,
             name,
             email

--- a/tutoraspects/templates/openedx-assets/queries/watched_video_segments.sql
+++ b/tutoraspects/templates/openedx-assets/queries/watched_video_segments.sql
@@ -125,7 +125,7 @@ with
                 ':'
             ) as video_number,
             concat(video_number, ' - ', _video_with_name[2]) as video_name_location,
-            block_id,
+            splitByChar('@',block_id)[3] as block_id,
             username,
             name,
             email


### PR DESCRIPTION
The In-Context front end only passes the last hash string of the block id to the dashboards for filtering

block-v1:course-v1:Org0+DemoX+2bc51b+type@problem+block@**42e10810**