### PR TITLE
chore: Add 'permissions' to Tutor build commands in CI

### DIFF
--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -46,7 +46,7 @@ jobs:
           large-packages: false
           swap-storage: true
       - name: Tutor build openedx
-        run: tutor images build openedx aspects aspects-superset
+        run: tutor images build openedx aspects aspects-superset permissions
       - name: Tutor start
         run: tutor local start -d
       - name: Tutor init
@@ -119,7 +119,7 @@ jobs:
           large-packages: false
           swap-storage: true
       - name: Tutor build openedx
-        run: tutor images build openedx-dev aspects aspects-superset
+        run: tutor images build openedx-dev aspects aspects-superset permissions
       - name: Tutor start
         run: tutor dev start -d
       - name: Tutor init
@@ -198,7 +198,7 @@ jobs:
       - name: Setup Docker Buildx
         uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5 # v4.1.0
       - name: Tutor build openedx
-        run: tutor images build openedx aspects aspects-superset
+        run: tutor images build openedx aspects aspects-superset permissions
       - name: Create k8s Kind Cluster
         uses: helm/kind-action@ef37e7f390d99f746eb8b610417061a60e82a6cc # v1.14.0
       - name: Mount docker image
@@ -340,7 +340,7 @@ jobs:
           large-packages: false
           swap-storage: true
       - name: Tutor build openedx
-        run: tutor images build openedx aspects aspects-superset
+        run: tutor images build openedx aspects aspects-superset permissions
       - name: Tutor start
         run: tutor local start -d
       - name: Tutor init
@@ -413,7 +413,7 @@ jobs:
           large-packages: false
           swap-storage: true
       - name: Tutor build openedx
-        run: tutor images build openedx-dev aspects aspects-superset
+        run: tutor images build openedx-dev aspects aspects-superset permissions
       - name: Tutor start
         run: tutor dev start -d
       - name: Tutor init
@@ -490,7 +490,7 @@ jobs:
       - name: Setup Docker Buildx
         uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5 # v4.1.0
       - name: Tutor build openedx
-        run: tutor images build openedx aspects aspects-superset
+        run: tutor images build openedx aspects aspects-superset permissions
       - name: Create k8s Kind Cluster
         uses: helm/kind-action@ef37e7f390d99f746eb8b610417061a60e82a6cc # v1.14.0
       - name: Mount docker image


### PR DESCRIPTION
Needed in 'Verawood' branch to build correct versions of tutor images