### PR TITLE
fix: Course run tab incorrect dashboard filter link

### DIFF
--- a/tutoraspects/templates/aspects/apps/superset/pythonpath/openedx_jinja_filters.py
+++ b/tutoraspects/templates/aspects/apps/superset/pythonpath/openedx_jinja_filters.py
@@ -4,11 +4,12 @@ Custom Jinja template filters that can be used in Superset queries.
 cf https://superset.apache.org/docs/installation/sql-templating/
 """
 
-from superset.extensions import security_manager
-from openedx.localization import get_translation, DATASET_STRINGS
-from superset import security_manager
 import logging
+
 from flask import g
+from openedx.localization import DATASET_STRINGS, get_translation
+from superset import security_manager
+from superset.extensions import security_manager
 
 log = logging.getLogger(__name__)
 ALL_COURSES = "1 = 1"
@@ -104,37 +105,86 @@ def translate_column_bool(column_name):
     false_str = get_translation(strings[1], lang)
 
     return f"""
-        CASE WHEN {column_name} = true 
-        THEN '{true_str}' 
+        CASE WHEN {column_name} = true
+        THEN '{true_str}'
         ELSE '{false_str}'
         END
     """
 
 
-SQL_LINK_FORMAT = """
-concat('<a href="{% if ENABLE_HTTPS %}https{% else %}http{% endif %}://{{ SUPERSET_HOST }}/superset/dashboard/{dashboard_slug}/?native_filters=(NATIVE_FILTER-{filter_id}:(__cache:(label:''', 
-    {column}, 
-    ''',validateStatus:!f,value:!(''', 
-    {column}, 
-    ''')),extraFormData:(filters:!((col:{column},op:IN,val:!(''', 
-    {column}, 
-    ''')))),filterState:(label:''', 
-    {column}, 
-    ''',validateStatus:!f,value:!(''', 
-    {column}, 
-    ''')),id:NATIVE_FILTER-{filter_id},ownState:()))">', 
-    {column}, 
-    '</a>'
+# Opening of the link / URL, up to the opening paren of the
+# Rison-encoded `native_filters` map. Reminder that this first
+# gets rendered by Tutor, so things in Jinja syntax (double curly
+# braces or curly-brace-percent) will be replaced before being
+# sent to Superset.
+SQL_LINK_HEADER = (
+    """concat('<a href="{% if ENABLE_HTTPS %}https{% else %}http{% endif %}"""
+    """://{{ SUPERSET_HOST }}/superset/dashboard/{dashboard_slug}/?native_filters=('"""
 )
-"""
+
+# A single `NATIVE_FILTER-<id>` entry in the `native_filters` map. Multiple of
+# these can be joined with a comma to use more than one filter at once.
+SQL_LINK_FILTER = """'NATIVE_FILTER-{filter_id}:(__cache:(label:''',
+    {column},
+    ''',validateStatus:!f,value:!(''',
+    {column},
+    ''')),extraFormData:(filters:!((col:{column},op:IN,val:!(''',
+    {column},
+    ''')))),filterState:(label:''',
+    {column},
+    ''',validateStatus:!f,value:!(''',
+    {column},
+    ''')),id:NATIVE_FILTER-{filter_id},ownState:())'"""
+
+# Closes the `native_filters` map / href attribute, then renders the link text.
+SQL_LINK_FOOTER = """')">',
+    {label_column},
+    '</a>'
+)"""
+
+SQL_LINK_FILTER_SEPARATOR = ", ',', \n    "
+
+
 def get_filtered_dashboard_link(dashboard_slug, column_name, filter_id):
     """
     Creates a link to a dashboard with filters preloaded given a dashboard-slug, a column_name and a filter_id
     """
+    return get_multiple_filtered_dashboard_link(
+        dashboard_slug, [(column_name, filter_id)]
+    )
+
+
+def get_multiple_filtered_dashboard_link(dashboard_slug, filters, label_column=None):
+    """
+    Creates a link to a dashboard with one or more native filters preloaded.
+
+    Args:
+        dashboard_slug: slug of the destination dashboard (the current user's
+            language suffix is appended automatically).
+        filters: an iterable of (column_name, filter_id) pairs. Each pair adds a
+            native filter to the link, scoped to ``column_name IN (<row value>)``.
+        label_column: the column whose value is shown as the link text. Defaults
+            to the first filter's column.
+    """
+    filters = list(filters)
+    if not filters:
+        raise ValueError(
+            "get_multiple_filtered_dashboard_link requires at least one filter."
+        )
+
+    if label_column is None:
+        label_column = filters[0][0]
+
     lang = security_manager.get_preferences(g.user.username)
 
-    hlink = SQL_LINK_FORMAT.format(dashboard_slug=f"{dashboard_slug}-{lang}", column=column_name, filter_id=filter_id)
+    header = SQL_LINK_HEADER.format(dashboard_slug=f"{dashboard_slug}-{lang}")
+    blocks = SQL_LINK_FILTER_SEPARATOR.join(
+        SQL_LINK_FILTER.format(column=column_name, filter_id=filter_id)
+        for column_name, filter_id in filters
+    )
+    footer = SQL_LINK_FOOTER.format(label_column=label_column)
 
-    return hlink
+    return f"{header}, \n    {blocks}, \n    {footer}"
+
 
 {{patch("superset-jinja-filters")}}

--- a/tutoraspects/templates/aspects/apps/superset/pythonpath/superset_config_docker.py
+++ b/tutoraspects/templates/aspects/apps/superset/pythonpath/superset_config_docker.py
@@ -123,6 +123,7 @@ JINJA_CONTEXT_ADDONS = {
     'translate_column': translate_column,
     'translate_column_bool': translate_column_bool,
     'get_filtered_dashboard_link': get_filtered_dashboard_link,
+    'get_multiple_filtered_dashboard_link': get_multiple_filtered_dashboard_link,
     {% for filter in SUPERSET_EXTRA_JINJA_FILTERS %}'{{ filter }}': {{filter}},{% endfor %}
 }
 

--- a/tutoraspects/templates/aspects/build/aspects-superset/openedx-assets/assets/charts/Course_Info_ccdd7d.yaml
+++ b/tutoraspects/templates/aspects/build/aspects-superset/openedx-assets/assets/charts/Course_Info_ccdd7d.yaml
@@ -6,11 +6,11 @@ dataset_uuid: 27a4476b-5a9a-4fc4-ac75-da520b522341
 description: null
 params:
   adhoc_filters:
-  - clause: WHERE
-    comparator: No filter
-    expressionType: SIMPLE
-    operator: TEMPORAL_RANGE
-    subject: emission_time
+    - clause: WHERE
+      comparator: No filter
+      expressionType: SIMPLE
+      operator: TEMPORAL_RANGE
+      subject: emission_time
   all_columns: []
   annotation_layers: []
   color_pn: false
@@ -28,17 +28,18 @@ params:
   conditional_formatting: []
   extra_form_data: {}
   groupby:
-  - course_run
-  - course_name
-  - expressionType: SQL
-    label: More details
-    sqlExpression: |-
-      {% raw %}{{ get_filtered_dashboard_link('course-dashboard', 'course_run', 'w863AfFgi') }}
-      {% endraw %}
+    - course_run
+    - course_name
+    - expressionType: SQL
+      label: More details
+      sqlExpression: |-
+        {% raw %}
+        {{ get_multiple_filtered_dashboard_link('course-dashboard', [('course_name', 'IfS-Rd0ZS'), ('org', 'w863AfFgi'), ('course_run', 'w863AfFgi')]) }}
+        {% endraw %}
   metrics:
-  - enrollees
-  - active_count
-  - tag_list
+    - enrollees
+    - active_count
+    - tag_list
   order_by_cols: []
   order_desc: false
   percent_metrics: []
@@ -56,11 +57,11 @@ query_context:
   force: false
   form_data:
     adhoc_filters:
-    - clause: WHERE
-      comparator: No filter
-      expressionType: SIMPLE
-      operator: TEMPORAL_RANGE
-      subject: emission_time
+      - clause: WHERE
+        comparator: No filter
+        expressionType: SIMPLE
+        operator: TEMPORAL_RANGE
+        subject: emission_time
     all_columns: []
     annotation_layers: []
     color_pn: false
@@ -80,17 +81,17 @@ query_context:
     extra_form_data: {}
     force: false
     groupby:
-    - course_run
-    - course_name
-    - expressionType: SQL
-      label: More details
-      sqlExpression: |-
-        {% raw %}{{ get_filtered_dashboard_link('course-dashboard', 'course_run', 'w863AfFgi') }}
-        {% endraw %}
+      - course_run
+      - course_name
+      - expressionType: SQL
+        label: More details
+        sqlExpression: |-
+          {% raw %}{{ get_filtered_dashboard_link('course-dashboard', 'course_run', 'w863AfFgi') }}
+          {% endraw %}
     metrics:
-    - enrollees
-    - active_count
-    - tag_list
+      - enrollees
+      - active_count
+      - tag_list
     order_by_cols: []
     order_desc: false
     percent_metrics: []
@@ -105,38 +106,38 @@ query_context:
     time_grain_sqla: P1M
     viz_type: table
   queries:
-  - annotation_layers: []
-    applied_time_extras: {}
-    columns:
-    - course_run
-    - course_name
-    - expressionType: SQL
-      label: More details
-      sqlExpression: |-
-        {% raw %}{{ get_filtered_dashboard_link('course-dashboard', 'course_run', 'w863AfFgi') }}
-        {% endraw %}
-    custom_form_data: {}
-    custom_params: {}
-    extras:
-      having: ''
-      time_grain_sqla: P1M
-      where: ''
-    filters:
-    - col: emission_time
-      op: TEMPORAL_RANGE
-      val: No filter
-    metrics:
-    - enrollees
-    - active_count
-    - tag_list
-    order_desc: false
-    orderby:
-    - - enrollees
-      - false
-    post_processing: []
-    row_limit: 50000
-    series_limit: 0
-    url_params: {}
+    - annotation_layers: []
+      applied_time_extras: {}
+      columns:
+        - course_run
+        - course_name
+        - expressionType: SQL
+          label: More details
+          sqlExpression: |-
+            {% raw %}{{ get_filtered_dashboard_link('course-dashboard', 'course_run', 'w863AfFgi') }}
+            {% endraw %}
+      custom_form_data: {}
+      custom_params: {}
+      extras:
+        having: ""
+        time_grain_sqla: P1M
+        where: ""
+      filters:
+        - col: emission_time
+          op: TEMPORAL_RANGE
+          val: No filter
+      metrics:
+        - enrollees
+        - active_count
+        - tag_list
+      order_desc: false
+      orderby:
+        - - enrollees
+          - false
+      post_processing: []
+      row_limit: 50000
+      series_limit: 0
+      url_params: {}
   result_format: json
   result_type: full
 slice_name: Course Info


### PR DESCRIPTION
I should have rolled this for the Verawood branch first, it can come back with the forwardport. 

Linking from Course Comparison -> Course Run tab in the "Course Info" chart to the "Course Dashboard" only included the course run filter, not the course name filter. This fixes that.