### PR TITLE
feat: New action for manual version release

### DIFF
--- a/.github/workflows/bump-version-manual.yaml
+++ b/.github/workflows/bump-version-manual.yaml
@@ -12,6 +12,11 @@ on:
         default: 'auto'
         type: choice
         options: [auto, patch, minor, major]
+      make_latest:
+        description: 'Mark this release as latest on GitHub'
+        required: false
+        default: false
+        type: boolean
 
 jobs:
   prepare-pr:
@@ -41,6 +46,7 @@ jobs:
         env:
           BASE_TAG: ${{ inputs.base_tag }}
           FORCE_BUMP: ${{ inputs.force_bump }}
+          MAKE_LATEST: ${{ inputs.make_latest }}
           REPO_URL: "https://github.com/tutor-contrib-aspects"
         run: |
           python3 << 'PYEOF'
@@ -48,15 +54,20 @@ jobs:
           from datetime import date
           from pathlib import Path
 
-          base_tag   = os.environ["BASE_TAG"]
-          force_bump = os.environ["FORCE_BUMP"]
-          repo_url   = os.environ["REPO_URL"]
+          base_tag    = os.environ["BASE_TAG"]
+          force_bump  = os.environ["FORCE_BUMP"]
+          make_latest = os.environ["MAKE_LATEST"]
+          repo_url    = os.environ["REPO_URL"]
+
+          def fail(msg: str) -> None:
+              print(f"::error::{msg}", file=sys.stderr)
+              sys.exit(1)
 
           if not re.fullmatch(r"v\d+\.\d+\.\d+", base_tag):
-              sys.exit("::error::base_tag must be in the format vX.Y.Z (e.g. v1.4.2)")
+              fail("base_tag must be in the format vX.Y.Z (e.g. v1.4.2)")
 
           if subprocess.run(["git", "rev-parse", base_tag], capture_output=True).returncode != 0:
-              sys.exit(f"::error::Base tag {base_tag} does not exist in local history.")
+              fail(f"Base tag {base_tag} does not exist in local history.")
 
           log = subprocess.run(
               ["git", "log", f"{base_tag}..HEAD", "--format=%H%n%s%n---"],
@@ -64,7 +75,7 @@ jobs:
           ).stdout.strip()
 
           if not log:
-              sys.exit(f"::error::No commits found between {base_tag} and HEAD. Nothing to release.")
+              fail(f"No commits found between {base_tag} and HEAD. Nothing to release.")
 
           sections: dict[str, list[str]] = {k: [] for k in ("feat", "fix", "chore", "misc")}
           bump = "patch"
@@ -104,7 +115,7 @@ jobs:
           new_tag, raw_v = f"v{major}.{minor}.{patch}", f"{major}.{minor}.{patch}"
 
           if subprocess.run(["git", "rev-parse", new_tag], capture_output=True).returncode == 0:
-              sys.exit(f"::error::Target version '{new_tag}' already exists.")
+              fail(f"Target version '{new_tag}' already exists.")
 
           for path, pattern, repl in [
               ("tutoraspects/__about__.py", r"(__version__\s*=\s*['\"])[^'\"]*", rf"\g<1>{raw_v}"),
@@ -131,7 +142,7 @@ jobs:
 
           eof = f"EOF_{os.urandom(4).hex()}"
           with open(os.environ["GITHUB_OUTPUT"], "a") as fh:
-              fh.write(f"new_tag={new_tag}\nraw_version={raw_v}\nBODY<<{eof}\n{entry}\n{eof}\n")
+              fh.write(f"new_tag={new_tag}\nraw_version={raw_v}\nmake_latest={make_latest}\nBODY<<{eof}\n{entry}\n{eof}\n")
 
           print(f"✅  Prepared release {new_tag} (bump: {bump})")
           PYEOF
@@ -153,4 +164,6 @@ jobs:
 
             ### Proposed Release Notes:
             ${{ steps.git_changelog.outputs.BODY }}
-          labels: release-pr
+          labels: |
+            release-pr
+            ${{ inputs.make_latest && 'make-latest' || '' }}

--- a/.github/workflows/bump-version-manual.yaml
+++ b/.github/workflows/bump-version-manual.yaml
@@ -1,0 +1,147 @@
+name: Bump Version (Manually)
+
+on:
+  workflow_dispatch:
+    inputs:
+      base_tag:
+        description: 'The previous release tag to base this new version on (e.g., v1.4.2)'
+        required: true
+      force_bump:
+        description: 'Force a specific SemVer increment tier (default: auto-detect from commit messages)'
+        required: false
+        default: 'auto'
+        type: choice
+        options: [auto, patch, minor, major]
+
+jobs:
+  prepare-pr:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+    steps:
+      - name: Checkout Targeted Branch Code
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.ref_name }}
+          fetch-depth: 0
+
+      - name: Force Fetch Tags and Remote History
+        run: |
+          git fetch --tags --force origin
+          git fetch origin ${{ github.ref_name }}
+
+      - name: Calculate Version and Process Changelog
+        id: git_changelog
+        run: |
+          BASE="${{ inputs.base_tag }}"
+          FORCE_BUMP="${{ inputs.force_bump }}"
+          # FIX: Added missing '/' before github.repository
+          REPO_URL="https://github.com/${{ github.repository }}"
+          CURRENT_DATE=$(date +%Y-%m-%d)
+
+          # FIX: Validate base_tag is a well-formed semver tag before proceeding
+          if ! echo "$BASE" | grep -Eq '^v[0-9]+\.[0-9]+\.[0-9]+$'; then
+            echo "::error::base_tag must be in the format vX.Y.Z (e.g. v1.4.2)" && exit 1
+          fi
+
+          if ! git rev-parse "$BASE" >/dev/null 2>&1; then
+            echo "::error::Base tag $BASE does not exist in local history." && exit 1
+          fi
+
+          FEAT="" FIX="" CHORE="" MISC="" BUMP="patch"
+
+          # FIX: Use --format=%H%n%s to capture full hash and subject line together
+          COMMIT_LOG=$(git log "${BASE}..HEAD" --format="%H%n%s%n---")
+
+          # FIX: Exit early with a clear error if there are no commits to release
+          if [ -z "$COMMIT_LOG" ]; then
+            echo "::error::No commits found between ${BASE} and HEAD. Nothing to release." && exit 1
+          fi
+
+          while IFS= read -r FULL_HASH && IFS= read -r RAW_MSG && IFS= read -r _SEP; do
+            [ -z "$RAW_MSG" ] && continue
+
+            if [ "$FORCE_BUMP" = "auto" ]; then
+              if echo "$RAW_MSG" | grep -q "BREAKING CHANGE" || echo "$RAW_MSG" | grep -Eq '^[a-z]+!(\(.*\))?:'; then BUMP="major"
+              elif echo "$RAW_MSG" | grep -q "^feat" && [ "$BUMP" != "major" ]; then BUMP="minor"; fi
+            fi
+
+            SHORT_HASH="${FULL_HASH:0:7}"
+            COMMIT_LINK=" ([${SHORT_HASH}](${REPO_URL}/commit/${FULL_HASH}))"
+
+            W_MSG=$(echo "$RAW_MSG" | sed -E 's/^Merge pull request #[0-9]+ from [^ ]+ //I')
+            CLEAN_MSG=$(echo "$W_MSG" | sed -E 's/[[:space:]]*\(?#[0-9]+\)?//g' | sed 's/^[[:space:]]*//;s/[[:space:]]*$//')
+            BULLET="* ${CLEAN_MSG}${COMMIT_LINK}"
+
+            if echo "$CLEAN_MSG" | grep -iq "^feat"; then FEAT="${FEAT}\n${BULLET}"
+            elif echo "$CLEAN_MSG" | grep -Eiq '^fix|^bug'; then FIX="${FIX}\n${BULLET}"
+            elif echo "$CLEAN_MSG" | grep -Eiq '^chore|^docs|^refactor'; then CHORE="${CHORE}\n${BULLET}"
+            else MISC="${MISC}\n${BULLET}"; fi
+          done <<< "$COMMIT_LOG"
+
+          [ "$FORCE_BUMP" != "auto" ] && BUMP="$FORCE_BUMP"
+          IFS='.' read -r ver_major ver_minor ver_patch <<< "${BASE#v}"
+          case "$BUMP" in
+            major) ver_major=$((ver_major+1)); ver_minor=0; ver_patch=0 ;;
+            minor) ver_minor=$((ver_minor+1)); ver_patch=0 ;;
+            patch) ver_patch=$((ver_patch+1)) ;;
+            *)     ver_patch=$((ver_patch+1)) ;;
+          esac
+
+          NEW_TAG="v${ver_major}.${ver_minor}.${ver_patch}"
+          RAW_V="${ver_major}.${ver_minor}.${ver_patch}"
+          if git rev-parse "$NEW_TAG" >/dev/null 2>&1; then echo "::error::Target version '${NEW_TAG}' already exists." && exit 1; fi
+
+          sed -i -E "s/(__version__ *= *['\"])[^'\"]*(['\"])/\1${RAW_V}\2/g" "tutoraspects/__about__.py"
+          sed -i -E "s/(ASPECTS_VERSION\s*:\s*)[0-9]+\.[0-9]+\.[0-9]+/\1${RAW_V}/g" ".ci/config.yml"
+          sed -i -E "s/(current_version\s*=\s*)[0-9]+\.[0-9]+\.[0-9]+/\1${RAW_V}/g" "setup.cfg"
+
+          # Build changelog sections once; reuse for both CHANGELOG.md and PR body
+          ENTRY_MD=""
+          add_section() { ENTRY_MD="${ENTRY_MD}\n\n### $1$2"; }
+          [ -n "$FEAT" ]  && add_section "Features" "$FEAT"
+          [ -n "$FIX" ]   && add_section "Bug Fixes" "$FIX"
+          [ -n "$CHORE" ] && add_section "Maintenance & Refactoring" "$CHORE"
+          [ -n "$MISC" ]  && add_section "Miscellaneous Updates" "$MISC"
+
+          PR_MD="## ${NEW_TAG} - ${CURRENT_DATE}\n\n${ENTRY_MD}"
+
+          C_FILE="CHANGELOG.md"
+          [ ! -f "$C_FILE" ] && touch "$C_FILE"
+
+          # Build entry in existing CHANGELOG format: ## vX.Y.Z - YYYY-MM-DD
+          NEW_ENTRY="## ${NEW_TAG} - ${CURRENT_DATE}\n${ENTRY_MD}\n\n---\n"
+          # Insert after the file header, before the first existing release entry
+          awk -v entry="$(printf '%b' "$NEW_ENTRY")" '
+            /^## v/ && !done { print entry; done=1 }
+            { print }
+          ' "$C_FILE" > temp.md && mv temp.md "$C_FILE"
+
+          echo "new_tag=${NEW_TAG}" >> $GITHUB_OUTPUT
+          echo "raw_version=${RAW_V}" >> $GITHUB_OUTPUT
+
+          EOF_SECTOR="EOF_${RANDOM}${RANDOM}"
+          echo "BODY<<${EOF_SECTOR}" >> $GITHUB_OUTPUT
+          printf '%b' "${PR_MD}" >> $GITHUB_OUTPUT
+          echo "" >> $GITHUB_OUTPUT
+          echo "${EOF_SECTOR}" >> $GITHUB_OUTPUT
+
+      - name: Create Pull Request
+        uses: peter-evans/create-pull-request@v6
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          commit-message: "chore: bump version to ${{ steps.git_changelog.outputs.raw_version }} and update CHANGELOG [skip ci]"
+          base: ${{ github.ref_name }}
+          branch: "bot/v${{ steps.git_changelog.outputs.raw_version }}"
+          title: "Release ${{ steps.git_changelog.outputs.new_tag }}"
+          body: |
+            This PR prepares the release for version **${{ steps.git_changelog.outputs.new_tag }}** branching from base version `${{ inputs.base_tag }}`.
+
+            The SemVer bump type calculation rule applied was: `${{ inputs.force_bump }}`.
+
+            Once merged, the publication pipeline will trigger automatically.
+
+            ### Proposed Release Notes:
+            ${{ steps.git_changelog.outputs.BODY }}
+          labels: release-pr

--- a/.github/workflows/bump-version-manual.yaml
+++ b/.github/workflows/bump-version-manual.yaml
@@ -7,7 +7,7 @@ on:
         description: 'The previous release tag to base this new version on (e.g., v1.4.2)'
         required: true
       force_bump:
-        description: 'Force a specific SemVer increment tier (default: auto-detect from commit messages)'
+        description: 'Force an increment tier (default: auto)'
         required: false
         default: 'auto'
         type: choice
@@ -21,7 +21,7 @@ jobs:
       pull-requests: write
     steps:
       - name: Checkout Targeted Branch Code
-        uses: actions/checkout@v4
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           ref: ${{ github.ref_name }}
           fetch-depth: 0
@@ -36,11 +36,9 @@ jobs:
         run: |
           BASE="${{ inputs.base_tag }}"
           FORCE_BUMP="${{ inputs.force_bump }}"
-          # FIX: Added missing '/' before github.repository
-          REPO_URL="https://github.com/${{ github.repository }}"
+          REPO_URL="https://github.com/tutor-contrib-aspects"
           CURRENT_DATE=$(date +%Y-%m-%d)
 
-          # FIX: Validate base_tag is a well-formed semver tag before proceeding
           if ! echo "$BASE" | grep -Eq '^v[0-9]+\.[0-9]+\.[0-9]+$'; then
             echo "::error::base_tag must be in the format vX.Y.Z (e.g. v1.4.2)" && exit 1
           fi
@@ -51,7 +49,6 @@ jobs:
 
           FEAT="" FIX="" CHORE="" MISC="" BUMP="patch"
 
-          # FIX: Use --format=%H%n%s to capture full hash and subject line together
           COMMIT_LOG=$(git log "${BASE}..HEAD" --format="%H%n%s%n---")
 
           # FIX: Exit early with a clear error if there are no commits to release
@@ -97,7 +94,6 @@ jobs:
           sed -i -E "s/(ASPECTS_VERSION\s*:\s*)[0-9]+\.[0-9]+\.[0-9]+/\1${RAW_V}/g" ".ci/config.yml"
           sed -i -E "s/(current_version\s*=\s*)[0-9]+\.[0-9]+\.[0-9]+/\1${RAW_V}/g" "setup.cfg"
 
-          # Build changelog sections once; reuse for both CHANGELOG.md and PR body
           ENTRY_MD=""
           add_section() { ENTRY_MD="${ENTRY_MD}\n\n### $1$2"; }
           [ -n "$FEAT" ]  && add_section "Features" "$FEAT"
@@ -110,8 +106,6 @@ jobs:
           C_FILE="CHANGELOG.md"
           [ ! -f "$C_FILE" ] && touch "$C_FILE"
 
-          # Build entry in existing CHANGELOG format: ## vX.Y.Z - YYYY-MM-DD
-          NEW_ENTRY="## ${NEW_TAG} - ${CURRENT_DATE}\n${ENTRY_MD}\n\n---\n"
           # Insert after the file header, before the first existing release entry
           awk -v entry="$(printf '%b' "$NEW_ENTRY")" '
             /^## v/ && !done { print entry; done=1 }
@@ -128,7 +122,7 @@ jobs:
           echo "${EOF_SECTOR}" >> $GITHUB_OUTPUT
 
       - name: Create Pull Request
-        uses: peter-evans/create-pull-request@v6
+        uses: peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1 # v8.1.1
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           commit-message: "chore: bump version to ${{ steps.git_changelog.outputs.raw_version }} and update CHANGELOG [skip ci]"

--- a/.github/workflows/bump-version-manual.yaml
+++ b/.github/workflows/bump-version-manual.yaml
@@ -31,95 +31,110 @@ jobs:
           git fetch --tags --force origin
           git fetch origin ${{ github.ref_name }}
 
+      - name: Set up Python 3.12
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
+        with:
+          python-version: '3.12'
+
       - name: Calculate Version and Process Changelog
         id: git_changelog
+        env:
+          BASE_TAG: ${{ inputs.base_tag }}
+          FORCE_BUMP: ${{ inputs.force_bump }}
+          REPO_URL: "https://github.com/tutor-contrib-aspects"
         run: |
-          BASE="${{ inputs.base_tag }}"
-          FORCE_BUMP="${{ inputs.force_bump }}"
-          REPO_URL="https://github.com/tutor-contrib-aspects"
-          CURRENT_DATE=$(date +%Y-%m-%d)
+          python3 << 'PYEOF'
+          import os, re, subprocess, sys
+          from datetime import date
+          from pathlib import Path
 
-          if ! echo "$BASE" | grep -Eq '^v[0-9]+\.[0-9]+\.[0-9]+$'; then
-            echo "::error::base_tag must be in the format vX.Y.Z (e.g. v1.4.2)" && exit 1
-          fi
+          base_tag   = os.environ["BASE_TAG"]
+          force_bump = os.environ["FORCE_BUMP"]
+          repo_url   = os.environ["REPO_URL"]
 
-          if ! git rev-parse "$BASE" >/dev/null 2>&1; then
-            echo "::error::Base tag $BASE does not exist in local history." && exit 1
-          fi
+          if not re.fullmatch(r"v\d+\.\d+\.\d+", base_tag):
+              sys.exit("::error::base_tag must be in the format vX.Y.Z (e.g. v1.4.2)")
 
-          FEAT="" FIX="" CHORE="" MISC="" BUMP="patch"
+          if subprocess.run(["git", "rev-parse", base_tag], capture_output=True).returncode != 0:
+              sys.exit(f"::error::Base tag {base_tag} does not exist in local history.")
 
-          COMMIT_LOG=$(git log "${BASE}..HEAD" --format="%H%n%s%n---")
+          log = subprocess.run(
+              ["git", "log", f"{base_tag}..HEAD", "--format=%H%n%s%n---"],
+              capture_output=True, text=True
+          ).stdout.strip()
 
-          # FIX: Exit early with a clear error if there are no commits to release
-          if [ -z "$COMMIT_LOG" ]; then
-            echo "::error::No commits found between ${BASE} and HEAD. Nothing to release." && exit 1
-          fi
+          if not log:
+              sys.exit(f"::error::No commits found between {base_tag} and HEAD. Nothing to release.")
 
-          while IFS= read -r FULL_HASH && IFS= read -r RAW_MSG && IFS= read -r _SEP; do
-            [ -z "$RAW_MSG" ] && continue
+          sections: dict[str, list[str]] = {k: [] for k in ("feat", "fix", "chore", "misc")}
+          bump = "patch"
 
-            if [ "$FORCE_BUMP" = "auto" ]; then
-              if echo "$RAW_MSG" | grep -q "BREAKING CHANGE" || echo "$RAW_MSG" | grep -Eq '^[a-z]+!(\(.*\))?:'; then BUMP="major"
-              elif echo "$RAW_MSG" | grep -q "^feat" && [ "$BUMP" != "major" ]; then BUMP="minor"; fi
-            fi
+          for raw in log.split("---"):
+              lines = [l for l in raw.strip().splitlines() if l.strip()]
+              if len(lines) < 2:
+                  continue
+              full_hash, raw_msg = lines[0], lines[1]
 
-            SHORT_HASH="${FULL_HASH:0:7}"
-            COMMIT_LINK=" ([${SHORT_HASH}](${REPO_URL}/commit/${FULL_HASH}))"
+              if force_bump == "auto":
+                  if "BREAKING CHANGE" in raw_msg or re.match(r"^[a-z]+!(\(.*\))?:", raw_msg):
+                      bump = "major"
+                  elif raw_msg.startswith("feat") and bump != "major":
+                      bump = "minor"
 
-            W_MSG=$(echo "$RAW_MSG" | sed -E 's/^Merge pull request #[0-9]+ from [^ ]+ //I')
-            CLEAN_MSG=$(echo "$W_MSG" | sed -E 's/[[:space:]]*\(?#[0-9]+\)?//g' | sed 's/^[[:space:]]*//;s/[[:space:]]*$//')
-            BULLET="* ${CLEAN_MSG}${COMMIT_LINK}"
+              short  = full_hash[:7]
+              clean  = re.sub(r"\s*\(?#\d+\)?", "",
+                       re.sub(r"^Merge pull request #\d+ from \S+ ", "", raw_msg, flags=re.I)).strip()
+              bullet = f"* {clean} ([{short}]({repo_url}/commit/{full_hash}))"
+              lower  = clean.lower()
 
-            if echo "$CLEAN_MSG" | grep -iq "^feat"; then FEAT="${FEAT}\n${BULLET}"
-            elif echo "$CLEAN_MSG" | grep -Eiq '^fix|^bug'; then FIX="${FIX}\n${BULLET}"
-            elif echo "$CLEAN_MSG" | grep -Eiq '^chore|^docs|^refactor'; then CHORE="${CHORE}\n${BULLET}"
-            else MISC="${MISC}\n${BULLET}"; fi
-          done <<< "$COMMIT_LOG"
+              key = ("feat"  if lower.startswith("feat") else
+                     "fix"   if re.match(r"^(fix|bug)", lower) else
+                     "chore" if re.match(r"^(chore|docs|refactor)", lower) else "misc")
+              sections[key].append(bullet)
 
-          [ "$FORCE_BUMP" != "auto" ] && BUMP="$FORCE_BUMP"
-          IFS='.' read -r ver_major ver_minor ver_patch <<< "${BASE#v}"
-          case "$BUMP" in
-            major) ver_major=$((ver_major+1)); ver_minor=0; ver_patch=0 ;;
-            minor) ver_minor=$((ver_minor+1)); ver_patch=0 ;;
-            patch) ver_patch=$((ver_patch+1)) ;;
-            *)     ver_patch=$((ver_patch+1)) ;;
-          esac
+          if force_bump != "auto":
+              bump = force_bump
 
-          NEW_TAG="v${ver_major}.${ver_minor}.${ver_patch}"
-          RAW_V="${ver_major}.${ver_minor}.${ver_patch}"
-          if git rev-parse "$NEW_TAG" >/dev/null 2>&1; then echo "::error::Target version '${NEW_TAG}' already exists." && exit 1; fi
+          major, minor, patch = (int(x) for x in base_tag.lstrip("v").split("."))
+          match bump:
+              case "major": major += 1; minor = 0; patch = 0
+              case "minor": minor += 1; patch = 0
+              case _:       patch += 1
 
-          sed -i -E "s/(__version__ *= *['\"])[^'\"]*(['\"])/\1${RAW_V}\2/g" "tutoraspects/__about__.py"
-          sed -i -E "s/(ASPECTS_VERSION\s*:\s*)[0-9]+\.[0-9]+\.[0-9]+/\1${RAW_V}/g" ".ci/config.yml"
-          sed -i -E "s/(current_version\s*=\s*)[0-9]+\.[0-9]+\.[0-9]+/\1${RAW_V}/g" "setup.cfg"
+          new_tag, raw_v = f"v{major}.{minor}.{patch}", f"{major}.{minor}.{patch}"
 
-          ENTRY_MD=""
-          add_section() { ENTRY_MD="${ENTRY_MD}\n\n### $1$2"; }
-          [ -n "$FEAT" ]  && add_section "Features" "$FEAT"
-          [ -n "$FIX" ]   && add_section "Bug Fixes" "$FIX"
-          [ -n "$CHORE" ] && add_section "Maintenance & Refactoring" "$CHORE"
-          [ -n "$MISC" ]  && add_section "Miscellaneous Updates" "$MISC"
+          if subprocess.run(["git", "rev-parse", new_tag], capture_output=True).returncode == 0:
+              sys.exit(f"::error::Target version '{new_tag}' already exists.")
 
-          PR_MD="## ${NEW_TAG} - ${CURRENT_DATE}\n\n${ENTRY_MD}"
+          for path, pattern, repl in [
+              ("tutoraspects/__about__.py", r"(__version__\s*=\s*['\"])[^'\"]*", rf"\g<1>{raw_v}"),
+              (".ci/config.yml",            r"(ASPECTS_VERSION\s*:\s*)\d+\.\d+\.\d+", rf"\g<1>{raw_v}"),
+              ("setup.cfg",                 r"(current_version\s*=\s*)\d+\.\d+\.\d+", rf"\g<1>{raw_v}"),
+          ]:
+              p = Path(path)
+              if p.exists():
+                  p.write_text(re.sub(pattern, repl, p.read_text()))
 
-          C_FILE="CHANGELOG.md"
-          [ ! -f "$C_FILE" ] && touch "$C_FILE"
+          TITLES = {"feat": "Features", "fix": "Bug Fixes",
+                    "chore": "Maintenance & Refactoring", "misc": "Miscellaneous Updates"}
+          body = "\n\n".join(
+              f"### {TITLES[k]}\n" + "\n".join(v)
+              for k, v in sections.items() if v
+          )
+          entry = f"## {new_tag} - {date.today().isoformat()}\n\n{body}"
 
-          # Insert after the file header, before the first existing release entry
-          awk -v entry="$(printf '%b' "$NEW_ENTRY")" '
-            /^## v/ && !done { print entry; done=1 }
-            { print }
-          ' "$C_FILE" > temp.md && mv temp.md "$C_FILE"
+          cl = Path("CHANGELOG.md")
+          cl.touch(exist_ok=True)
+          existing = cl.read_text()
+          cl.write_text(re.sub(r"(^## v)", entry + "\n\n" + r"\1", existing, count=1, flags=re.M)
+                        if re.search(r"^## v", existing, re.M) else existing + "\n\n" + entry)
 
-          echo "new_tag=${NEW_TAG}" >> $GITHUB_OUTPUT
-          echo "raw_version=${RAW_V}" >> $GITHUB_OUTPUT
+          eof = f"EOF_{os.urandom(4).hex()}"
+          with open(os.environ["GITHUB_OUTPUT"], "a") as fh:
+              fh.write(f"new_tag={new_tag}\nraw_version={raw_v}\nBODY<<{eof}\n{entry}\n{eof}\n")
 
-          EOF_SECTOR="EOF_${RANDOM}${RANDOM}"
-          echo "BODY<<${EOF_SECTOR}" >> $GITHUB_OUTPUT
-          printf '%b' "${PR_MD}" >> $GITHUB_OUTPUT
-          echo "" >> $GITHUB_OUTPUT
-          echo "${EOF_SECTOR}" >> $GITHUB_OUTPUT
+          print(f"✅  Prepared release {new_tag} (bump: {bump})")
+          PYEOF
 
       - name: Create Pull Request
         uses: peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1 # v8.1.1

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,46 +1,120 @@
 name: Release
+
 on:
   pull_request:
     types:
       - closed
     branches:
       - main
+  workflow_dispatch:
+    inputs:
+      ref:
+        description: 'Branch, tag, or version to release from (e.g. 2.5.3, v2.5.3, or bot/v2.5.3, default: main)'
+        required: false
+        default: 'main'
+      dry_run:
+        description: 'Skip publishing to PyPI'
+        required: false
+        default: true
+        type: boolean
 
 env:
   TUTOR_ROOT: ./.ci/
 
 jobs:
   release:
-    if: github.event.pull_request.merged == true && startsWith(github.head_ref, 'bot/v')
+    if: >
+      github.event_name == 'workflow_dispatch' ||
+      (github.event.pull_request.merged == true && startsWith(github.head_ref, 'bot/v'))
     runs-on: ubuntu-latest
     permissions:
       contents: write
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-      - name: Create tag
-        id: tag_version
-        uses: python-semantic-release/python-semantic-release@350c48fcb3ffcdfd2e0a235206bc2ecea6b69df0 # v10.5.3
-        with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-          push: false
-      - name: Create a GitHub release
-        if: steps.tag_version.outputs.tag
-        uses: ncipollo/release-action@339a81892b84b4eeb0f6e744e4574d79d0d9b8dd # v1.21.0
-        with:
-          tag: ${{ steps.tag_version.outputs.tag }}
-          name: Release ${{ steps.tag_version.outputs.tag }}
-          body: ${{ steps.tag_version.outputs.release_notes }}
+      - name: Resolve ref
+        id: resolve_ref
+        run: |
+          REF="${{ inputs.ref || github.ref }}"
+          # Normalize bare version (2.5.3 or v2.5.3) to bot/vX.Y.Z
+          if echo "$REF" | grep -Eq '^v?[0-9]+\.[0-9]+\.[0-9]+$'; then
+            REF="bot/v${REF#v}"
+          fi
+          echo "ref=${REF}" >> $GITHUB_OUTPUT
+
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-      - name: setup python
+        with:
+          ref: ${{ steps.resolve_ref.outputs.ref }}
+          fetch-depth: 0
+
+      - name: Read version from package
+        id: read_version
+        run: |
+          RAW_V=$(grep -Eo "[0-9]+\.[0-9]+\.[0-9]+" tutoraspects/__about__.py | head -n 1)
+          echo "raw_version=${RAW_V}" >> $GITHUB_OUTPUT
+          echo "tag=v${RAW_V}" >> $GITHUB_OUTPUT
+
+      - name: Check if version already exists on PyPI
+        if: github.event_name == 'pull_request' || inputs.dry_run == false
+        run: |
+          VERSION="${{ steps.read_version.outputs.raw_version }}"
+          STATUS=$(curl -s -o /dev/null -w "%{http_code}" "https://pypi.org/pypi/tutor-contrib-aspects/${VERSION}/json")
+          if [ "$STATUS" = "200" ]; then
+            echo "::error::Version ${VERSION} is already published on PyPI. Aborting."
+            exit 1
+          fi
+          echo "Version ${VERSION} not found on PyPI, proceeding."
+
+      - name: Create GitHub tag
+        if: github.event_name == 'pull_request' || inputs.dry_run == false
+        # Skip if tag already exists (e.g. re-running after a partial failure)
+        run: |
+          TAG="${{ steps.read_version.outputs.tag }}"
+          if git rev-parse "$TAG" >/dev/null 2>&1; then
+            echo "Tag $TAG already exists, skipping."
+          else
+            git config user.name "github-actions[bot]"
+            git config user.email "github-actions[bot]@users.noreply.github.com"
+            git tag "$TAG"
+            git push origin "$TAG"
+          fi
+
+      - name: Extract release notes
+        id: release_notes
+        run: |
+          EOF_SECTOR="EOF_${RANDOM}${RANDOM}"
+          echo "NOTES<<${EOF_SECTOR}" >> $GITHUB_OUTPUT
+          awk '/^## v/{if(found) exit; found=1} found{print}' CHANGELOG.md >> $GITHUB_OUTPUT
+          echo "${EOF_SECTOR}" >> $GITHUB_OUTPUT
+
+      - name: Create GitHub release
+        if: github.event_name == 'pull_request' || inputs.dry_run == false
+        uses: ncipollo/release-action@v1
+        with:
+          tag: ${{ steps.read_version.outputs.tag }}
+          name: Release ${{ steps.read_version.outputs.tag }}
+          body: ${{ steps.release_notes.outputs.NOTES }}
+          skipBodyUpdate: true
+
+      - name: Set up Python
         uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         with:
-          python-version: 3.12
-      - name: Install pip
+          python-version: '3.12'
+
+      - name: Install dependencies
         run: pip install -r requirements/pip.txt
+
       - name: Build package
         run: make build-pythonpackage
+
+      - name: Validate package
+        run: |
+          pip install twine
+          twine check dist/*
+
       - name: Publish to PyPI
+        if: >
+          github.event_name == 'pull_request' ||
+          (github.event_name == 'workflow_dispatch' && inputs.dry_run == false)
         uses: pypa/gh-action-pypi-publish@release/v1
         with:
           user: __token__

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -93,6 +93,7 @@ jobs:
           name: Release ${{ steps.read_version.outputs.tag }}
           body: ${{ steps.release_notes.outputs.NOTES }}
           skipBodyUpdate: true
+          makeLatest: ${{ github.event_name == 'pull_request' }}
 
       - name: Set up Python
         uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,5 +1,4 @@
 name: Release
-
 on:
   pull_request:
     types:
@@ -9,7 +8,7 @@ on:
   workflow_dispatch:
     inputs:
       ref:
-        description: 'Branch, tag, or version to release from (e.g. 2.5.3, v2.5.3, or bot/v2.5.3, default: main)'
+        description: 'Version to release from (e.g. 2.5.3)'
         required: false
         default: 'main'
       dry_run:
@@ -88,7 +87,7 @@ jobs:
 
       - name: Create GitHub release
         if: github.event_name == 'pull_request' || inputs.dry_run == false
-        uses: ncipollo/release-action@v1
+        uses: ncipollo/release-action@339a81892b84b4eeb0f6e744e4574d79d0d9b8dd # v1.21.0
         with:
           tag: ${{ steps.read_version.outputs.tag }}
           name: Release ${{ steps.read_version.outputs.tag }}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,4 +1,5 @@
 name: Release
+
 on:
   pull_request:
     types:
@@ -33,7 +34,6 @@ jobs:
         id: resolve_ref
         run: |
           REF="${{ inputs.ref || github.ref }}"
-          # Normalize bare version (2.5.3 or v2.5.3) to bot/vX.Y.Z
           if echo "$REF" | grep -Eq '^v?[0-9]+\.[0-9]+\.[0-9]+$'; then
             REF="bot/v${REF#v}"
           fi
@@ -65,7 +65,6 @@ jobs:
 
       - name: Create GitHub tag
         if: github.event_name == 'pull_request' || inputs.dry_run == false
-        # Skip if tag already exists (e.g. re-running after a partial failure)
         run: |
           TAG="${{ steps.read_version.outputs.tag }}"
           if git rev-parse "$TAG" >/dev/null 2>&1; then
@@ -82,7 +81,7 @@ jobs:
         run: |
           EOF_SECTOR="EOF_${RANDOM}${RANDOM}"
           echo "NOTES<<${EOF_SECTOR}" >> $GITHUB_OUTPUT
-          awk '/^## v/{if(found) exit; found=1} found{print}' CHANGELOG.md >> $GITHUB_OUTPUT
+          awk '/^## v/{if(found) exit; found=1; next} found{print}' CHANGELOG.md >> $GITHUB_OUTPUT
           echo "${EOF_SECTOR}" >> $GITHUB_OUTPUT
 
       - name: Create GitHub release
@@ -93,7 +92,7 @@ jobs:
           name: Release ${{ steps.read_version.outputs.tag }}
           body: ${{ steps.release_notes.outputs.NOTES }}
           skipBodyUpdate: true
-          makeLatest: ${{ github.event_name == 'pull_request' }}
+          makeLatest: ${{ contains(github.event.pull_request.labels.*.name, 'make-latest') || 'false' }}
 
       - name: Set up Python
         uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0


### PR DESCRIPTION
co-authored by Claude

gists:
https://gist.github.com/saraburns1/3fddc76328ff0b2b320aa690266e4810
https://gist.github.com/saraburns1/a1c92d04e6d245c83bff7d9be6f2b8c0


**New action to manually release a version based on an old tag (not the most current)**
Accepts tag or branch as a workflow input
Creates PR with changes to version numbers and changelog additions

Tested on fork:
https://github.com/saraburns1/tutor-contrib-aspects/pull/15
```
This PR prepares the release for version v2.5.3 branching from base version v2.5.2.

The SemVer bump type calculation rule applied was: patch.

Once merged, the publication pipeline will trigger automatically.

Proposed Release Notes:
v2.5.3 - 2026-05-20
Features
feat: Add manual version bump workflow ([41f12cd](https://github.com/saraburns1/tutor-contrib-aspects/commit/41f12cde8a4ac203075bc479aa4cf11474f39ffa))
Bug Fixes
Fix commit log formatting and message parsing ([674fe8d](https://github.com/saraburns1/tutor-contrib-aspects/commit/674fe8dcadcc92f3499ade5d97165ace6c134fbb))
Maintenance & Refactoring
Refactor version bumping logic in workflow ([6d687ce](https://github.com/saraburns1/tutor-contrib-aspects/commit/6d687cea8ef43196a54450b57f2f2647ec417fd7))
Miscellaneous Updates
Modify versioning in multiple configuration files ([ad34bb8](https://github.com/saraburns1/tutor-contrib-aspects/commit/ad34bb80692d981c45500580f6bb315c25dc8dd6))
```


**Updates to release action to support new manual version bump process**
Now includes a dry-run option to do everything but push to PyPi 
Uses the version from __about__.py instead of getting 'next tag'
Can be rerun with no effect as long as the version has not actually been published
Will automatically run (with dry-run = false) when release PR is merged into main, otherwise can be run manually in actions

Tested on fork:
https://github.com/saraburns1/tutor-contrib-aspects/actions/runs/26193028803/job/77065897039
```
Checking dist/tutor_contrib_aspects-2.5.3-py3-none-any.whl: PASSED
Checking dist/tutor_contrib_aspects-2.5.3.tar.gz: PASSED
```
```
adding 'tutor_contrib_aspects-2.5.3.dist-info/METADATA'
adding 'tutor_contrib_aspects-2.5.3.dist-info/WHEEL'
adding 'tutor_contrib_aspects-2.5.3.dist-info/entry_points.txt'
adding 'tutor_contrib_aspects-2.5.3.dist-info/top_level.txt'
adding 'tutor_contrib_aspects-2.5.3.dist-info/RECORD'
```