### PR TITLE
chore: Replace kube-tools with arkade-get in workflow

### DIFF
--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -187,11 +187,11 @@ jobs:
           pip install -e .
           tutor config save
       - name: Run Kubernetes tools
-        uses: alexellis/arkade-get@master
+        uses: alexellis/arkade-get@519940f35dea471a2a508b9ddba7be1ddadbb4cc
         with:
           kubectl: 1.23.0
           kustomize: 4.4.1
-          helmv3: 3.7.2
+          helm: 3.7.2
           kubeconform: 0.4.13
           command: |
             kustomize build $TUTOR_ROOT/env | kubeconform -strict -ignore-missing-schemas -kubernetes-version 1.22.0
@@ -479,11 +479,11 @@ jobs:
           tutor config save --set ASPECTS_XAPI_SOURCE=vector
           tutor config printvalue ASPECTS_XAPI_DATABASE | grep openedx
       - name: Run Kubernetes tools
-        uses: alexellis/arkade-get@master
+        uses: alexellis/arkade-get@519940f35dea471a2a508b9ddba7be1ddadbb4cc
         with:
           kubectl: 1.23.0
           kustomize: 4.4.1
-          helmv3: 3.7.2
+          helm: 3.7.2
           kubeconform: 0.4.13
           command: |
             kustomize build $TUTOR_ROOT/env | kubeconform -strict -ignore-missing-schemas -kubernetes-version 1.22.0

--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -187,7 +187,7 @@ jobs:
           pip install -e .
           tutor config save
       - name: Run Kubernetes tools
-        uses: stefanprodan/kube-tools@v1
+        uses: alexellis/arkade-get@master
         with:
           kubectl: 1.23.0
           kustomize: 4.4.1
@@ -479,7 +479,7 @@ jobs:
           tutor config save --set ASPECTS_XAPI_SOURCE=vector
           tutor config printvalue ASPECTS_XAPI_DATABASE | grep openedx
       - name: Run Kubernetes tools
-        uses: stefanprodan/kube-tools@v1
+        uses: alexellis/arkade-get@master
         with:
           kubectl: 1.23.0
           kustomize: 4.4.1

--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -186,14 +186,12 @@ jobs:
           pip install -r requirements/dev.txt
           pip install -e .
           tutor config save
-      - name: Run Kubernetes tools
+      - name: Install kube tools
         uses: alexellis/arkade-get@519940f35dea471a2a508b9ddba7be1ddadbb4cc
         with:
-          kubectl: 1.23.0
           kustomize: 4.4.1
-          helm: 3.7.2
           kubeconform: 0.4.13
-      - name: Run Kubernetes tools
+      - name: Run kubeconform
         run: |
           kustomize build $TUTOR_ROOT/env | kubeconform -strict -ignore-missing-schemas -kubernetes-version 1.22.0
       - name: Setup Docker Buildx
@@ -479,14 +477,12 @@ jobs:
           pip install -e .
           tutor config save --set ASPECTS_XAPI_SOURCE=vector
           tutor config printvalue ASPECTS_XAPI_DATABASE | grep openedx
-      - name: Run Kubernetes tools
+      - name: Install kube tools
         uses: alexellis/arkade-get@519940f35dea471a2a508b9ddba7be1ddadbb4cc
         with:
-          kubectl: 1.23.0
           kustomize: 4.4.1
-          helm: 3.7.2
           kubeconform: 0.4.13
-      - name: Run Kubernetes tools
+      - name: Run kubeconform
         run: |
           kustomize build $TUTOR_ROOT/env | kubeconform -strict -ignore-missing-schemas -kubernetes-version 1.22.0
       - name: Setup Docker Buildx

--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -193,8 +193,9 @@ jobs:
           kustomize: 4.4.1
           helm: 3.7.2
           kubeconform: 0.4.13
-          command: |
-            kustomize build $TUTOR_ROOT/env | kubeconform -strict -ignore-missing-schemas -kubernetes-version 1.22.0
+      - name: Run Kubernetes tools
+        run: |
+          kustomize build $TUTOR_ROOT/env | kubeconform -strict -ignore-missing-schemas -kubernetes-version 1.22.0
       - name: Setup Docker Buildx
         uses: docker/setup-buildx-action@v4
       - name: Tutor build openedx
@@ -485,8 +486,9 @@ jobs:
           kustomize: 4.4.1
           helm: 3.7.2
           kubeconform: 0.4.13
-          command: |
-            kustomize build $TUTOR_ROOT/env | kubeconform -strict -ignore-missing-schemas -kubernetes-version 1.22.0
+      - name: Run Kubernetes tools
+        run: |
+          kustomize build $TUTOR_ROOT/env | kubeconform -strict -ignore-missing-schemas -kubernetes-version 1.22.0
       - name: Setup Docker Buildx
         uses: docker/setup-buildx-action@v4
       - name: Tutor build openedx


### PR DESCRIPTION
kube-tools is deprecated and was failing with recent req updates