### PR TITLE
fix: correctlyassign value of ENABLE_PROXY_FIX

### DIFF
--- a/tutoraspects/templates/aspects/apps/superset/pythonpath/superset_config_docker.py
+++ b/tutoraspects/templates/aspects/apps/superset/pythonpath/superset_config_docker.py
@@ -129,7 +129,7 @@ JINJA_CONTEXT_ADDONS = {
 {% if SUPERSET_ENABLE_PROXY_FIX %}
 # Caddy is running behind a proxy: Superset needs to handle x-forwarded-* headers
 # https://flask.palletsprojects.com/en/latest/deploying/proxy_fix/
-ENABLE_PROXY_FIX = True
+ENABLE_PROXY_FIX = {{SUPERSET_ENABLE_PROXY_FIX}}
 {% endif %}
 
 # Allows superset to open links in a new tab


### PR DESCRIPTION
From https://discuss.openedx.org/t/error-invalid-request-when-trying-to-access-to-superset/16922/3

Tutor [config](https://github.com/overhangio/tutor/blob/release/tutor/templates/config/defaults.yml#L33) uses `ENABLE_PROXY_FIX` (not `SUPERSET_ENABLE_PROXY_FIX`)

Aspects plugin assigns value to `SUPERSET_ENABLE_PROXY_FIX` [here](https://github.com/openedx/tutor-contrib-aspects/blob/main/tutoraspects/plugin.py#L366) so [this](https://github.com/openedx/tutor-contrib-aspects/blob/main/tutoraspects/templates/aspects/apps/superset/pythonpath/superset_config_docker.py#L129) is always returning `True` even if the value is `False`


Tested with:
1. Local config `ENABLE_PROXY_FIX` True -- Superset config `ENABLE_PROXY_FIX` True
2. Local config `ENABLE_PROXY_FIX` False -- Superset config `ENABLE_PROXY_FIX` False
3. Local config `ENABLE_PROXY_FIX` not defined -- Superset config `ENABLE_PROXY_FIX` True
4. Local config `ENABLE_PROXY_FIX` not defined & `SUPERSET_ENABLE_PROXY_FIX` True -- Superset config `ENABLE_PROXY_FIX` True
5. Local config `ENABLE_PROXY_FIX` not defined & `SUPERSET_ENABLE_PROXY_FIX` False -- Superset config `ENABLE_PROXY_FIX` not defined