### PR TITLE
feat: enable secure session cookie for Superset when using HTTPS

### DIFF
--- a/tutoraspects/templates/aspects/apps/superset/pythonpath/superset_config.py
+++ b/tutoraspects/templates/aspects/apps/superset/pythonpath/superset_config.py
@@ -162,6 +162,9 @@ sentry_sdk.init(
 {% endif %}
 
 {% if ENABLE_HTTPS %}
+# Grant a Superset secure session cookie
+SESSION_COOKIE_SECURE = True
+
 TALISMAN_ENABLED = True
 TALISMAN_CONFIG = {
     "content_security_policy": {


### PR DESCRIPTION
This PR enables the secure session cookie feature for Superset when HTTPS is enabled. This was tested with success in the latest version of Aspects Superset used by the main branch (3.0.3)