### PR TITLE
fix: Removes legacy peer dependency flag to make the install flexible

### DIFF
--- a/tutoraspects/patches/mfe-dockerfile-post-npm-install-authoring
+++ b/tutoraspects/patches/mfe-dockerfile-post-npm-install-authoring
@@ -1,3 +1,3 @@
 {% if ASPECTS_ENABLE_STUDIO_IN_CONTEXT_METRICS %}
-RUN --mount=type=cache,target=/root/.npm,sharing=shared npm install --legacy-peer-deps openedx/frontend-plugin-aspects
+RUN --mount=type=cache,target=/root/.npm,sharing=shared npm install openedx/frontend-plugin-aspects
 {% endif %}


### PR DESCRIPTION
The changes remove legacy-peer-dependency flag because we matched the dependency in frontend-plugin-aspects, this helps to be flexible with installing dependencies as reported in #1091.

**Discussions**: 
https://github.com/openedx/frontend-plugin-aspects/pull/51

**Dependencies**: None

**Screenshots**: Always include screenshots if there is any change to the UI.

**Testing instructions**:

Same as https://github.com/openedx/frontend-plugin-aspects/pull/51