### PR TITLE
fix: Remove 'Course Name' field from at_risk dataset

### DIFF
--- a/tutoraspects/templates/aspects/build/aspects-superset/openedx-assets/assets/datasets/at_risk_coursewide_avg.yaml
+++ b/tutoraspects/templates/aspects/build/aspects-superset/openedx-assets/assets/datasets/at_risk_coursewide_avg.yaml
@@ -159,18 +159,6 @@ columns:
   type: String
   verbose_name: Actor Id
 - advanced_data_type: null
-  column_name: course_name
-  description: null
-  expression: null
-  extra: {}
-  filterable: true
-  groupby: true
-  is_active: true
-  is_dttm: false
-  python_date_format: null
-  type: String
-  verbose_name: Course Name
-- advanced_data_type: null
   column_name: course_run
   description: null
   expression: null


### PR DESCRIPTION
Removed 'Course Name' field from dataset configuration.