### PR TITLE
fix: adds the port to superset's metadata sqlalchemy uri

### DIFF
--- a/tutoraspects/plugin.py
+++ b/tutoraspects/plugin.py
@@ -312,7 +312,7 @@ hooks.Filters.CONFIG_DEFAULTS.add_items(
         (
             "SUPERSET_METADATA_SQLALCHEMY_URI",
             "mysql://{{SUPERSET_DB_USERNAME}}:{{SUPERSET_DB_PASSWORD}}"
-            "@{{SUPERSET_DB_HOST}}/{{SUPERSET_DB_METADATA_NAME}}",
+            "@{{SUPERSET_DB_HOST}}:{{SUPERSET_DB_PORT}}/{{SUPERSET_DB_METADATA_NAME}}",
         ),
         (
             "SUPERSET_DATABASES",


### PR DESCRIPTION
## Description

When MySQL is being served in non-default port, the SUPERSET_METADATA_SQLALCHEMY_URI becomes invalid as there is not explicit port. This commit adds the port to the URI.

### Debugging logs

The Step 4 **Importing Assets** fails as it tries to connect to the Metadata DB without the Port.

```
Init Step 4/5 [Starting] -- Importing assets
 
 
######################################################################
 
Loaded your Docker configuration at [/app/pythonpath/..2026_06_03_12_40_57.4203812166/superset_config_docker.py]
Loaded your LOCAL configuration at [/app/pythonpath/..2026_06_03_12_40_57.4203812166/superset_config.py]
2026-06-03 12:42:17,270:WARNING:superset.initialization:We haven't found any Content Security Policy (CSP) defined in the configurations. Please make sure to configure CSP using the TALISMAN_ENABLED and TALISMAN_CONFIG keys or any other external software. Failing to configure CSP have serious security implications. Check https://developer.mozilla.org/en-US/docs/Web/HTTP/CSP for more information. You can disable this warning using the CONTENT_SECURITY_POLICY_WARNING key.
2026-06-03 12:42:17,276:INFO:superset.initialization:Setting database isolation level to READ COMMITTED
/usr/local/lib/python3.10/site-packages/flask_limiter/extension.py:333: UserWarning: Using the in-memory storage for tracking rate limits as no storage was explicitly specified. This is not recommended for production use. See: https://flask-limiter.readthedocs.io#configuring-a-storage-backend for documentation about configuring the storage backend.
  warnings.warn(
2026-06-03 12:42:17,592:INFO:superset.utils.screenshots:No PIL installation found
2026-06-03 12:42:18,449:INFO:superset.utils.pdf:No PIL installation found
/app/superset/commands/importers/v1/utils.py:113: SAWarning: TypeDecorator EncryptedType() will not produce a cache key because the ``cache_ok`` attribute is not set to True.  This can have significant performance implications including some performance degradations in comparison to prior SQLAlchemy versions.  Set this attribute to True if this type object's state is safe to use in a cache key, or False to disable this warning. (Background on this error at: https://sqlalche.me/e/14/cprf)
  for uuid, password in db.session.query(Database.uuid, Database.password).all()
/app/superset/commands/importers/v1/utils.py:118: SAWarning: TypeDecorator EncryptedType() will not produce a cache key because the ``cache_ok`` attribute is not set to True.  This can have significant performance implications including some performance degradations in comparison to prior SQLAlchemy versions.  Set this attribute to True if this type object's state is safe to use in a cache key, or False to disable this warning. (Background on this error at: https://sqlalche.me/e/14/cprf)
  for uuid, password in db.session.query(SSHTunnel.uuid, SSHTunnel.password).all()
/app/superset/commands/importers/v1/utils.py:125: SAWarning: TypeDecorator EncryptedType() will not produce a cache key because the ``cache_ok`` attribute is not set to True.  This can have significant performance implications including some performance degradations in comparison to prior SQLAlchemy versions.  Set this attribute to True if this type object's state is safe to use in a cache key, or False to disable this warning. (Background on this error at: https://sqlalche.me/e/14/cprf)
  ).all()
/app/superset/commands/importers/v1/utils.py:132: SAWarning: TypeDecorator EncryptedType() will not produce a cache key because the ``cache_ok`` attribute is not set to True.  This can have significant performance implications including some performance degradations in comparison to prior SQLAlchemy versions.  Set this attribute to True if this type object's state is safe to use in a cache key, or False to disable this warning. (Background on this error at: https://sqlalche.me/e/14/cprf)
  ).all()
Traceback (most recent call last):
  File "/app/superset/utils/decorators.py", line 259, in wrapped
    result = func(*args, **kwargs)
  File "/app/superset/commands/importers/v1/assets.py", line 167, in run
    self._import(self._configs)
  File "/app/superset/commands/importers/v1/assets.py", line 89, in _import
    database = import_database(config, overwrite=True)
  File "/app/superset/commands/database/importers/v1/utils.py", line 84, in import_database
    add_permissions(database, ssh_tunnel)
  File "/app/superset/commands/database/importers/v1/utils.py", line 113, in add_permissions
    for schema in database.get_all_schema_names(
  File "/app/superset/utils/cache.py", line 127, in wrapped_f
    return f(*args, **kwargs)
  File "/app/superset/models/core.py", line 846, in get_all_schema_names
    raise self.db_engine_spec.get_dbapi_mapped_exception(ex) from ex
  File "/app/superset/models/core.py", line 840, in get_all_schema_names
    with self.get_inspector(
  File "/usr/local/lib/python3.10/contextlib.py", line 135, in __enter__
    return next(self.gen)
  File "/app/superset/models/core.py", line 820, in get_inspector
    yield sqla.inspect(engine)
  File "/usr/local/lib/python3.10/site-packages/sqlalchemy/inspection.py", line 64, in inspect
    ret = reg(subject)
  File "/usr/local/lib/python3.10/site-packages/sqlalchemy/engine/reflection.py", line 182, in _engine_insp
    return Inspector._construct(Inspector._init_engine, bind)
  File "/usr/local/lib/python3.10/site-packages/sqlalchemy/engine/reflection.py", line 117, in _construct
    init(self, bind)
  File "/usr/local/lib/python3.10/site-packages/sqlalchemy/engine/reflection.py", line 128, in _init_engine
    engine.connect().close()
  File "/usr/local/lib/python3.10/site-packages/sqlalchemy/engine/base.py", line 3325, in connect
    return self._connection_cls(self, close_with_result=close_with_result)
  File "/usr/local/lib/python3.10/site-packages/sqlalchemy/engine/base.py", line 96, in __init__
    else engine.raw_connection()
  File "/usr/local/lib/python3.10/site-packages/sqlalchemy/engine/base.py", line 3404, in raw_connection
    return self._wrap_pool_connect(self.pool.connect, _connection)
  File "/usr/local/lib/python3.10/site-packages/sqlalchemy/engine/base.py", line 3374, in _wrap_pool_connect
    Connection._handle_dbapi_exception_noconnection(
  File "/usr/local/lib/python3.10/site-packages/sqlalchemy/engine/base.py", line 2208, in _handle_dbapi_exception_noconnection
    util.raise_(
  File "/usr/local/lib/python3.10/site-packages/sqlalchemy/util/compat.py", line 211, in raise_
    raise exception
  File "/usr/local/lib/python3.10/site-packages/sqlalchemy/engine/base.py", line 3371, in _wrap_pool_connect
    return fn()
  File "/usr/local/lib/python3.10/site-packages/sqlalchemy/pool/base.py", line 327, in connect
    return _ConnectionFairy._checkout(self)
  File "/usr/local/lib/python3.10/site-packages/sqlalchemy/pool/base.py", line 894, in _checkout
    fairy = _ConnectionRecord.checkout(pool)
  File "/usr/local/lib/python3.10/site-packages/sqlalchemy/pool/base.py", line 493, in checkout
    rec = pool._do_get()
  File "/usr/local/lib/python3.10/site-packages/sqlalchemy/pool/impl.py", line 256, in _do_get
    return self._create_connection()
  File "/usr/local/lib/python3.10/site-packages/sqlalchemy/pool/base.py", line 273, in _create_connection
    return _ConnectionRecord(self)
  File "/usr/local/lib/python3.10/site-packages/sqlalchemy/pool/base.py", line 388, in __init__
    self.__connect()
  File "/usr/local/lib/python3.10/site-packages/sqlalchemy/pool/base.py", line 690, in __connect
    with util.safe_reraise():
  File "/usr/local/lib/python3.10/site-packages/sqlalchemy/util/langhelpers.py", line 70, in __exit__
    compat.raise_(
  File "/usr/local/lib/python3.10/site-packages/sqlalchemy/util/compat.py", line 211, in raise_
    raise exception
  File "/usr/local/lib/python3.10/site-packages/sqlalchemy/pool/base.py", line 686, in __connect
    self.dbapi_connection = connection = pool._invoke_creator(self)
  File "/usr/local/lib/python3.10/site-packages/sqlalchemy/engine/create.py", line 574, in connect
    return dialect.connect(*cargs, **cparams)
  File "/usr/local/lib/python3.10/site-packages/sqlalchemy/engine/default.py", line 598, in connect
    return self.dbapi.connect(*cargs, **cparams)
  File "/usr/local/lib/python3.10/site-packages/MySQLdb/__init__.py", line 123, in Connect
    return Connection(*args, **kwargs)
  File "/usr/local/lib/python3.10/site-packages/MySQLdb/connections.py", line 185, in __init__
    super().__init__(*args, **kwargs2)
sqlalchemy.exc.OperationalError: (MySQLdb._exceptions.OperationalError) (2002, "Can't connect to server on 'xxxxxxxxxxxxxx.db.ondigitalocean.com' (115)")
(Background on this error at: https://sqlalche.me/e/14/e3q8)
 
The above exception was the direct cause of the following exception:
 
Traceback (most recent call last):
  File "/app/pythonpath/create_assets.py", line 354, in <module>
    main()
  File "/app/pythonpath/create_assets.py", line 59, in main
    create_assets()
  File "/app/pythonpath/create_assets.py", line 86, in create_assets
    import_assets()
  File "/app/pythonpath/create_assets.py", line 263, in import_assets
    load_configs_from_directory(
  File "/app/pythonpath/openedx/create_assets_utils.py", line 85, in load_configs_from_directory
    command.run()
  File "/app/superset/utils/decorators.py", line 266, in wrapped
    return on_error(ex)
  File "/app/superset/utils/decorators.py", line 234, in on_error
    raise reraise() from ex
superset.commands.exceptions.ImportFailedError: Import failed for an unknown reason
```

Internal-ref: https://tasks.opencraft.com/browse/BB-10779