### PR TITLE
fix: show default unit sidebar content when in context metrics disabled

### DIFF
--- a/tutoraspects/patches/mfe-env-config-runtime-definitions-authoring
+++ b/tutoraspects/patches/mfe-env-config-runtime-definitions-authoring
@@ -8,7 +8,7 @@
       // So, as a workaround, tutor-contrib-aspects simply defines the components added to the plugin as empty components.
       const CourseOutlineSidebar = () => {};
       const UnitPageSidebar = () => {};
-      const SidebarToggleWrapper = () => {};
+      const SidebarToggleWrapper = ({component}) => component;
       const CourseHeaderButton = () => {};
       const UnitActionsButton = () => {};
       const SubSectionAnalyticsButton = () => {};


### PR DESCRIPTION
> [!NOTE]
> I've only tested this by modifying a local `env.config.jsx` file in a local checkout of `frontend-app-authoring`.

The `SidebarToggleWrapper` is added by using [the FPF Wrap operation](https://github.com/openedx/frontend-plugin-framework?tab=readme-ov-file#wrap)

https://github.com/openedx/tutor-contrib-aspects/blob/5a42275baf5c3061c02f662be99e71c236127f44/tutoraspects/plugin.py#L715-L724

When using Wrap, FPF expects the wrapper to take in the default content and then render it. This is being [done properly by the full `SidebarToggleWrapper` component](https://github.com/openedx/frontend-plugin-aspects/blob/d8da80eee7587e6b1617ff9210a44002f36ab3f8/src/components/SidebarToggleWrapper.tsx#L8-L11).

```tsx
export const SidebarToggleWrapper = ({ component }: { component: ReactNode }) => {
  const { sidebarOpen } = useAspectsSidebarContext();
  return !sidebarOpen && component;
};
```

When the component is set to be empty

https://github.com/openedx/tutor-contrib-aspects/blob/5a42275baf5c3061c02f662be99e71c236127f44/tutoraspects/patches/mfe-env-config-runtime-definitions-authoring#L11

 the default content is not rendered.
 
 This PR changes the empty `SidebarToggleWrapper` to simply render the default content unconditionally.