### PR TITLE
fix: Pin earlier version of Click until bug is fixed

### DIFF
--- a/requirements/base.in
+++ b/requirements/base.in
@@ -1,4 +1,5 @@
-click
+# TODO: remove 8.3.0 when https://github.com/overhangio/tutor/issues/1276 is resolved completely
+click>=8.0,<8.3.0
 bcrypt
 importlib-resources
 openedx-atlas

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -18,7 +18,7 @@ certifi==2025.10.5
     #   requests
 charset-normalizer==3.4.3
     # via requests
-click==8.3.0
+click==8.2.1
     # via
     #   -r requirements/base.in
     #   black

--- a/requirements/translations.in
+++ b/requirements/translations.in
@@ -1,3 +1,3 @@
 # Requirements needed to run in openedx-translations to manage localization
-click
+click>=8.0,<8.3.0
 ruamel.yaml

--- a/requirements/translations.txt
+++ b/requirements/translations.txt
@@ -4,7 +4,7 @@
 #
 #    make upgrade
 #
-click==8.3.0
+click==8.2.1
     # via -r requirements/translations.in
 ruamel-yaml==0.18.15
     # via -r requirements/translations.in


### PR DESCRIPTION
Click 8.3 doesn't work with the latest version of tutor. Once we start testing for Ulmo, this will cause failures