### PR TITLE
fix: setting push to false for tag action

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -22,6 +22,7 @@ jobs:
         uses: python-semantic-release/python-semantic-release@v10.5.3
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
+          push: false
       - name: Create a GitHub release
         if: steps.tag_version.outputs.tag
         uses: ncipollo/release-action@v1


### PR DESCRIPTION
Create Tag step was creating the release which is not what we want as it causes the next step to fail.
 http://github.com/openedx/tutor-contrib-aspects/actions/runs/21410368018/job/61645506828#step:4:9183