### PR TITLE
fix: adds the port to superset's metadata sqlalchemy uri

### DIFF
--- a/tutoraspects/plugin.py
+++ b/tutoraspects/plugin.py
@@ -312,7 +312,7 @@ hooks.Filters.CONFIG_DEFAULTS.add_items(
         (
             "SUPERSET_METADATA_SQLALCHEMY_URI",
             "mysql://{{SUPERSET_DB_USERNAME}}:{{SUPERSET_DB_PASSWORD}}"
-            "@{{SUPERSET_DB_HOST}}/{{SUPERSET_DB_METADATA_NAME}}",
+            "@{{SUPERSET_DB_HOST}}:{{SUPERSET_DB_PORT}}/{{SUPERSET_DB_METADATA_NAME}}",
         ),
         (
             "SUPERSET_DATABASES",


### PR DESCRIPTION
When MySQL is being served in non-default port, the SUPERSET_METADATA_SQLALCHEMY_URI becomes invalid as there is not explicit port. This commit adds the port to the URI.

Internal-ref: https://tasks.opencraft.com/browse/BB-10779