### PR TITLE
fix: Superset Celery issues with healthcheck and pid

### DIFF
--- a/tutoraspects/patches/local-docker-compose-dev-services
+++ b/tutoraspects/patches/local-docker-compose-dev-services
@@ -20,7 +20,9 @@ superset-worker:
     SUPERSET_ENV: development
   command: ["bash", "/app/docker/docker-bootstrap.sh", "worker"]
   healthcheck:
-    test: ["CMD-SHELL", "celery inspect ping -A superset.tasks.celery_app:app -d celery@$$HOSTNAME"]
+    test: ["CMD-SHELL", "celery -A superset.tasks.celery_app:app inspect ping -d celery@$$HOSTNAME"]
+    interval: 30s
+    retries: 3
   depends_on:
     {% if RUN_MYSQL %}- mysql{% endif %}
     - redis

--- a/tutoraspects/patches/local-docker-compose-services
+++ b/tutoraspects/patches/local-docker-compose-services
@@ -65,7 +65,9 @@ superset-worker:
     SUPERSET_ENV: production
   command: ["bash", "/app/docker/docker-bootstrap.sh", "worker"]
   healthcheck:
-    test: ["CMD-SHELL", "celery inspect ping -A superset.tasks.celery_app:app -d celery@$$HOSTNAME"]
+    test: ["CMD-SHELL", "celery -A superset.tasks.celery_app:app inspect ping -d celery@$$HOSTNAME"]
+    interval: 30s
+    retries: 3
   depends_on:
     {% if RUN_MYSQL %}- mysql{% endif %}
     - redis

--- a/tutoraspects/templates/aspects/apps/superset/docker/docker-bootstrap.sh
+++ b/tutoraspects/templates/aspects/apps/superset/docker/docker-bootstrap.sh
@@ -43,6 +43,8 @@ if [[ "${1}" == "worker" ]]; then
   echo "Starting Celery worker..."
   celery --app=superset.tasks.celery_app:app worker -Ofair -l INFO
 elif [[ "${1}" == "beat" ]]; then
+  echo "Removing any orphan pid..."
+  rm -rf /tmp/celerybeat.pid
   echo "Starting Celery beat..."
   celery --app=superset.tasks.celery_app:app beat --pidfile /tmp/celerybeat.pid -l INFO -s "${SUPERSET_HOME}"/celerybeat-schedule
 elif [[ "${1}" == "app" ]]; then


### PR DESCRIPTION
Superset worker's healthcheck was incorrectly formatted for the version of Celery that Superset now uses.

Superset beat was failing to start at all because the image already had a pidfile on it. We now delete that if it exists.

Tested by taking down redis until the Supserset worker showed unhealthy.

Closes: #1103