### PR TITLE
feat: Trying out Altinity lightweight connector

### DIFF
--- a/tutoraspects/patches/local-docker-compose-dev-services
+++ b/tutoraspects/patches/local-docker-compose-dev-services
@@ -54,3 +54,22 @@ aspects-consumer:
   command: |
     ./manage.py lms consume_events -t analytics -g event_routing_backends --extra '{"consumer_name": "aspects"}'
 {% endif %}
+
+{% if ASPECTS_RUN_ALTINITY_CONNECTOR %}
+debezium:
+  image: altinity/clickhouse-sink-connector:{{ALTINITY_SINK_LIGHTWEIGHT_VERSION}}
+  # image: clickhouse_debezium_embedded:{{ALTINITY_SINK_LIGHTWEIGHT_VERSION}}
+  restart: "no"
+  ports:
+    - "8083:8083"
+    - "5005:5005"
+    - "7000:7000"
+  depends_on:
+      - mysql
+      - clickhouse
+  extra_hosts:
+      - "host.docker.internal:host-gateway"
+  volumes:
+      # - ./config.yml:/config.yml
+      - ../../env/plugins/aspects/apps/debezium/config.yml:/config.yml
+{% endif %}

--- a/tutoraspects/patches/local-docker-compose-services
+++ b/tutoraspects/patches/local-docker-compose-services
@@ -150,3 +150,20 @@ aspects-docs:
   depends_on:
   {% if RUN_CLICKHOUSE %}  - clickhouse{% endif %}
 {% endif %}
+
+{% if ASPECTS_RUN_ALTINITY_CONNECTOR %}
+debezium:
+  image: altinity/clickhouse-sink-connector:{{ALTINITY_SINK_LIGHTWEIGHT_VERSION}}
+  restart: unless-stopped
+  ports:
+    - "8083:8083"
+    - "5005:5005"
+    - "7100:7000"
+  depends_on:
+      - mysql
+      - clickhouse
+  extra_hosts:
+      - "host.docker.internal:host-gateway"
+  volumes:
+      - ../../env/plugins/aspects/apps/debezium/config.yml:/config.yml
+{% endif %}

--- a/tutoraspects/plugin.py
+++ b/tutoraspects/plugin.py
@@ -169,6 +169,13 @@ hooks.Filters.CONFIG_DEFAULTS.add_items(
         ("ASPECTS_VECTOR_RAW_TRACKING_LOGS_TABLE", "_tracking"),
         ("ASPECTS_VECTOR_RAW_XAPI_TABLE", "xapi_events_all"),
         ("ASPECTS_DATA_TTL_EXPRESSION", "toDateTime(emission_time) + INTERVAL 1 YEAR"),
+        # Altinity sink connector settings
+        ("ASPECTS_RUN_ALTINITY_CONNECTOR", True),
+        ("ALTINITY_SINK_LIGHTWEIGHT_VERSION", "2.7.1-lt"),
+        (
+            "ALTINITY_SINK_TABLE_LIST",
+            "openedx.auth_user,openedx.student_courseenrollment,openedx.grades_persistentcoursegrade,openedx.grades_persistentsubsectiongrade",
+        ),
         # Make sure LMS / CMS have event-routing-backends installed
         ######################
         # ClickHouse Settings
@@ -544,9 +551,7 @@ MY_INIT_TASKS: list[tuple[str, tuple[str, ...], int]] = [
 # run it as part of the `init` job.
 try:
     for service, template_path, priority in MY_INIT_TASKS:
-        hooks.Filters.COMMANDS_INIT.add_item(
-            (service, template_path)
-        )  # pylint: disable=no-member
+        hooks.Filters.COMMANDS_INIT.add_item((service, template_path))  # pylint: disable=no-member
 except AttributeError:
     for service, template_path, priority in MY_INIT_TASKS:
         full_path = os.path.join(

--- a/tutoraspects/templates/aspects/apps/debezium/config.yml
+++ b/tutoraspects/templates/aspects/apps/debezium/config.yml
@@ -1,0 +1,233 @@
+#### Some of the properties are part of Debezium MYSQL Connector
+#### https://debezium.io/documentation/reference/stable/connectors/mysql.html#mysql-connector-properties
+
+# Unique name for the connector. Attempting to register again with the same name will fail.
+name: "lms-1"
+
+# Primary key used for state storage. Refer to State Storage documentation.
+# If multiple connectors are writing to the same ClickHouse instance, this
+# value needs to be unique for a connector.
+topic.prefix: "sink-connector-1"
+
+# IP address or hostname of the MySQL database server.
+database.hostname: "{{ MYSQL_HOST }}"
+
+# Integer port number of the MySQL database server listening for client connections.
+database.port: "{{ MYSQL_PORT }}"
+
+# Name of the MySQL database user to be used when connecting to the database.
+database.user: "root"
+
+# Password of the MySQL database user to be used when connecting to the database.
+database.password: "{{ MYSQL_ROOT_PASSWORD }}"
+
+# Unique name for the connector.
+database.server.id: "1"
+
+# The name of the MySQL database from which events are to be captured when not using snapshot mode.
+database.server.name: "ER54"
+
+# database.include.list An optional list of regular expressions that match database names to be monitored;
+# any database name not included in the whitelist will be excluded from monitoring. By default all databases will be monitored.
+database.include.list: openedx
+
+# table.include.list An optional list of regular expressions that match fully-qualified table identifiers for tables to be monitored;
+table.include.list: {{ ALTINITY_SINK_TABLE_LIST }}
+
+# Clickhouse Server URL, Specify only the hostname.
+clickhouse.server.url: "{{ CLICKHOUSE_HOST }}"
+
+# Clickhouse Server User
+clickhouse.server.user: "{{ CLICKHOUSE_ADMIN_USER }}"
+
+#Clickhouse Server Password
+clickhouse.server.password: "{{ CLICKHOUSE_ADMIN_PASSWORD }}"
+
+# Clickhouse Server Port
+clickhouse.server.port: {{ CLICKHOUSE_INTERNAL_HTTP_PORT }}
+
+# TODO: If we ever want to write to a database named differently than the source...
+# clickhouse.server.database: event_sink
+
+# database.allowPublicKeyRetrieval: "true" https://rmoff.net/2019/10/23/debezium-mysql-v8-public-key-retrieval-is-not-allowed/
+database.allowPublicKeyRetrieval: "true"
+
+# TODO: Prevent Debezium from capturing DDL changes for untracked tables
+# store.only.captured.tables.ddl: "true"
+
+# snapshot.mode: Debezium can use different modes when it runs a snapshot. The snapshot mode is determined by the snapshot.mode configuration property.
+# The default value of the property is initial. You can customize the way that the connector creates snapshots by changing the value of the snapshot.mode property
+# TODO: "when_needed" might be better here
+snapshot.mode: "initial"
+
+# TODO: Snapshot.locking.mode Required for Debezium 2.7.0 and later. The snapshot.locking.mode configuration property specifies the mode that the connector uses to lock tables during snapshotting.
+#snapshot.locking.mode: "minimal"
+
+# offset.flush.interval.ms: The number of milliseconds to wait before flushing recent offsets to Kafka. This ensures that offsets are committed within the specified time interval.
+offset.flush.interval.ms: 5000
+
+# connector.class: The Java class for the connector. This must be set to io.debezium.connector.mysql.MySqlConnector.
+connector.class: "io.debezium.connector.mysql.MySqlConnector"
+
+# offset.storage: The Java class that implements the offset storage strategy. This must be set to io.debezium.storage.jdbc.offset.JdbcOffsetBackingStore.
+offset.storage: "io.debezium.storage.jdbc.offset.JdbcOffsetBackingStore"
+
+# offset.storage.jdbc.offset.table.name: The name of the database table where connector offsets are to be stored.
+# Curently seem to need both the old and new name?
+offset.storage.jdbc.table.name: "altinity_sink_connector.replica_source_info"
+offset.storage.jdbc.offset.table.name: "altinity_sink_connector.replica_source_info"
+
+# offset.storage.jdbc.url: The JDBC URL for the database where connector offsets are to be stored.
+offset.storage.jdbc.url: "jdbc:clickhouse://{{CLICKHOUSE_HOST}}:{{CLICKHOUSE_INTERNAL_HTTP_PORT}}/altinity_sink_connector"
+
+# offset.storage.jdbc.user: The name of the database user to be used when connecting to the database where connector offsets are to be stored.
+offset.storage.jdbc.user: "{{CLICKHOUSE_ADMIN_USER}}"
+
+# offset.storage.jdbc.password: The password of the database user to be used when connecting to the database where connector offsets are to be stored.
+offset.storage.jdbc.password: "{{CLICKHOUSE_ADMIN_PASSWORD}}"
+
+# offset.storage.jdbc.offset.table.ddl: The DDL statement used to create the database table where connector offsets are to be stored.(Advanced)
+# Currently seem to need both old and new names for this?
+offset.storage.jdbc.table.ddl: "CREATE TABLE if not exists %s
+(
+    `id` String,
+    `offset_key` String,
+    `offset_val` String,
+    `record_insert_ts` DateTime,
+    `record_insert_seq` UInt64,
+    `_version` UInt64 MATERIALIZED toUnixTimestamp64Nano(now64(9))
+)
+ENGINE = ReplacingMergeTree(_version)
+ORDER BY id
+SETTINGS index_granularity = 8192"
+
+offset.storage.jdbc.offset.table.ddl: "CREATE TABLE if not exists %s
+(
+    `id` String,
+    `offset_key` String,
+    `offset_val` String,
+    `record_insert_ts` DateTime,
+    `record_insert_seq` UInt64,
+    `_version` UInt64 MATERIALIZED toUnixTimestamp64Nano(now64(9))
+)
+ENGINE = ReplacingMergeTree(_version)
+ORDER BY id
+SETTINGS index_granularity = 8192"
+
+# offset.storage.jdbc.offset.table.delete: The DML statement used to delete the database table where connector offsets are to be stored.(Advanced)
+# Currently seem to need both old and new names for this?
+offset.storage.jdbc.table.delete: "delete from %s where 1=1"
+offset.storage.jdbc.offset.table.delete: "delete from %s where 1=1"
+
+# schema.history.internal: The Java class that implements the schema history strategy. This must be set to io.debezium.storage.jdbc.history.JdbcSchemaHistory.
+schema.history.internal: "io.debezium.storage.jdbc.history.JdbcSchemaHistory"
+
+# schema.history.internal.jdbc.url: The JDBC URL for the database where connector schema history is to be stored.
+schema.history.internal.jdbc.url: "jdbc:clickhouse://{{CLICKHOUSE_HOST}}:{{CLICKHOUSE_INTERNAL_HTTP_PORT}}/altinity_sink_connector"
+
+# schema.history.internal.jdbc.user: The name of the database user to be used when connecting to the database where connector schema history is to be stored.
+schema.history.internal.jdbc.user: "{{CLICKHOUSE_ADMIN_USER}}"
+
+# schema.history.internal.jdbc.password: The password of the database user to be used when connecting to the database where connector schema history is to be stored.
+schema.history.internal.jdbc.password: "{{CLICKHOUSE_ADMIN_PASSWORD}}"
+
+# schema.history.internal.jdbc.schema.history.table.ddl: The DDL statement used to create the database table where connector schema history is to be stored.(Advanced)
+schema.history.internal.jdbc.schema.history.table.ddl: "CREATE TABLE if not exists %s
+(`id` VARCHAR(36) NOT NULL, `history_data` VARCHAR(65000), `history_data_seq` INTEGER, `record_insert_ts` TIMESTAMP NOT NULL, `record_insert_seq` INTEGER NOT NULL) ENGINE=ReplacingMergeTree(record_insert_seq) order by id"
+
+# schema.history.internal.jdbc.schema.history.table.name: The name of the database table where connector schema history is to be stored.
+schema.history.internal.jdbc.schema.history.table.name: "altinity_sink_connector.replicate_schema_history"
+
+# enable.snapshot.ddl: If set to true, the connector will parse the DDL statements from the initial load
+enable.snapshot.ddl: "true"
+
+# persist.raw.bytes: If set to true, the connector will persist raw bytes as received in a String column.
+persist.raw.bytes: "false"
+
+# auto.create.tables: If set to true, the connector will create tables in the target based on the schema received in the incoming message.
+auto.create.tables: "true"
+
+# auto.create.tables.replicated: If set to true, the connector will create table with Engine set to ReplicatedReplacingMergeTree
+#"auto.create.tables.replicated: "true"
+
+# database.connectionTimeZone: The timezone of the MySQL database server used to correctly shift the commit transaction timestamp.
+database.connectionTimeZone: "UTC"
+
+# number of retries in case of errors(mostly with clickhouse db connections)
+errors.max.retries: 20
+
+# Configuration to override the clickhouse database name for a given MySQL database name. If this configuration is not
+# provided, the MySQL database name will be used as the ClickHouse database name.
+#clickhouse.database.override.map: "test:ch_test"
+
+# clickhouse.datetime.timezone: This timezone will override the default timezone of ClickHouse server. Timezone columns will be set to this timezone.
+clickhouse.datetime.timezone: "UTC"
+
+# skip_replica_start: If set to true, the connector will skip replication on startup. sink-connector-client start_replica will start replication.
+#skip_replica_start: "false"
+
+# binary.handling.mode: The mode for handling binary values. Possible values are bytes, base64, and decode. The default is bytes.
+#binary.handling.mode: "base64"
+
+# ignore_delete: If set to true, the connector will ignore delete events. The default is false.
+# TODO: Set this when it actually works, right now if causes errors on all inserts like:
+# Expected one of: ParserArrayOfJSONIdentifierDelimiter, token sequence, OpeningSquareBracket, Dot, token. (SYNTAX_ERROR)
+#ignore_delete: "true"
+
+#disable.ddl: If set to true, the connector will ignore DDL events. The default is false.
+#disable.ddl: "false"
+
+#ignore.ddl.regex: If set, the connector will ignore DDL events that match the regex.
+ignore.ddl.regex: "(?i)(ANALYZE PARTITION).*"
+
+#disable.drop.truncate: If set to true, the connector will ignore drop and truncate events. The default is false.
+disable.drop.truncate: "true"
+
+#restart.event.loop: This will restart the CDC event loop if there are no messages received after
+#timeout specified in restart.event.loop.timeout.period.secs.
+#Workaround to restart debezium loop(in case of freeze)
+restart.event.loop: "true"
+
+#restart.event.loop.timeout.period.secs: Defines the restart timeout period.
+# TODO: Make configurable
+restart.event.loop.timeout.period.secs: "3000"
+
+# Flush time of the buffer in milliseconds. The buffer that is stored in memory before being flushed to ClickHouse.
+# TODO: Make configurable
+buffer.flush.time.ms: "1000"
+
+# Max number of records for the flush buffer.
+# TODO: Make configurable
+buffer.max.records: "10000"
+
+# ClickHouse JDBC configuration parameters, as a list of key-value pairs separated by commas.
+clickhouse.jdbc.params: "keepalive.timeout=3,max_buffer_size=1000000,socket_timeout=30000,connection_timeout=30000"
+
+# ClickHouse JDBC configuration settings, as a list of key-value pairs separated by commas.
+clickhouse.jdbc.settings: "input_format_null_as_default=0,allow_experimental_object_type=1,insert_allow_materialized_columns=1"
+
+# Maximum number of threads in the thread pool for processing CDC records.
+#thread.pool.size: 10
+
+# Sink Connector maximum queue size
+#sink.connector.max.queue.size: "100000"
+
+#Metrics (Prometheus target), required for Grafana Dashboard
+metrics.enable: "false"
+
+#connection.pool.disable: "true"
+#connection.pool.max.size: 500
+
+# Skip schema history capturing, use the following configuration
+# to reduce slow startup when replicating dbs with large number of tables
+schema.history.internal.store.only.captured.tables.ddl: "true"
+schema.history.internal.store.only.captured.databases.ddl: "true"
+
+# Required for fixing bug with freeze in debezium loop.
+use.nongraceful.disconnect: "true"
+database.keep.alive.interval.ms: "30000"  #Send keepalive every 30 seconds
+database.connection.reconnect.backoff.ms: "1000"
+database.connection.reconnect.backoff.max.ms: "10000"
+database.ssl.mode: "disabled"
+# If set, a non-default value will be set, for example if NULL is passed from source, the value will be NULL.
+non.default.value: "true"

--- a/tutoraspects/templates/aspects/jobs/init/mysql/init-mysql.sh
+++ b/tutoraspects/templates/aspects/jobs/init/mysql/init-mysql.sh
@@ -21,3 +21,6 @@ mysql -u {{ MYSQL_ROOT_USERNAME }} --password="{{ MYSQL_ROOT_PASSWORD }}" --host
 mysql -u {{ MYSQL_ROOT_USERNAME }} --password="{{ MYSQL_ROOT_PASSWORD }}" --host "{{ MYSQL_HOST }}" --port {{ MYSQL_PORT }} -e "CREATE USER IF NOT EXISTS '{{ SUPERSET_DB_USERNAME }}';"
 mysql -u {{ MYSQL_ROOT_USERNAME }} --password="{{ MYSQL_ROOT_PASSWORD }}" --host "{{ MYSQL_HOST }}" --port {{ MYSQL_PORT }} -e "ALTER USER '{{ SUPERSET_DB_USERNAME }}'@'%' IDENTIFIED BY '{{ SUPERSET_DB_PASSWORD }}';"
 mysql -u {{ MYSQL_ROOT_USERNAME }} --password="{{ MYSQL_ROOT_PASSWORD }}" --host "{{ MYSQL_HOST }}" --port {{ MYSQL_PORT }} -e "GRANT ALL ON {{ SUPERSET_DB_NAME }}.* TO '{{ SUPERSET_DB_USERNAME }}'@'%';"
+
+# Altinity replication user
+mysql -u {{ MYSQL_ROOT_USERNAME }} --password="{{ MYSQL_ROOT_PASSWORD }}" --host "{{ MYSQL_HOST }}" --port {{ MYSQL_PORT }} -e " GRANT SELECT, RELOAD, SHOW DATABASES, REPLICATION SLAVE, REPLICATION CLIENT ON *.* TO {{ SUPERSET_DB_USERNAME }}@'%';"


### PR DESCRIPTION
This is a **highly** speculative attempt to replace the platform-plugin-aspects sinks with something more robust and reliable. Currently this test works, creating ClickHouse tables to match MySQL versions and appending data as MySQL changes (for tables set in `ALTINITY_SINK_TABLE_LIST`). It is not plumbed through dbt or into downstream reports at this time.

Currently only Tutor local should work, dev is unlikely to work, k8s is not implemented.