### PR TITLE
feat: add compatibility with frontend-base

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -6,6 +6,8 @@
 #
 appdirs==1.4.4
     # via tutor
+ast-serialize==0.3.0
+    # via mypy
 bcrypt==5.0.0
     # via -r requirements/base.in
 black==26.3.1
@@ -24,7 +26,7 @@ click==8.2.1
     #   tutor
 durationpy==0.10
     # via kubernetes
-idna==3.13
+idna==3.14
     # via requests
 importlib-metadata==9.0.0
     # via tutor
@@ -38,11 +40,11 @@ jinja2==3.1.6
     #   tutor
 kubernetes==35.0.0
     # via tutor
-librt==0.9.0
+librt==0.11.0
     # via mypy
 markupsafe==3.0.3
     # via jinja2
-mypy==1.20.2
+mypy==2.0.0
     # via tutor
 mypy-extensions==1.1.0
     # via
@@ -90,7 +92,7 @@ six==1.17.0
     #   python-dateutil
 tqdm==4.67.3
     # via shandy-sqlfmt
-tutor==21.0.4
+tutor==21.0.6
     # via
     #   -r requirements/base.in
     #   tutor-mfe
@@ -100,7 +102,7 @@ typing-extensions==4.15.0
     # via
     #   mypy
     #   tutor
-urllib3==2.6.3
+urllib3==2.7.0
     # via
     #   kubernetes
     #   requests

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -10,6 +10,10 @@ appdirs==1.4.4
     # via
     #   -r requirements/base.txt
     #   tutor
+ast-serialize==0.3.0
+    # via
+    #   -r requirements/base.txt
+    #   mypy
 astroid==4.0.4
     # via pylint
 bcrypt==5.0.0
@@ -36,7 +40,7 @@ click==8.2.1
     #   black
     #   shandy-sqlfmt
     #   tutor
-cryptography==47.0.0
+cryptography==48.0.0
     # via secretstorage
 dill==0.4.1
     # via pylint
@@ -48,7 +52,7 @@ durationpy==0.10
     #   kubernetes
 id==1.6.1
     # via twine
-idna==3.13
+idna==3.14
     # via
     #   -r requirements/base.txt
     #   requests
@@ -83,11 +87,11 @@ kubernetes==35.0.0
     # via
     #   -r requirements/base.txt
     #   tutor
-librt==0.9.0
+librt==0.11.0
     # via
     #   -r requirements/base.txt
     #   mypy
-markdown-it-py==4.0.0
+markdown-it-py==4.2.0
     # via rich
 markupsafe==3.0.3
     # via
@@ -101,7 +105,7 @@ more-itertools==11.0.2
     # via
     #   jaraco-classes
     #   jaraco-functools
-mypy==1.20.2
+mypy==2.0.0
     # via
     #   -r requirements/base.txt
     #   tutor
@@ -149,7 +153,7 @@ pygments==2.20.0
     #   rich
 pyinstaller==6.20.0
     # via -r requirements/dev.in
-pyinstaller-hooks-contrib==2026.4
+pyinstaller-hooks-contrib==2026.5
     # via pyinstaller
 pylint==4.0.5
     # via -r requirements/dev.in
@@ -196,13 +200,13 @@ six==1.17.0
     #   -r requirements/base.txt
     #   kubernetes
     #   python-dateutil
-tomlkit==0.14.0
+tomlkit==0.15.0
     # via pylint
 tqdm==4.67.3
     # via
     #   -r requirements/base.txt
     #   shandy-sqlfmt
-tutor==21.0.4
+tutor==21.0.6
     # via
     #   -r requirements/base.txt
     #   tutor-mfe
@@ -215,7 +219,7 @@ typing-extensions==4.15.0
     #   -r requirements/base.txt
     #   mypy
     #   tutor
-urllib3==2.6.3
+urllib3==2.7.0
     # via
     #   -r requirements/base.txt
     #   id

--- a/requirements/pip.txt
+++ b/requirements/pip.txt
@@ -10,7 +10,7 @@ wheel==0.47.0
     # via -r requirements/pip.in
 
 # The following packages are considered to be unsafe in a requirements file:
-pip==26.1
+pip==26.1.1
     # via -r requirements/pip.in
 setuptools==82.0.1
     # via -r requirements/pip.in

--- a/tutoraspects/patches/openedx-common-settings
+++ b/tutoraspects/patches/openedx-common-settings
@@ -28,12 +28,20 @@ try:
     not OPEN_EDX_FILTERS_CONFIG
 except NameError:  # OPEN_EDX_FILTERS_CONFIG is not defined
     OPEN_EDX_FILTERS_CONFIG = {}
+# When DEPR-38432 is pickedup we may want to cleanup here.
 if not OPEN_EDX_FILTERS_CONFIG.get("org.openedx.learning.instructor.dashboard.render.started.v1"):
     OPEN_EDX_FILTERS_CONFIG["org.openedx.learning.instructor.dashboard.render.started.v1"] = {
         "fail_silently": False,
         "pipeline": [],
     }
+if not OPEN_EDX_FILTERS_CONFIG.get("org.openedx.learning.instructor.dashboard.tabs.requested.v1"):
+    OPEN_EDX_FILTERS_CONFIG["org.openedx.learning.instructor.dashboard.tabs.requested.v1"] = {
+        "fail_silently": False,
+        "pipeline": [],
+    }
+
 OPEN_EDX_FILTERS_CONFIG["org.openedx.learning.instructor.dashboard.render.started.v1"]["pipeline"].append("platform_plugin_aspects.extensions.filters.AddSupersetTab")
+OPEN_EDX_FILTERS_CONFIG["org.openedx.learning.instructor.dashboard.tabs.requested.v1"]["pipeline"].append("platform_plugin_aspects.extensions.filters.AddSupersetTabToInstructorDashboard")
 {% endif %}
 
 {% if ASPECTS_ENABLE_EVENT_BUS_PRODUCER %}

--- a/tutoraspects/patches/openedx-dev-dockerfile-post-python-requirements
+++ b/tutoraspects/patches/openedx-dev-dockerfile-post-python-requirements
@@ -1,5 +1,5 @@
 RUN --mount=type=cache,target=/openedx/.cache/pip,sharing=shared \
-    pip install "platform-plugin-aspects==v1.2.0"
+    pip install "platform-plugin-aspects==v1.3.0"
 
 RUN --mount=type=cache,target=/openedx/.cache/pip,sharing=shared \
     pip install "edx-event-routing-backends>=10.0.0"

--- a/tutoraspects/patches/openedx-dockerfile-post-python-requirements
+++ b/tutoraspects/patches/openedx-dockerfile-post-python-requirements
@@ -1,5 +1,5 @@
 RUN --mount=type=cache,target=/openedx/.cache/pip,sharing=shared \
-    pip install "platform-plugin-aspects==v1.2.0"
+    pip install "platform-plugin-aspects==v1.3.0"
 
 RUN --mount=type=cache,target=/openedx/.cache/pip,sharing=shared \
     pip install "edx-event-routing-backends>=10.0.0"

--- a/tutoraspects/plugin.py
+++ b/tutoraspects/plugin.py
@@ -13,9 +13,10 @@ import importlib_resources
 from tutor import hooks
 
 try:
-    from tutormfe.hooks import PLUGIN_SLOTS
+    from tutormfe.hooks import FRONTEND_APPS, PLUGIN_SLOTS
+    _tutormfe_available = True
 except ImportError:
-    PLUGIN_SLOTS = None
+    _tutormfe_available = False
 
 from .__about__ import __version__
 from .commands_v1 import COMMANDS as TUTOR_V1_COMMANDS
@@ -685,7 +686,7 @@ except ImportError:
 
 # If PLUGIN_SLOTS doesn't exist, we are on Redwood and do not
 # support in-context metrics.
-if PLUGIN_SLOTS:
+if _tutormfe_available:
     PLUGIN_SLOTS.add_items(
         [
             (
@@ -794,3 +795,22 @@ if PLUGIN_SLOTS:
             ),
         ]
     )
+
+    @FRONTEND_APPS.add()
+    def _add_frontend_app_aspects(apps):
+        apps["aspects"] = {
+            "npm_package": "@openedx/frontend-app-aspects",
+            "npm_version": "*",
+            "enabled": True,
+        }
+        return apps
+
+    hooks.Filters.ENV_PATCHES.add_item((
+        "mfe-site-config-imports",
+        "import { aspectsApp } from '@openedx/frontend-app-aspects';",
+    ))
+
+    hooks.Filters.ENV_PATCHES.add_item((
+        "mfe-site-config",
+        "addApp(siteConfig, aspectsApp);",
+    ))

--- a/tutoraspects/plugin.py
+++ b/tutoraspects/plugin.py
@@ -14,9 +14,10 @@ from tutor import hooks
 
 try:
     from tutormfe.hooks import FRONTEND_APPS, PLUGIN_SLOTS
-    _tutormfe_available = True
+
+    _TUTORMFE_AVAILABLE = True
 except ImportError:
-    _tutormfe_available = False
+    _TUTORMFE_AVAILABLE = False
 
 from .__about__ import __version__
 from .commands_v1 import COMMANDS as TUTOR_V1_COMMANDS
@@ -686,7 +687,7 @@ except ImportError:
 
 # If PLUGIN_SLOTS doesn't exist, we are on Redwood and do not
 # support in-context metrics.
-if _tutormfe_available:
+if _TUTORMFE_AVAILABLE:
     PLUGIN_SLOTS.add_items(
         [
             (
@@ -805,12 +806,16 @@ if _tutormfe_available:
         }
         return apps
 
-    hooks.Filters.ENV_PATCHES.add_item((
-        "mfe-site-config-imports",
-        "import { aspectsApp } from '@openedx/frontend-app-aspects';",
-    ))
+    hooks.Filters.ENV_PATCHES.add_item(
+        (
+            "mfe-site-config-imports",
+            "import { aspectsApp } from '@openedx/frontend-app-aspects';",
+        )
+    )
 
-    hooks.Filters.ENV_PATCHES.add_item((
-        "mfe-site-config",
-        "addApp(siteConfig, aspectsApp);",
-    ))
+    hooks.Filters.ENV_PATCHES.add_item(
+        (
+            "mfe-site-config",
+            "addApp(siteConfig, aspectsApp);",
+        )
+    )


### PR DESCRIPTION
In order to have https://github.com/openedx/frontend-app-instructor-dashboard/issues/86 ready we need compatibility for the reports tab.

The old reports tab was being added through a filter that modified the Mako template, the new instructor dashboard it's made with the [frontend-base](https://github.com/openedx/frontend-base) pattern so in order to make the Reports tab available we need some changes

This PR does two things

- adds the base configuration for a new app called `frontend-app-aspects` which will hold all the UI related functionality for the reports tab
- adds the filter to the pipeline for the tab info

This PR depends on:

Implement new filter for the new instructor dashboard data request-> https://github.com/openedx/openedx-filters/pull/355
Uses new filter to modify new tabs endpoint -> https://github.com/openedx/openedx-platform/pull/38499
Adds class for the filter pipeline and creates endpoint to fetch information required by the frontend-app -> TBD
