### PR TITLE
feat: added new patch to customize superset image

### DIFF
--- a/tutoraspects/templates/aspects/build/aspects-superset/Dockerfile
+++ b/tutoraspects/templates/aspects/build/aspects-superset/Dockerfile
@@ -39,3 +39,5 @@ RUN atlas pull translations/tutor-contrib-aspects/tutoraspects/templates/aspects
 RUN python /app/localization/compile_translations.py
 
 USER superset
+
+{{ patch("superset-dockerfile-production-final") }}

--- a/tutoraspects/templates/aspects/build/aspects-superset/Dockerfile
+++ b/tutoraspects/templates/aspects/build/aspects-superset/Dockerfile
@@ -40,4 +40,4 @@ RUN python /app/localization/compile_translations.py
 
 USER superset
 
-{{ patch("superset-dockerfile-production-final") }}
+{{ patch("superset-dockerfile") }}


### PR DESCRIPTION
This PR introduces an optional customization patch step at the end of the aspects-superset Dockerfile.

This allows downstream builds or deployment pipelines to apply post-build modifications (such as altering file/directory permissions, installing custom packages, or running configuration scripts) without needing to modify the core build steps of the Dockerfile.