### PR TITLE
feat: upgrading to superset 6.1

### DIFF
--- a/tutoraspects/patches/mfe-dockerfile-post-npm-install-authoring
+++ b/tutoraspects/patches/mfe-dockerfile-post-npm-install-authoring
@@ -1,3 +1,3 @@
 {% if ASPECTS_ENABLE_STUDIO_IN_CONTEXT_METRICS %}
-RUN --mount=type=cache,target=/root/.npm,sharing=shared npm install openedx/frontend-plugin-aspects#v3.0.0
+RUN --mount=type=cache,target=/root/.npm,sharing=shared npm install openedx/frontend-plugin-aspects#v3.0.1
 {% endif %}

--- a/tutoraspects/templates/aspects/apps/superset/pythonpath/superset_config_docker.py
+++ b/tutoraspects/templates/aspects/apps/superset/pythonpath/superset_config_docker.py
@@ -73,7 +73,6 @@ AUTH_ROLES_MAPPING = {
     "public": ["Public"],    # AKA anonymous users
 }
 
-PUBLIC_ROLE_LIKE = "Public"
 
 for locale in DASHBOARD_LOCALES:
     AUTH_ROLES_MAPPING[f"instructor-{locale}"] = [f"{{SUPERSET_ROLES_MAPPING.instructor}} - {locale}"]

--- a/tutoraspects/templates/aspects/apps/superset/pythonpath/superset_config_docker.py
+++ b/tutoraspects/templates/aspects/apps/superset/pythonpath/superset_config_docker.py
@@ -73,6 +73,8 @@ AUTH_ROLES_MAPPING = {
     "public": ["Public"],    # AKA anonymous users
 }
 
+PUBLIC_ROLE_LIKE = "Public"
+
 for locale in DASHBOARD_LOCALES:
     AUTH_ROLES_MAPPING[f"instructor-{locale}"] = [f"{{SUPERSET_ROLES_MAPPING.instructor}} - {locale}"]
     AUTH_ROLES_MAPPING[f"student-{locale}"] = [f"{{SUPERSET_ROLES_MAPPING.student}} - {locale}"]

--- a/tutoraspects/templates/aspects/apps/superset/security/roles.json
+++ b/tutoraspects/templates/aspects/apps/superset/security/roles.json
@@ -4037,6 +4037,14 @@
         "view_menu": {
           "name": "Theme"
         }
+      },
+      {
+        "permission": {
+          "name": "can_read"
+        },
+        "view_menu": {
+          "name": "CurrentUserRestApi"
+        }
       }
     ]
   },

--- a/tutoraspects/templates/aspects/build/aspects-superset/Dockerfile
+++ b/tutoraspects/templates/aspects/build/aspects-superset/Dockerfile
@@ -4,7 +4,7 @@
 # https://github.com/apache/superset/blob/master/Dockerfile
 # https://superset.apache.org/docs/databases/installing-database-drivers
 
-FROM apache/superset:6.0.0
+FROM apache/superset:6.1.0
 
 USER root
 


### PR DESCRIPTION
in context metrics work:
<img width="1378" height="839" alt="image" src="https://github.com/user-attachments/assets/edd62953-de66-401e-8a2f-ae1f2a0bcde6" />

reports tab works:
<img width="1378" height="839" alt="image" src="https://github.com/user-attachments/assets/bcf54399-c112-4df4-a852-f7e8c61275a3" />

-------------

The `CurrentUserRestApi` permission is needed now due to stricter security introduced in https://github.com/apache/superset/pull/36410 (v6.0.1) and then a followup fix to force Public roles to define the necessary permission (https://github.com/apache/superset/pull/38474)