### PR TITLE
chore: upgrade Authoring MFE slot IDs to namespaced version

### DIFF
--- a/tutoraspects/plugin.py
+++ b/tutoraspects/plugin.py
@@ -687,7 +687,7 @@ PLUGIN_SLOTS.add_items(
     [
         (
             "authoring",
-            "course_authoring_outline_sidebar_slot",
+            "org.openedx.frontend.authoring.course_outline_sidebar.v1",
             """
           {
             op: PLUGIN_OPERATIONS.Insert,
@@ -701,7 +701,7 @@ PLUGIN_SLOTS.add_items(
         ),
         (
             "authoring",
-            "course_authoring_outline_sidebar_slot",
+            "org.openedx.frontend.authoring.course_outline_sidebar.v1",
             """
           {
             op: PLUGIN_OPERATIONS.Wrap,
@@ -711,7 +711,7 @@ PLUGIN_SLOTS.add_items(
         ),
         (
             "authoring",
-            "course_authoring_unit_sidebar_slot",
+            "org.openedx.frontend.authoring.course_unit_sidebar.v2",
             """
           {
             op: PLUGIN_OPERATIONS.Insert,
@@ -725,7 +725,7 @@ PLUGIN_SLOTS.add_items(
         ),
         (
             "authoring",
-            "course_authoring_unit_sidebar_slot",
+            "org.openedx.frontend.authoring.course_unit_sidebar.v2",
             """
           {
             op: PLUGIN_OPERATIONS.Wrap,
@@ -735,7 +735,7 @@ PLUGIN_SLOTS.add_items(
         ),
         (
             "authoring",
-            "course_unit_header_actions_slot",
+            "org.openedx.frontend.authoring.course_unit_header_actions.v1",
             """
           {
               op: PLUGIN_OPERATIONS.Insert,
@@ -749,7 +749,7 @@ PLUGIN_SLOTS.add_items(
         ),
         (
             "authoring",
-            "course_outline_header_actions_slot",
+            "org.openedx.frontend.authoring.course_outline_header_actions.v1",
             """
           {
               op: PLUGIN_OPERATIONS.Insert,
@@ -763,7 +763,7 @@ PLUGIN_SLOTS.add_items(
         ),
         (
             "authoring",
-            "course_outline_unit_card_extra_actions_slot",
+            "org.openedx.frontend.authoring.course_outline_unit_card_extra_actions.v1",
             """
           {
             op: PLUGIN_OPERATIONS.Insert,
@@ -777,7 +777,7 @@ PLUGIN_SLOTS.add_items(
         ),
         (
             "authoring",
-            "course_outline_subsection_card_extra_actions_slot",
+            "org.openedx.frontend.authoring.course_outline_subsection_card_extra_actions.v1",
             """
           {
             op: PLUGIN_OPERATIONS.Insert,


### PR DESCRIPTION
Authoring MFE's slots were updated to use the namespaced ID format for all the slots in frontend-app-authoring PR#1854.

This commit brings the latest IDs to the Authoring MFE patch and also upgrades the unit-page sidebar slot to the latest version - v2.