### PR TITLE
fix: Add user to Clickhouse compose file

### DIFF
--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -52,6 +52,12 @@ jobs:
           tutor local start -d
           sleep 10
           tutor local logs clickhouse
+          tutor local stop clickhouse
+          tutor local start permissions -d
+          sleep 20
+          tutor local start clickhouse -d
+          sleep 10
+          tutor local logs clickhouse
       - name: Tutor init
         run: tutor local do init
       - name: Test alembic

--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -48,7 +48,10 @@ jobs:
       - name: Tutor build openedx
         run: tutor images build openedx aspects aspects-superset
       - name: Tutor start
-        run: tutor local start -d
+        run: |
+          tutor local start -d
+          sleep 10
+          tutor local logs clickhouse
       - name: Tutor init
         run: tutor local do init
       - name: Test alembic
@@ -278,7 +281,7 @@ jobs:
             echo "------------------------"
           done
       - name: Check jobs logs
-        if: '!cancelled()'
+        if: "!cancelled()"
         run: |
           job_list=($(kubectl get jobs | grep job | awk '{print $1}'))
 

--- a/tutoraspects/patches/local-docker-compose-services
+++ b/tutoraspects/patches/local-docker-compose-services
@@ -1,6 +1,7 @@
 {% if RUN_CLICKHOUSE %}
 clickhouse:
     image: {{DOCKER_IMAGE_CLICKHOUSE}}
+    user: "101:101"
     restart: unless-stopped
     environment:
         CLICKHOUSE_DB: "{{ ASPECTS_XAPI_DATABASE }}"


### PR DESCRIPTION
This seems to be necessary for rootless Docker and possibly Podman setups.